### PR TITLE
feat: Pipenvのenv読込とconfig読込境界を正本化する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,5 @@
-#--------------------------------------------
-# Setting
-#--------------------------------------------
-
-# OpenAI canonical reviewer
-export OPENAI_API_KEY=""
+# OpenAI
+OPENAI_API_KEY=
 
 # GitHub
-export GH_TOKEN=""
-
-export CODEX_BIN="$(find "$HOME/.vscode/extensions" -path '*/openai.chatgpt-*/bin/macos-aarch64/codex' -type f | sort | tail -1)"
-export PATH="$(dirname "$CODEX_BIN"):$PATH"
+GH_TOKEN=

--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ repository = owner/repository
 
 API key、token、database credential等の秘密値は設定ファイルへ直接書きません。設定ファイルには環境変数名だけを記載し、実値はGit管理外の`.env`へ定義します。
 
-```bash
-export GH_TOKEN="..."
-export OPENAI_API_KEY="..."
+```dotenv
+GH_TOKEN=
+OPENAI_API_KEY=
 ```
+
+Repository rootの`.env`はPipenvが自動読込します。通常起動前に`source .env`は行いません。Loop EngineeringのPythonコードも`.env`を直接読みません。
+
+`CODEX_BIN`や`PATH`などshell自体の設定はzsh側で管理し、`.env`へshell command substitutionを置きません。
 
 `config/loop-engineering.ini`と`.env`はGit管理対象外です。Repositoryへはexampleだけを保存します。
 
@@ -79,6 +83,8 @@ Project / Mission / Parent / Integration Workを同じIssue番号へ便宜的に
 pipenv run python -m loop_engineering
 ```
 
+PipenvがRepository rootの`.env`を環境へ注入し、Loop Engineering本体は`config/loop-engineering.ini`をロードします。
+
 別の設定ファイルを一時的に使用する場合だけ`--config`を指定できます。
 
 ```bash
@@ -94,6 +100,7 @@ CLIからWorkspace path自体を直接上書きする方式は通常経路にし
 - Platform / Product / Workspace境界: `docs/architecture/workspace_boundary.md`
 - Project Profile: `docs/architecture/project_profile.md`
 - 設定と秘密情報: `docs/architecture/configuration_and_secrets.md`
+- env読込境界: `docs/operations/env_loading_contract.md`
 - GitHub運用: `docs/operations/github_project_management.md`
 - active Mission Goal: `docs/operations/loop_mission_goal.md`
 

--- a/docs/architecture/configuration_and_secrets.md
+++ b/docs/architecture/configuration_and_secrets.md
@@ -1,6 +1,6 @@
 # 設定ファイルと秘密情報の境界
 
-管理Issue: #31
+管理Issue: #31, #36
 状態: standalone設定正本
 
 ## 1. 目的
@@ -29,6 +29,8 @@ config/loop-engineering.example.ini
 設定ファイルを別場所に置く場合は、CLIの`--config <path>`または非秘密の環境変数`LOOP_CONFIG_FILE`で設定ファイル自体を選択できる。
 
 Workspace pathそのものをCLI引数や環境変数で通常上書きしない。Workspace pathのAuthorityは選択された設定ファイルとする。
+
+Loop EngineeringのPythonコードがファイルとして直接ロードする実行設定はこのconfigであり、`.env`を直接探索・読込しない。
 
 ## 3. Workspace
 
@@ -93,7 +95,7 @@ reviewer_api_key_env = OPENAI_API_KEY
 
 `reviewer_api_key_env`には秘密値ではなく環境変数名だけを書く。OpenAI API keyの標準環境変数名は`OPENAI_API_KEY`とし、`OPENAI_API_KEY_REVIEWER`は使用しない。
 
-## 6. 秘密情報
+## 6. 秘密情報と`.env`
 
 次のような値は設定ファイル・Repository・Issue・PR・Checkpoint・通常logへ直接保存しない。
 
@@ -103,14 +105,18 @@ reviewer_api_key_env = OPENAI_API_KEY
 - private key
 - reviewer credential
 
-実値は`.env`またはホスト側の秘密情報sourceに置く。
+Repository rootの`.env`はPipenvが標準機能で自動読込するdotenvファイルとして使用する。
 
-現時点で必須として確定しているローカル秘密値は次である。
+現時点の最小構成:
 
-```bash
-export GH_TOKEN="..."
-export OPENAI_API_KEY="..."
+```dotenv
+OPENAI_API_KEY=
+GH_TOKEN=
 ```
+
+`.env`には単純な環境変数だけを記載する。shell command substitution、`find`、`dirname`、PATH組立処理を置かない。
+
+`CODEX_BIN`や`PATH`などshell自体の実行環境設定はzsh側の設定ファイルで管理する。
 
 `LOOP_POSTGRES_DSN`と`LOOP_TRUSTED_REVIEWER_SOCKET`は利用契約が未確定のため、ローカル`.env`へ空値や自己参照値を置かない。必要性と値を確定した時点で追加する。
 
@@ -124,7 +130,9 @@ export OPENAI_API_KEY="..."
 pipenv run python -m loop_engineering
 ```
 
-Pipenvがproject rootの`.env`を読み込むため、Loop Engineering自身で独自の秘密情報ファイル探索を行わない。
+Pipenvがproject rootの`.env`を自動読込して子process環境へ注入する。通常起動前に`source .env`を要求しない。
+
+Loop Engineering自身は`.env`をloadせず、注入済み環境変数を参照しながら`config/loop-engineering.ini`をロードする。
 
 既にホスト環境へ注入された環境変数も同じ契約で使用できる。
 
@@ -144,6 +152,11 @@ CLI overrideは設定ファイルの選択等の明示的な一時変更に限�
 ## 9. Hard invariants
 
 - Workspace pathは選択された設定ファイルから解決する
+- Pythonコードは`.env`を直接loadしない
+- `.env`はPipenvが自動読込するdotenvとして扱う
+- `.env`へshell command substitutionを書かない
+- `CODEX_BIN` / `PATH`はzsh側で管理する
+- 通常起動前に`source .env`を要求しない
 - 秘密情報の実値を設定ファイルへ保存しない
 - 設定ファイルには秘密情報の環境変数名を記録できる
 - OpenAI API keyの標準環境変数名は`OPENAI_API_KEY`とする

--- a/docs/operations/env_loading_contract.md
+++ b/docs/operations/env_loading_contract.md
@@ -1,1 +1,70 @@
-x
+# `.env` / Pipenv / config の読込契約
+
+管理Issue: #36
+状態: standalone運用正本
+
+## 1. 目的
+
+Loop Engineeringの起動時に、`.env`、Pipenv、`config/loop-engineering.ini`の責務を分離する。
+
+## 2. `.env`
+
+Repository rootの`.env`は、Pipenvが標準機能で自動読込するdotenvファイルとして使用する。
+
+`.env`には単純な環境変数だけを記載する。
+
+```dotenv
+OPENAI_API_KEY=
+GH_TOKEN=
+```
+
+shell command substitution、`find`、`dirname`、PATH組立処理などは`.env`へ置かない。
+
+`LOOP_POSTGRES_DSN`と`LOOP_TRUSTED_REVIEWER_SOCKET`は利用契約が未確定のため、確定するまで定義しない。
+
+## 3. shell環境
+
+`CODEX_BIN`や`PATH`など、shell自体の実行環境設定はzsh側の設定ファイルで管理する。
+
+`.env`へ`CODEX_BIN` / `PATH`を置かない。
+
+## 4. Python / Loop Engineering
+
+`src/loop_engineering/**`は`.env`を直接探索・読込しない。
+
+Loop Engineeringがファイルとして直接ロードする実行設定は次である。
+
+```text
+config/loop-engineering.ini
+```
+
+設定ファイルにはWorkspace、Repository、Project、Mission、モデル等の非秘密設定と、秘密値を参照する環境変数名を記載する。秘密値そのものは保存しない。
+
+## 5. 通常起動
+
+通常起動前に`source .env`を要求しない。Pipenvの標準dotenv読込へ任せる。
+
+```bash
+pipenv run python -m loop_engineering
+```
+
+1遷移だけ実行する場合:
+
+```bash
+pipenv run python -m loop_engineering --once
+```
+
+別のconfigを使う場合:
+
+```bash
+pipenv run python -m loop_engineering --config /path/to/another.ini
+```
+
+## 6. Hard invariants
+
+- Pythonコードから`.env`をロードしない
+- `.env`へshell command substitutionを書かない
+- `CODEX_BIN` / `PATH`を`.env`で管理しない
+- 通常起動前に`source .env`を要求しない
+- 実行設定ファイルのAuthorityは`config/loop-engineering.ini`
+- 秘密値をconfigへ直接保存しない

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -105,6 +105,18 @@ def test_default_reviewer_api_key_environment_is_openai_api_key(tmp_path: Path) 
     assert settings.secrets.reviewer_api_key_env == "OPENAI_API_KEY"
 
 
+def test_python_source_does_not_load_dotenv_directly() -> None:
+    root = Path(__file__).resolve().parents[1]
+    source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (root / "src" / "loop_engineering").rglob("*.py")
+    )
+
+    assert "load_dotenv" not in source
+    assert "dotenv_values" not in source
+    assert "python-dotenv" not in source
+
+
 def test_relative_workspace_path_is_rejected(tmp_path: Path) -> None:
     config = tmp_path / "loop-engineering.ini"
     _write_config(config, "relative/product")


### PR DESCRIPTION
Closes #36
Related: #27, #33

## 目的
Pipenvの`.env`自動読込とLoop Engineering本体のconfig読込責務を分離して正本化する。

## 確定契約
- `.env`はPipenvが自動読込するdotenv
- `.env`には`OPENAI_API_KEY` / `GH_TOKEN`等の単純変数だけを置く
- `CODEX_BIN` / `PATH`はzsh側で管理する
- 通常起動前に`source .env`を要求しない
- Python / Loop Engineeringは`.env`を直接loadしない
- Pythonがファイルとしてloadする実行設定は`config/loop-engineering.ini`

## 変更
- `.env.example`からshell command substitutionと`CODEX_BIN` / `PATH`を除去
- `.env.example`をdotenv形式へ統一
- README / 設定設計 / env読込運用契約を統一
- Python sourceにdotenv loaderを持たないことを試験で固定

## 履歴逸脱
PR作成前の操作ミスで`docs/operations/env_loading_contract.md`を内容`x`でmainへ直接追加するcommit `ea6f9454b5ca263afe5b5c26d08d2e4f169f475a`が入った。履歴rewriteせず、本PRで正しい内容へ修正する。

exact-head CI PASS後に通常mergeする。