### PR TITLE
fix: 次Work未選択Checkpointを計画遷移として扱う

### DIFF
--- a/docs/architecture/v2/loop_autonomous_runner.md
+++ b/docs/architecture/v2/loop_autonomous_runner.md
@@ -115,6 +115,8 @@ Work merge/readback/close完了後は、次の限定遷移でGitHub liveとProje
 
 この時点で「前Workは統合済みだが次Workはまだ未選択」という状態は起こり得る。これを即座に破損Checkpointとみなして古いWorkへfallbackしない。
 
+最新Checkpointが、`Mission state: ACTIVE`、完了したWork、統合済みPR、および次Workを最新状態から選択する次の操作（next action）を明示し、`current Work`を持たない場合は、この正常な計画境界として扱う。ホストは現在対象なしとして次Work計画へ遷移する。この判定は完了済み識別子だけでは行わず、上記の明示項目がそろわないCheckpointや、現在Workと矛盾するCheckpointは安全側停止にする。
+
 次Workが選択された後はCheckpointへ少なくとも`current Work`を明示する。有効PRがある場合だけ`current PR`と厳密HEADを記録し、存在しないPR / HEADを捏造しない。
 
 #27では次を検証する。

--- a/src/loop_engineering/host_entrypoint.py
+++ b/src/loop_engineering/host_entrypoint.py
@@ -39,6 +39,15 @@ _CURRENT_PR_RE = re.compile(
 _EXACT_HEAD_RE = re.compile(
     r"(?im)^.*?(?:exact\s+HEAD|HEAD)\s*:\s*`?([0-9a-f]{40})"
 )
+_COMPLETED_WORK_RE = re.compile(
+    r"(?im)^.*?(?:completed\s+Work|完了(?:済み)?Work)\s*:\s*`?#?(\d+)"
+)
+_MERGED_PR_RE = re.compile(r"(?im)^.*?(?:merged\s+PR|統合済みPR)\s*:\s*`?#?(\d+)")
+_ACTIVE_MISSION_RE = re.compile(r"(?im)^.*?Mission\s+state\s*:\s*`?ACTIVE`?")
+_NEXT_WORK_SELECTION_RE = re.compile(
+    r"(?im)^.*?(?:next\s+action|次(?:の)?action|次の作業)(?:\s*(?:は|:))?\s*"
+    r".*?(?:next\s+.*?Work|次.*?Work).*?(?:select|選択)"
+)
 
 
 class StrictGhMissionPort(GhMissionPort):
@@ -69,6 +78,8 @@ class StrictGhMissionPort(GhMissionPort):
             raise RuntimeError("MISSION_CHECKPOINT_TARGET_UNRESOLVED")
         work_match = _CURRENT_WORK_RE.search(body_value)
         if work_match is None:
+            if self._is_explicit_planning_boundary(body_value):
+                return None
             raise RuntimeError("MISSION_CHECKPOINT_TARGET_UNRESOLVED")
 
         pr_match = _CURRENT_PR_RE.search(body_value)
@@ -81,6 +92,15 @@ class StrictGhMissionPort(GhMissionPort):
             int(pr_match.group(1)) if pr_match else None,
             head_match.group(1) if head_match else None,
             comment_id,
+        )
+
+    @staticmethod
+    def _is_explicit_planning_boundary(body: str) -> bool:
+        return bool(
+            _ACTIVE_MISSION_RE.search(body)
+            and _COMPLETED_WORK_RE.search(body)
+            and _MERGED_PR_RE.search(body)
+            and _NEXT_WORK_SELECTION_RE.search(body)
         )
 
     def merge_current(self, target: HostTarget) -> bool:

--- a/tests/loop_engineering/test_host_entrypoint.py
+++ b/tests/loop_engineering/test_host_entrypoint.py
@@ -123,6 +123,19 @@ class NoopImplementer:
         return False
 
 
+class PlanningImplementer:
+    def __init__(self) -> None:
+        self.plan_calls: list[int | None] = []
+
+    def continue_work(self, target: HostTarget, *, repair: bool) -> bool:
+        del target, repair
+        return False
+
+    def plan_next_work(self, completed_work: int | None) -> bool:
+        self.plan_calls.append(completed_work)
+        return True
+
+
 class MutablePilotImplementer(PilotPlanningImplementer):
     def __init__(
         self,
@@ -150,7 +163,68 @@ class MutablePilotImplementer(PilotPlanningImplementer):
         return True
 
 
-def test_latest_ambiguous_mission_checkpoint_does_not_fall_back() -> None:
+def test_completion_checkpoint_without_current_work_dispatches_planning() -> None:
+    responses = {
+        "repos/ktan514/ai-liver-yura/issues/450/comments?per_page=100&page=1": [
+            {
+                "id": 1,
+                "body": (
+                    "## Mission Checkpoint — ACTIVE / 実装更新\n\n"
+                    "- current Work: #465\n"
+                    "- current PR: #466\n"
+                    f"- exact HEAD: `{'1' * 40}`"
+                ),
+            },
+            {
+                "id": 2,
+                "body": (
+                    "## Mission Checkpoint — 完了 / 次Work選択\n\n"
+                    "- Mission state: `ACTIVE`\n"
+                    "- completed Work: #494\n"
+                    "- merged PR: #496\n"
+                    "- current PR: なし\n"
+                    "次のactionはProjectとGitHub liveから次の依存関係を満たしたWorkを"
+                    "fresh readして選択すること"
+                ),
+            },
+        ]
+    }
+    mission = StrictGhMissionPort(config(), FakeLocalRunner(responses), {"PATH": "/usr/bin"})
+    implementer = PlanningImplementer()
+
+    result = HostLoopController(config(), mission, implementer).run_once()
+
+    assert result.status is HostTransitionStatus.COMPLETED
+    assert result.detail == "PLANNING_DISPATCHED"
+    assert result.work_issue is None
+    assert implementer.plan_calls == [None]
+
+
+def test_completion_checkpoint_does_not_fall_back_to_old_current_work() -> None:
+    responses = {
+        "repos/ktan514/ai-liver-yura/issues/450/comments?per_page=100&page=1": [
+            {
+                "id": 1,
+                "body": "## Mission Checkpoint\n\n- current Work: #465",
+            },
+            {
+                "id": 2,
+                "body": (
+                    "## Mission Checkpoint\n\n"
+                    "- Mission state: `ACTIVE`\n"
+                    "- completed Work: #494\n"
+                    "- merged PR: #496\n"
+                    "次のactionはGitHub liveから次の依存関係を満たしたWorkを選択すること"
+                ),
+            },
+        ]
+    }
+    port = StrictGhMissionPort(config(), FakeLocalRunner(responses), {"PATH": "/usr/bin"})
+
+    assert port.current_target() is None
+
+
+def test_ambiguous_latest_checkpoint_does_not_fall_back_to_old_work() -> None:
     responses = {
         "repos/ktan514/ai-liver-yura/issues/450/comments?per_page=100&page=1": [
             {
@@ -166,6 +240,26 @@ def test_latest_ambiguous_mission_checkpoint_does_not_fall_back() -> None:
                 "id": 2,
                 "body": "## Mission Checkpoint\n\n現在対象を明示していない状態記録",
             },
+        ]
+    }
+    port = StrictGhMissionPort(config(), FakeLocalRunner(responses), {"PATH": "/usr/bin"})
+
+    with pytest.raises(RuntimeError, match="MISSION_CHECKPOINT_TARGET_UNRESOLVED"):
+        port.current_target()
+
+
+def test_malformed_latest_checkpoint_fails_closed() -> None:
+    responses = {
+        "repos/ktan514/ai-liver-yura/issues/450/comments?per_page=100&page=1": [
+            {
+                "id": 2,
+                "body": (
+                    "## Mission Checkpoint\n\n"
+                    "- Mission state: `ACTIVE`\n"
+                    "- completed Work: #494\n"
+                    "- next action: Projectから次Workをfresh選択する"
+                ),
+            }
         ]
     }
     port = StrictGhMissionPort(config(), FakeLocalRunner(responses), {"PATH": "/usr/bin"})


### PR DESCRIPTION
## 概要

#27 の修正です。Draft PR #41はReady化APIのconnector不具合によりcloseし、同一branch・同一exact HEADの本PRへ置換しました。実装内容は変更していません。

正常な完了後・次Work未選択Checkpointを計画境界として扱い、古いCheckpointへ戻らず次Work計画へ遷移します。曖昧・不足Checkpointは従来どおりfail-closedです。

## 検証

- `pipenv run pytest`（114 passed）
- `pipenv run ruff check src tests`
- `pipenv run mypy --strict src tests`
- `pipenv run python -m compileall -q src tests`
- `git diff --check`
- exact-head CI `33288058104` SUCCESS（`53c590bdf7d41cf3b42b3dc250727b5e0e306994`）
- current-head review #41上でblocking 0（同一exact HEAD）

Related: #27