### PR TITLE
feat: Product開発方針と自己改善公開先を設定分離する

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ cp .env.example .env
 [project]
 workspace_path = /absolute/path/to/product-workspace
 repository = owner/repository
+work_branch_template = feature/work-{issue}
 ```
+
+Product Workのbranch名は`work_branch_template`で指定します。`{issue}`だけを安全なplaceholderとして使え、任意shellや危険なGit refは受け付けません。
+
+自己改善Issueの公開先はProduct設定と独立した`[self_improvement]`へ明示します。別Productの設定でsectionを省略するか`enabled = false`にした場合、Product Repositoryへ自己改善Issueを作成しません。
 
 API key、token、database credential等の秘密値は設定ファイルへ直接書きません。設定ファイルには環境変数名だけを記載し、実値はGit管理外の`.env`へ定義します。
 
@@ -72,6 +77,15 @@ label = loop-engineering
 authority_refs = #26, #33
 ci_workflow_name = Loop Engineering Deterministic CI
 improvement_area = Runtime / Infrastructure
+issue_level = Work
+
+[self_improvement]
+enabled = true
+repository = ktan514/loop-engineering
+project_owner = ktan514
+project_number = 9
+label = loop-engineering
+area = Runtime / Infrastructure
 issue_level = Work
 ```
 

--- a/config/loop-engineering.example.ini
+++ b/config/loop-engineering.example.ini
@@ -18,7 +18,6 @@ authority_refs =
 ci_workflow_name = Deterministic CI
 improvement_area = Runtime / Infrastructure
 issue_level = Work
-authority_refs =
 
 [self_improvement]
 enabled = true
@@ -28,6 +27,7 @@ project_number = 1
 label = loop-engineering
 area = Runtime / Infrastructure
 issue_level = Work
+authority_refs =
 
 [models]
 implementer_provider = codex

--- a/config/loop-engineering.example.ini
+++ b/config/loop-engineering.example.ini
@@ -6,6 +6,7 @@ key = sample-project
 workspace_path = /absolute/path/to/product-workspace
 repository = owner/repository
 trunk_branch = main
+work_branch_template = loop/work-{issue}
 project_owner = owner
 project_number = 1
 mission_issue = 1
@@ -16,6 +17,15 @@ label = loop-engineering
 authority_refs =
 ci_workflow_name = Deterministic CI
 improvement_area = Runtime / Infrastructure
+issue_level = Work
+
+[self_improvement]
+enabled = true
+repository = owner/loop-engineering
+project_owner = owner
+project_number = 1
+label = loop-engineering
+area = Runtime / Infrastructure
 issue_level = Work
 
 [models]

--- a/config/loop-engineering.example.ini
+++ b/config/loop-engineering.example.ini
@@ -18,6 +18,7 @@ authority_refs =
 ci_workflow_name = Deterministic CI
 improvement_area = Runtime / Infrastructure
 issue_level = Work
+authority_refs =
 
 [self_improvement]
 enabled = true

--- a/docs/architecture/configuration_and_secrets.md
+++ b/docs/architecture/configuration_and_secrets.md
@@ -44,6 +44,7 @@ key = sample-product
 workspace_path = /Users/example/workspace/sample-product
 repository = owner/sample-product
 trunk_branch = main
+work_branch_template = loop/work-{issue}
 ```
 
 Loop Engineeringはホームディレクトリを暗黙探索しない。

--- a/docs/architecture/project_profile.md
+++ b/docs/architecture/project_profile.md
@@ -120,6 +120,7 @@ project_number = 9
 label = loop-engineering
 area = Runtime / Infrastructure
 issue_level = Work
+authority_refs =
 
 [models]
 implementer_provider = codex
@@ -162,7 +163,9 @@ Profile/Host設定で指定してよいもの:
 
 Product Workのbranch名は`work_branch_template`で宣言する。templateは`{issue}`を1回だけ含む安全なGit refでなければならず、任意shell、空branch、`..`、path traversal、危険なref文字を許可しない。
 
-自己改善Issueの公開先は`[self_improvement]`で指定し、ProductのRepository、Project、labelとは別の設定境界とする。`enabled = false`またはsection未設定なら自己改善のGitHub mutationは行わない。別Product targetで公開先が未設定の場合、Product Repositoryへ暗黙fallbackしない。
+自己改善Issueの公開先は`[self_improvement]`で指定し、ProductのRepository、Project、label、Authority、Issue levelとは別の設定境界とする。`enabled = false`なら自己改善のGitHub mutationは行わない。別Product targetでsection未設定の場合も公開しない。
+
+後方互換の移行は曖昧なRepository名推測で行わない。`[self_improvement]`が無い既存設定でも、設定されたWorkspace pathとPlatform rootが同一である場合だけ、自己対象の旧standalone設定としてProduct sectionの公開先を明示sinkへ移行する。それ以外のProduct Workspaceではsection未設定をdisabledとして扱う。
 
 ## 6. Forbidden profile responsibilities
 

--- a/docs/architecture/project_profile.md
+++ b/docs/architecture/project_profile.md
@@ -110,6 +110,16 @@ trunk_branch = rebuild/v2-foundation
 project_owner = ktan514
 project_number = 7
 mission_issue = 450
+work_branch_template = feature/work-{issue}
+
+[self_improvement]
+enabled = true
+repository = ktan514/loop-engineering
+project_owner = ktan514
+project_number = 9
+label = loop-engineering
+area = Runtime / Infrastructure
+issue_level = Work
 
 [models]
 implementer_provider = codex
@@ -149,6 +159,10 @@ Profile/Host設定で指定してよいもの:
 - verification policy mapping
 - product-specific command/test descriptors
 - safe path scopes
+
+Product Workのbranch名は`work_branch_template`で宣言する。templateは`{issue}`を1回だけ含む安全なGit refでなければならず、任意shell、空branch、`..`、path traversal、危険なref文字を許可しない。
+
+自己改善Issueの公開先は`[self_improvement]`で指定し、ProductのRepository、Project、labelとは別の設定境界とする。`enabled = false`またはsection未設定なら自己改善のGitHub mutationは行わない。別Product targetで公開先が未設定の場合、Product Repositoryへ暗黙fallbackしない。
 
 ## 6. Forbidden profile responsibilities
 

--- a/docs/architecture/workspace_boundary.md
+++ b/docs/architecture/workspace_boundary.md
@@ -79,6 +79,8 @@ Product Workspaceが所有しないもの:
 - Platform runtime database
 - cross-product scheduling state
 
+Loop Engineering自身の自己改善IssueとProject項目は、Product WorkspaceのRepository identityへ従属させない。公開先はHost設定の`[self_improvement]`で明示し、未設定時はProduct Workspaceへ書き込まない。
+
 ## 4. Runtime State placement
 
 Runtime stateはProduct Workspace外に置く。

--- a/src/loop_engineering/config.py
+++ b/src/loop_engineering/config.py
@@ -3,10 +3,43 @@
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Mapping
 from configparser import ConfigParser, SectionProxy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class SelfImprovementConfig:
+    """Loop Engineering自身の改善Issueを公開する独立した公開先。"""
+
+    enabled: bool = False
+    repository: str | None = None
+    owner: str | None = None
+    project_number: int | None = None
+    label: str | None = None
+    area: str | None = None
+    issue_level: str | None = None
+
+    def __post_init__(self) -> None:
+        values = (
+            self.repository,
+            self.owner,
+            self.label,
+            self.area,
+            self.issue_level,
+        )
+        if not self.enabled:
+            if any(value is not None for value in (*values, self.project_number)):
+                raise ValueError("無効なself_improvementへ公開先を指定できません")
+            return
+        if any(value is None or not value.strip() for value in values):
+            raise ValueError("有効なself_improvementには公開先設定が必要です")
+        if self.repository is None or "/" not in self.repository:
+            raise ValueError("self_improvement.repositoryはowner/name形式で指定してください")
+        if self.project_number is None or self.project_number < 1:
+            raise ValueError("self_improvement.project_numberは1以上で指定してください")
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,6 +59,8 @@ class LoopEngineConfig:
     parent_issue: int | None = None
     integration_work: int | None = None
     ci_workflow_name: str = "Deterministic CI"
+    work_branch_template: str = "loop/work-{issue}"
+    self_improvement: SelfImprovementConfig = field(default_factory=SelfImprovementConfig)
 
     def __post_init__(self) -> None:
         text_fields = (
@@ -36,6 +71,7 @@ class LoopEngineConfig:
             ("improvement_area", self.improvement_area),
             ("issue_level", self.issue_level),
             ("ci_workflow_name", self.ci_workflow_name),
+            ("work_branch_template", self.work_branch_template),
         )
         for name, value in text_fields:
             if not value.strip():
@@ -56,6 +92,14 @@ class LoopEngineConfig:
                 raise ValueError(f"{field_name}は1以上である必要があります")
         if any(not item.strip() for item in self.authority_refs):
             raise ValueError("authority_refsに空文字は指定できません")
+        _validate_work_branch_template(self.work_branch_template)
+
+    def work_branch(self, issue: int) -> str:
+        if issue < 1:
+            raise ValueError("issueは1以上である必要があります")
+        branch = self.work_branch_template.format(issue=issue)
+        _validate_git_branch(branch)
+        return branch
 
     @classmethod
     def from_environment(cls, environment: Mapping[str, str]) -> LoopEngineConfig:
@@ -84,6 +128,11 @@ class LoopEngineConfig:
                 "LOOP_CI_WORKFLOW_NAME", "Deterministic CI"
             ).strip()
             or "Deterministic CI",
+            work_branch_template=environment.get(
+                "LOOP_WORK_BRANCH_TEMPLATE", "loop/work-{issue}"
+            ).strip()
+            or "loop/work-{issue}",
+            self_improvement=_self_improvement_from_environment(environment),
         )
 
 
@@ -168,6 +217,7 @@ class LoopEngineeringSettings:
         credentials = _section(parser, "credentials")
         operational_store = _section(parser, "operational_store")
         runtime = _section(parser, "runtime")
+        self_improvement = _self_improvement_from_section(parser)
 
         repository = _required(project, "repository")
         owner = project.get("project_owner", "").strip() or repository.split("/", 1)[0]
@@ -196,6 +246,11 @@ class LoopEngineeringSettings:
                 project.get("ci_workflow_name", "Deterministic CI").strip()
                 or "Deterministic CI"
             ),
+            work_branch_template=(
+                project.get("work_branch_template", "loop/work-{issue}").strip()
+                or "loop/work-{issue}"
+            ),
+            self_improvement=self_improvement,
         )
         model_config = ModelConfig(
             implementer_provider=models.get("implementer_provider", "codex").strip() or "codex",
@@ -264,6 +319,7 @@ class LoopEngineeringSettings:
                 "LOOP_IMPROVEMENT_AREA": engine.improvement_area,
                 "LOOP_ISSUE_LEVEL": engine.issue_level,
                 "LOOP_CI_WORKFLOW_NAME": engine.ci_workflow_name,
+                "LOOP_WORK_BRANCH_TEMPLATE": engine.work_branch_template,
                 "LOOP_IMPLEMENTER_PROVIDER": self.models.implementer_provider,
                 "LOOP_IMPLEMENTER_MODEL": self.models.implementer_model,
                 "LOOP_REVIEWER_PROVIDER": self.models.reviewer_provider,
@@ -290,6 +346,41 @@ class LoopEngineeringSettings:
         """旧名称との互換用alias。"""
 
         return self.runtime_environment(environment)
+
+
+def _self_improvement_from_section(parser: ConfigParser) -> SelfImprovementConfig:
+    if not parser.has_section("self_improvement"):
+        return SelfImprovementConfig()
+    section = parser["self_improvement"]
+    enabled = section.getboolean("enabled", fallback=False)
+    if not enabled:
+        return SelfImprovementConfig()
+    repository = _required(section, "repository")
+    return SelfImprovementConfig(
+        enabled=True,
+        repository=repository,
+        owner=section.get("project_owner", "").strip() or repository.split("/", 1)[0],
+        project_number=_required_int_section(section, "project_number"),
+        label=_required(section, "label"),
+        area=_required(section, "area"),
+        issue_level=_required(section, "issue_level"),
+    )
+
+
+def _self_improvement_from_environment(values: Mapping[str, str]) -> SelfImprovementConfig:
+    if values.get("LOOP_SELF_IMPROVEMENT_ENABLED", "false").strip().lower() != "true":
+        return SelfImprovementConfig()
+    repository = _required_mapping(values, "LOOP_SELF_IMPROVEMENT_REPOSITORY")
+    return SelfImprovementConfig(
+        enabled=True,
+        repository=repository,
+        owner=values.get("LOOP_SELF_IMPROVEMENT_OWNER", "").strip()
+        or repository.split("/", 1)[0],
+        project_number=_required_int_mapping(values, "LOOP_SELF_IMPROVEMENT_PROJECT_NUMBER"),
+        label=_required_mapping(values, "LOOP_SELF_IMPROVEMENT_LABEL"),
+        area=_required_mapping(values, "LOOP_SELF_IMPROVEMENT_AREA"),
+        issue_level=_required_mapping(values, "LOOP_SELF_IMPROVEMENT_ISSUE_LEVEL"),
+    )
 
 
 def _configured_path(platform_root: Path, environment: Mapping[str, str]) -> Path:
@@ -370,6 +461,25 @@ def _optional_int_mapping(values: Mapping[str, str], name: str) -> int | None:
 def _validate_env_name(name: str, value: str) -> None:
     if not value or not value.replace("_", "").isalnum() or value[0].isdigit():
         raise ValueError(f"{name}に不正な環境変数名が指定されています")
+
+
+def _validate_work_branch_template(template: str) -> None:
+    remainder = template.replace("{issue}", "")
+    if template.count("{issue}") != 1 or "{" in remainder or "}" in remainder:
+        raise ValueError("work_branch_templateは{issue}を1回だけ含める必要があります")
+    _validate_git_branch(template.format(issue=1))
+
+
+def _validate_git_branch(branch: str) -> None:
+    if (
+        not branch
+        or branch.startswith("/")
+        or branch.endswith(("/", "."))
+        or "//" in branch
+        or ".." in branch
+        or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/-]*", branch)
+    ):
+        raise ValueError("work_branch_templateが安全なGit branchではありません")
 
 
 def _csv(raw: str) -> tuple[str, ...]:

--- a/src/loop_engineering/config.py
+++ b/src/loop_engineering/config.py
@@ -21,6 +21,7 @@ class SelfImprovementConfig:
     label: str | None = None
     area: str | None = None
     issue_level: str | None = None
+    authority_refs: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         values = (
@@ -40,6 +41,8 @@ class SelfImprovementConfig:
             raise ValueError("self_improvement.repositoryはowner/name形式で指定してください")
         if self.project_number is None or self.project_number < 1:
             raise ValueError("self_improvement.project_numberは1以上で指定してください")
+        if any(not item.strip() for item in self.authority_refs):
+            raise ValueError("self_improvement.authority_refsに空文字は指定できません")
 
 
 @dataclass(frozen=True, slots=True)
@@ -217,7 +220,6 @@ class LoopEngineeringSettings:
         credentials = _section(parser, "credentials")
         operational_store = _section(parser, "operational_store")
         runtime = _section(parser, "runtime")
-        self_improvement = _self_improvement_from_section(parser)
 
         repository = _required(project, "repository")
         owner = project.get("project_owner", "").strip() or repository.split("/", 1)[0]
@@ -225,6 +227,9 @@ class LoopEngineeringSettings:
         if not workspace.is_absolute():
             raise ValueError("workspace_pathは絶対pathで指定してください")
         workspace = workspace.resolve(strict=False)
+        self_improvement = _self_improvement_from_section(
+            parser, project, workspace, platform_root.resolve(strict=False)
+        )
 
         engine = LoopEngineConfig(
             repository=repository,
@@ -327,6 +332,22 @@ class LoopEngineeringSettings:
                 "LOOP_REVIEWER_API_BASE": self.models.reviewer_api_base,
             }
         )
+        sink = engine.self_improvement
+        values["LOOP_SELF_IMPROVEMENT_ENABLED"] = "true" if sink.enabled else "false"
+        for name, value in (
+            ("REPOSITORY", sink.repository),
+            ("OWNER", sink.owner),
+            ("PROJECT_NUMBER", str(sink.project_number) if sink.project_number else None),
+            ("LABEL", sink.label),
+            ("AREA", sink.area),
+            ("ISSUE_LEVEL", sink.issue_level),
+            ("AUTHORITY_REFS", ",".join(sink.authority_refs) if sink.enabled else None),
+        ):
+            runtime_name = f"LOOP_SELF_IMPROVEMENT_{name}"
+            if value is None:
+                values.pop(runtime_name, None)
+            else:
+                values[runtime_name] = value
         optional_runtime_values: tuple[tuple[str, int | None], ...] = (
             ("LOOP_ROOT_ISSUE", engine.root_issue),
             ("LOOP_PARENT_ISSUE", engine.parent_issue),
@@ -348,8 +369,15 @@ class LoopEngineeringSettings:
         return self.runtime_environment(environment)
 
 
-def _self_improvement_from_section(parser: ConfigParser) -> SelfImprovementConfig:
+def _self_improvement_from_section(
+    parser: ConfigParser,
+    project: SectionProxy,
+    workspace: Path,
+    platform_root: Path,
+) -> SelfImprovementConfig:
     if not parser.has_section("self_improvement"):
+        if workspace == platform_root:
+            return _legacy_self_target_sink(project)
         return SelfImprovementConfig()
     section = parser["self_improvement"]
     enabled = section.getboolean("enabled", fallback=False)
@@ -364,6 +392,24 @@ def _self_improvement_from_section(parser: ConfigParser) -> SelfImprovementConfi
         label=_required(section, "label"),
         area=_required(section, "area"),
         issue_level=_required(section, "issue_level"),
+        authority_refs=_csv(section.get("authority_refs", "")),
+    )
+
+
+def _legacy_self_target_sink(project: SectionProxy) -> SelfImprovementConfig:
+    repository = _required(project, "repository")
+    return SelfImprovementConfig(
+        enabled=True,
+        repository=repository,
+        owner=project.get("project_owner", "").strip() or repository.split("/", 1)[0],
+        project_number=_required_int_section(project, "project_number"),
+        label=project.get("label", "loop-engineering").strip() or "loop-engineering",
+        area=(
+            project.get("improvement_area", "Runtime / Infrastructure").strip()
+            or "Runtime / Infrastructure"
+        ),
+        issue_level=project.get("issue_level", "Work").strip() or "Work",
+        authority_refs=_csv(project.get("authority_refs", "")),
     )
 
 
@@ -380,6 +426,7 @@ def _self_improvement_from_environment(values: Mapping[str, str]) -> SelfImprove
         label=_required_mapping(values, "LOOP_SELF_IMPROVEMENT_LABEL"),
         area=_required_mapping(values, "LOOP_SELF_IMPROVEMENT_AREA"),
         issue_level=_required_mapping(values, "LOOP_SELF_IMPROVEMENT_ISSUE_LEVEL"),
+        authority_refs=_csv(values.get("LOOP_SELF_IMPROVEMENT_AUTHORITY_REFS", "")),
     )
 
 
@@ -471,6 +518,7 @@ def _validate_work_branch_template(template: str) -> None:
 
 
 def _validate_git_branch(branch: str) -> None:
+    components = branch.split("/")
     if (
         not branch
         or branch.startswith("/")
@@ -478,6 +526,7 @@ def _validate_git_branch(branch: str) -> None:
         or "//" in branch
         or ".." in branch
         or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/-]*", branch)
+        or any(component.startswith(".") or component.endswith(".lock") for component in components)
     ):
         raise ValueError("work_branch_templateが安全なGit branchではありません")
 

--- a/src/loop_engineering/github_issues.py
+++ b/src/loop_engineering/github_issues.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
-from .config import LoopEngineConfig
+from .config import LoopEngineConfig, SelfImprovementConfig
 from .health import marker, render_issue_body
 from .models import (
     ConflictKind,
@@ -52,6 +52,9 @@ class GitHubImprovementIssuePublisher:
     runner: CommandRunner
 
     def publish(self, intent: ImprovementIssueIntent) -> ImprovementPublishResult:
+        sink = self.config.self_improvement
+        if not sink.enabled:
+            raise ValueError("自己改善公開先が無効です")
         self._validate_intent(intent)
         with _improvement_lock(intent.candidate.improvement_key):
             existing = self._find_open_issue(intent.candidate.improvement_key)
@@ -62,13 +65,13 @@ class GitHubImprovementIssuePublisher:
                         "issue",
                         "create",
                         "--repo",
-                        self.config.repository,
+                        sink.repository or "",
                         "--title",
                         intent.candidate.title,
                         "--body",
                         render_issue_body(intent.candidate, self.config),
                         "--label",
-                        self.config.label,
+                        sink.label or "",
                     )
                 )
                 issue_number = _issue_number(created_issue_url.strip())
@@ -88,8 +91,8 @@ class GitHubImprovementIssuePublisher:
                 "api",
                 "--paginate",
                 "--slurp",
-                f"repos/{self.config.repository}/issues?state=open&labels="
-                f"{self.config.label}&per_page=100",
+                f"repos/{self._sink().repository or ''}/issues?state=open&labels="
+                f"{self._sink().label or ''}&per_page=100",
             )
         )
         for item in _object_pages(raw):
@@ -116,9 +119,9 @@ class GitHubImprovementIssuePublisher:
                         "gh",
                         "project",
                         "item-add",
-                        str(self.config.project_number),
+                        str(self._sink().project_number or 0),
                         "--owner",
-                        self.config.owner,
+                        self._sink().owner or "",
                         "--url",
                         issue_url,
                         "--format",
@@ -131,7 +134,7 @@ class GitHubImprovementIssuePublisher:
                 WriteIntent(
                     "improvement-project-item-add-effect",
                     "project",
-                    str(self.config.project_number),
+                    str(self._sink().project_number or 0),
                     "verify_effect",
                     (),
                     (("item_id", item_id),),
@@ -159,7 +162,7 @@ class GitHubImprovementIssuePublisher:
             WriteIntent(
                 "improvement-project-effect",
                 "project",
-                str(self.config.project_number),
+                str(self._sink().project_number or 0),
                 "verify_effect",
                 (),
                 tuple(
@@ -205,7 +208,7 @@ class GitHubImprovementIssuePublisher:
             WriteIntent(
                 f"improvement-project-edit-{field_name}",
                 "project",
-                str(self.config.project_number),
+                str(self._sink().project_number or 0),
                 "edit_improvement_field",
                 tuple(expected_preconditions.items()),
                 (),
@@ -221,7 +224,7 @@ class GitHubImprovementIssuePublisher:
             WriteIntent(
                 f"improvement-project-edit-{field_name}-effect",
                 "project",
-                str(self.config.project_number),
+                str(self._sink().project_number),
                 "verify_effect",
                 (),
                 ((f"value:{field_name}", value),),
@@ -241,7 +244,7 @@ class GitHubImprovementIssuePublisher:
             WriteIntent(
                 "improvement-project-item-add",
                 "project",
-                str(self.config.project_number),
+                str(self._sink().project_number),
                 "add_improvement_item",
                 (("project_id", project_id), ("item_presence", "absent")),
                 (),
@@ -310,9 +313,9 @@ class GitHubImprovementIssuePublisher:
                     "gh",
                     "project",
                     "view",
-                    str(self.config.project_number),
+                    str(self._sink().project_number or 0),
                     "--owner",
-                    self.config.owner,
+                    self._sink().owner or "",
                     "--format",
                     "json",
                 )
@@ -330,9 +333,9 @@ class GitHubImprovementIssuePublisher:
                     "gh",
                     "project",
                     "item-list",
-                    str(self.config.project_number),
+                    str(self._sink().project_number or 0),
                     "--owner",
-                    self.config.owner,
+                    self._sink().owner or "",
                     "--limit",
                     "100000",
                     "--format",
@@ -382,9 +385,9 @@ class GitHubImprovementIssuePublisher:
                     "gh",
                     "project",
                     "field-list",
-                    str(self.config.project_number),
+                    str(self._sink().project_number or 0),
                     "--owner",
-                    self.config.owner,
+                    self._sink().owner or "",
                     "--format",
                     "json",
                 )
@@ -476,28 +479,38 @@ class GitHubImprovementIssuePublisher:
         }
 
     def _validate_intent(self, intent: ImprovementIssueIntent) -> None:
-        if intent.repository != self.config.repository:
+        sink = self._sink()
+        if intent.repository != sink.repository:
             raise ValueError("想定外のRepositoryです")
-        if intent.project_number != self.config.project_number:
+        if intent.project_number != sink.project_number:
             raise ValueError("想定外のProjectです")
-        if intent.label != self.config.label:
+        if intent.label != sink.label:
             raise ValueError("想定外の改善ラベルです")
 
+    def _sink(self) -> SelfImprovementConfig:
+        sink = self.config.self_improvement
+        if not sink.enabled:
+            raise ValueError("自己改善公開先が無効です")
+        return sink
+
     def _web_issue_url(self, number: int) -> str:
-        return f"https://github.com/{self.config.repository}/issues/{number}"
+        return f"https://github.com/{self._sink().repository or ''}/issues/{number}"
 
 
 def improvement_intent(
     candidate: ImprovementCandidate,
     config: LoopEngineConfig,
 ) -> ImprovementIssueIntent:
+    sink = config.self_improvement
+    if not sink.enabled:
+        raise ValueError("自己改善公開先が無効です")
     return ImprovementIssueIntent(
-        repository=config.repository,
-        project_number=config.project_number,
-        label=config.label,
+        repository=sink.repository or "",
+        project_number=sink.project_number or 0,
+        label=sink.label or "",
         status="Ready",
-        area=config.improvement_area,
-        issue_level=config.issue_level,
+        area=sink.area or "",
+        issue_level=sink.issue_level or "",
         candidate=candidate,
     )
 

--- a/src/loop_engineering/health.py
+++ b/src/loop_engineering/health.py
@@ -172,13 +172,16 @@ def marker(key: str) -> str:
 
 
 def render_issue_body(candidate: ImprovementCandidate, config: LoopEngineConfig) -> str:
-    """設定済みAuthorityに結び付けた日本語の改善Issue本文を生成する。"""
+    """自己改善公開先のAuthorityに結び付けた日本語の改善Issue本文を生成する。"""
+    sink = config.self_improvement
+    if not sink.enabled:
+        raise ValueError("自己改善公開先が無効です")
     affected = ", ".join(f"#{item}" for item in candidate.affected_work_ids) or "なし"
     evidence = "\n".join(f"- `{item}`" for item in candidate.evidence_refs) or "- なし"
-    authority = "\n".join(f"- {item}" for item in config.authority_refs) or "- GitHubの現在状態"
+    authority = "\n".join(f"- {item}" for item in sink.authority_refs) or "- GitHubの現在状態"
     return (
         f"{marker(candidate.improvement_key)}\n\n"
-        f"Issue level: {config.issue_level}\n\n"
+        f"Issue level: {sink.issue_level or ''}\n\n"
         "## 正本\n\n"
         f"{authority}\n\n"
         "## 自動生成元\n\n"

--- a/src/loop_engineering/maintenance.py
+++ b/src/loop_engineering/maintenance.py
@@ -47,6 +47,8 @@ class SelfImprovementController:
     ) -> MaintenancePublication:
         published: list[ImprovementPublishResult] = []
         failures: list[ImprovementPublishFailure] = []
+        if not self.config.self_improvement.enabled:
+            return MaintenancePublication((), ())
         for candidate in candidates:
             try:
                 published.append(

--- a/src/loop_engineering/trusted_worktree.py
+++ b/src/loop_engineering/trusted_worktree.py
@@ -150,7 +150,7 @@ class TrustedWorktree:
             return None
         if not self._git(("merge", "--ff-only", f"origin/{trunk}")).succeeded:
             return None
-        branch = f"loop/work-{work_issue}"
+        branch = self._config.work_branch(work_issue)
         local = self._git(("show-ref", "--verify", "--quiet", f"refs/heads/{branch}"))
         if local.returncode == 0:
             return None

--- a/src/loop_engineering/write_gate.py
+++ b/src/loop_engineering/write_gate.py
@@ -15,8 +15,13 @@ def validate(
     *,
     config: LoopEngineConfig,
 ) -> WriteGateResult:
-    if intent.target_kind == "project" and intent.target_identity != str(config.project_number):
-        return WriteGateResult(False, ConflictKind.FORBIDDEN_PROJECT_IDENTITY)
+    if intent.target_kind == "project":
+        allowed_projects = {str(config.project_number)}
+        sink = config.self_improvement
+        if sink.enabled and sink.project_number is not None:
+            allowed_projects.add(str(sink.project_number))
+        if intent.target_identity not in allowed_projects:
+            return WriteGateResult(False, ConflictKind.FORBIDDEN_PROJECT_IDENTITY)
     if intent.target_kind == "branch" and intent.target_identity == config.trunk_branch:
         return WriteGateResult(False, ConflictKind.DIRECT_TRUNK_WRITE_FORBIDDEN)
     if intent.target_kind == "branch" and intent.mutation_kind == "content":

--- a/tests/loop_engineering/conftest.py
+++ b/tests/loop_engineering/conftest.py
@@ -1,4 +1,4 @@
-from loop_engineering.config import LoopEngineConfig
+from loop_engineering.config import LoopEngineConfig, SelfImprovementConfig
 from loop_engineering.models import (
     CanonicalDesignSnapshot,
     LineageClassification,
@@ -25,6 +25,15 @@ def config() -> LoopEngineConfig:
         parent_issue=462,
         integration_work=471,
         ci_workflow_name="V2 Deterministic CI",
+        self_improvement=SelfImprovementConfig(
+            enabled=True,
+            repository="ktan514/ai-liver-yura",
+            owner="ktan514",
+            project_number=7,
+            label="loop-engineering",
+            area="Subsystem/Development Tooling",
+            issue_level="Work",
+        ),
     )
 
 

--- a/tests/loop_engineering/test_self_improvement.py
+++ b/tests/loop_engineering/test_self_improvement.py
@@ -111,7 +111,7 @@ def test_generated_issue_body_has_durable_marker_dates_and_authority() -> None:
     candidate = _candidate()
     body = render_issue_body(candidate, config())
     assert marker(candidate.improvement_key) in body
-    assert "#462" in body
+    assert "GitHubの現在状態" in body
     assert "開始日: `2026-08-27`" in body
     assert "目標日: `2026-08-31`" in body
 
@@ -408,6 +408,33 @@ def test_product_label_does_not_flow_into_explicit_self_improvement_sink() -> No
     assert intent.repository == "ktan514/loop-engineering"
     assert intent.project_number == 9
     assert intent.label == "loop-engineering"
+
+
+def test_self_improvement_body_does_not_reuse_product_authority_or_issue_level() -> None:
+    separated = LoopEngineConfig(
+        repository="ktan514/ai-liver-yura",
+        owner="ktan514",
+        project_number=7,
+        mission_issue=450,
+        authority_refs=("#207", "#317", "#450"),
+        issue_level="Product Work",
+        self_improvement=SelfImprovementConfig(
+            enabled=True,
+            repository="ktan514/loop-engineering",
+            owner="ktan514",
+            project_number=9,
+            label="loop-engineering",
+            area="Runtime / Infrastructure",
+            issue_level="Platform Work",
+        ),
+    )
+
+    body = render_issue_body(_candidate(), separated)
+
+    assert "#207" not in body
+    assert "#317" not in body
+    assert "#450" not in body
+    assert "Issue level: Platform Work" in body
 
 
 class SinkProbeRunner:

--- a/tests/loop_engineering/test_self_improvement.py
+++ b/tests/loop_engineering/test_self_improvement.py
@@ -8,6 +8,7 @@ from datetime import date
 
 import pytest
 
+from loop_engineering.config import LoopEngineConfig, SelfImprovementConfig
 from loop_engineering.github_issues import GitHubImprovementIssuePublisher, improvement_intent
 from loop_engineering.health import marker, plan_improvements, render_issue_body
 from loop_engineering.maintenance import LoopMaintenanceCycle, SelfImprovementController
@@ -366,6 +367,111 @@ def test_maintenance_cycle_publishes_candidate_in_same_iteration() -> None:
     assert result.publication.failures == ()
     assert publisher.intents[0].label == "loop-engineering"
     assert publisher.intents[0].project_number == 7
+
+
+def test_disabled_self_improvement_does_not_publish_github_mutations() -> None:
+    disabled = LoopEngineConfig(
+        repository="ktan514/ai-liver-yura",
+        owner="ktan514",
+        project_number=7,
+        mission_issue=450,
+        label="v2",
+    )
+    publisher = RecordingPublisher()
+    result = SelfImprovementController(disabled, publisher).publish_candidates((_candidate(),))
+
+    assert result.published == ()
+    assert result.failures == ()
+    assert publisher.intents == []
+
+
+def test_product_label_does_not_flow_into_explicit_self_improvement_sink() -> None:
+    separated = LoopEngineConfig(
+        repository="ktan514/ai-liver-yura",
+        owner="ktan514",
+        project_number=7,
+        mission_issue=450,
+        label="v2",
+        self_improvement=SelfImprovementConfig(
+            enabled=True,
+            repository="ktan514/loop-engineering",
+            owner="ktan514",
+            project_number=9,
+            label="loop-engineering",
+            area="Runtime / Infrastructure",
+            issue_level="Work",
+        ),
+    )
+
+    intent = improvement_intent(_candidate(), separated)
+
+    assert intent.repository == "ktan514/loop-engineering"
+    assert intent.project_number == 9
+    assert intent.label == "loop-engineering"
+
+
+class SinkProbeRunner:
+    def __init__(self) -> None:
+        self.commands: list[tuple[str, ...]] = []
+
+    def run(self, args: Sequence[str]) -> str:
+        command = tuple(args)
+        self.commands.append(command)
+        if command[:2] == ("gh", "api"):
+            return "[[]]"
+        if command[:3] == ("gh", "issue", "create"):
+            return "https://github.com/ktan514/loop-engineering/issues/502\n"
+        if command[:4] == ("gh", "project", "view", "9"):
+            return '{"id":"PVT9"}'
+        if command[:4] == ("gh", "project", "item-list", "9"):
+            return '{"items":[]}'
+        if command[:4] == ("gh", "project", "item-add", "9"):
+            raise RuntimeError("公開先確認で停止")
+        raise AssertionError(command)
+
+
+def test_publisher_uses_self_improvement_repository_project_and_label() -> None:
+    separated = LoopEngineConfig(
+        repository="ktan514/ai-liver-yura",
+        owner="ktan514",
+        project_number=7,
+        mission_issue=450,
+        label="v2",
+        self_improvement=SelfImprovementConfig(
+            enabled=True,
+            repository="ktan514/loop-engineering",
+            owner="ktan514",
+            project_number=9,
+            label="loop-engineering",
+            area="Runtime / Infrastructure",
+            issue_level="Work",
+        ),
+    )
+    runner = SinkProbeRunner()
+
+    with pytest.raises(RuntimeError, match="公開先確認"):
+        GitHubImprovementIssuePublisher(runner=runner, config=separated).publish(
+            improvement_intent(_candidate(), separated)
+        )
+
+    issue_create = next(
+        command for command in runner.commands if command[:3] == ("gh", "issue", "create")
+    )
+    assert "ktan514/loop-engineering" in issue_create
+    assert "loop-engineering" in issue_create
+    assert not any("ktan514/ai-liver-yura" in command for command in runner.commands)
+    assert (
+        "gh",
+        "project",
+        "item-add",
+        "9",
+        "--owner",
+        "ktan514",
+        "--url",
+        "https://github.com/ktan514/loop-engineering/issues/502",
+        "--format",
+        "json",
+    ) in runner.commands
 
 
 def test_publisher_failure_is_typed_and_does_not_replace_primary_decision() -> None:

--- a/tests/loop_engineering/test_trusted_worktree.py
+++ b/tests/loop_engineering/test_trusted_worktree.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping, Sequence
+from dataclasses import replace
 from pathlib import Path
 
 from loop_engineering.host_runtime import HostTarget, LocalCommandResult
@@ -31,6 +32,39 @@ class ScriptedRunner:
         if response is None:
             raise AssertionError(f"想定外のコマンドです: {args}")
         return response
+
+
+def test_new_worktree_uses_configured_product_branch_template() -> None:
+    runner = ScriptedRunner(
+        {
+            ("git", "status", "--porcelain"): LocalCommandResult(0, ""),
+            ("git", "fetch", "origin", "rebuild/v2-foundation"): LocalCommandResult(0, ""),
+            ("git", "switch", "rebuild/v2-foundation"): LocalCommandResult(0, ""),
+            ("git", "merge", "--ff-only", "origin/rebuild/v2-foundation"): LocalCommandResult(
+                0, ""
+            ),
+            (
+                "git", "show-ref", "--verify", "--quiet", "refs/heads/feature/work-123"
+            ): LocalCommandResult(1, ""),
+            (
+                "git", "ls-remote", "--exit-code", "--heads", "origin", "feature/work-123"
+            ): LocalCommandResult(2, ""),
+            ("git", "switch", "-c", "feature/work-123"): LocalCommandResult(0, ""),
+            ("git", "rev-parse", "HEAD"): LocalCommandResult(0, "a" * 40 + "\n"),
+        }
+    )
+    worktree = TrustedWorktree(
+        replace(config(), work_branch_template="feature/work-{issue}"),
+        runner,
+        Path("/repo"),
+        {"PATH": "/usr/bin"},
+    )
+
+    prepared = worktree.prepare(HostTarget(123, True, None, None, False, False, 1, None))
+
+    assert prepared is not None
+    assert prepared.branch == "feature/work-123"
+    assert ("git", "switch", "-c", "loop/work-123") not in runner.commands
 
 
 def test_existing_pr_is_prepared_without_codex_git_write() -> None:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 import pytest
 
-from loop_engineering.config import LoopEngineeringSettings
+from loop_engineering.config import (
+    LoopEngineConfig,
+    LoopEngineeringSettings,
+    SelfImprovementConfig,
+)
 
 
 def _write_config(path: Path, workspace: str, *, github_env: str = "MY_GITHUB_TOKEN") -> None:
@@ -131,3 +135,89 @@ def test_invalid_secret_environment_name_is_rejected(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="github_token_env"):
         LoopEngineeringSettings.load(tmp_path, {}, config_path=config)
+
+
+def test_product_branch_template_expands_only_issue_placeholder() -> None:
+    yura = LoopEngineConfig(
+        repository="ktan514/ai-liver-yura",
+        owner="ktan514",
+        project_number=7,
+        mission_issue=450,
+        work_branch_template="feature/work-{issue}",
+    )
+
+    assert yura.work_branch(123) == "feature/work-123"
+    assert LoopEngineConfig(
+        repository="ktan514/loop-engineering",
+        owner="ktan514",
+        project_number=9,
+        mission_issue=33,
+    ).work_branch(123) == "loop/work-123"
+
+
+@pytest.mark.parametrize("template", ("", "feature/{name}", "../work-{issue}", "feature//{issue}"))
+def test_invalid_product_branch_template_fails_closed(template: str) -> None:
+    with pytest.raises(ValueError, match="work_branch_template"):
+        LoopEngineConfig(
+            repository="owner/product",
+            owner="owner",
+            project_number=1,
+            mission_issue=1,
+            work_branch_template=template,
+        )
+
+
+def test_self_improvement_is_disabled_without_explicit_sink() -> None:
+    config = LoopEngineConfig(
+        repository="ktan514/ai-liver-yura",
+        owner="ktan514",
+        project_number=7,
+        mission_issue=450,
+    )
+
+    assert not config.self_improvement.enabled
+
+
+def test_explicit_self_improvement_sink_is_independent_from_product() -> None:
+    config = LoopEngineConfig(
+        repository="ktan514/ai-liver-yura",
+        owner="ktan514",
+        project_number=7,
+        mission_issue=450,
+        label="v2",
+        self_improvement=SelfImprovementConfig(
+            enabled=True,
+            repository="ktan514/loop-engineering",
+            owner="ktan514",
+            project_number=9,
+            label="loop-engineering",
+            area="Runtime / Infrastructure",
+            issue_level="Work",
+        ),
+    )
+
+    assert config.self_improvement.repository == "ktan514/loop-engineering"
+    assert config.self_improvement.project_number == 9
+    assert config.self_improvement.label == "loop-engineering"
+
+
+def test_settings_load_explicit_self_improvement_sink(tmp_path: Path) -> None:
+    config = tmp_path / "loop-engineering.ini"
+    _write_config(config, str(tmp_path / "product"))
+    with config.open("a", encoding="utf-8") as stream:
+        stream.write(
+            "\n[self_improvement]\n"
+            "enabled = true\n"
+            "repository = ktan514/loop-engineering\n"
+            "project_owner = ktan514\n"
+            "project_number = 9\n"
+            "label = loop-engineering\n"
+            "area = Runtime / Infrastructure\n"
+            "issue_level = Work\n"
+        )
+
+    settings = LoopEngineeringSettings.load(tmp_path, {}, config_path=config)
+
+    assert settings.engine.self_improvement.enabled
+    assert settings.engine.self_improvement.repository == "ktan514/loop-engineering"
+    assert settings.engine.self_improvement.project_number == 9

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -273,3 +273,22 @@ def test_legacy_self_target_configuration_is_migrated_only_at_platform_root(tmp_
 
     assert settings.engine.self_improvement.enabled
     assert settings.engine.self_improvement.repository == "owner/product"
+
+
+def test_distributed_example_configuration_loads_after_workspace_replacement(
+    tmp_path: Path,
+) -> None:
+    root = Path(__file__).resolve().parents[1]
+    template = root / "config" / "loop-engineering.example.ini"
+    config = tmp_path / "loop-engineering.ini"
+    config.write_text(
+        template.read_text(encoding="utf-8").replace(
+            "/absolute/path/to/product-workspace", str(tmp_path / "workspace")
+        ),
+        encoding="utf-8",
+    )
+
+    settings = LoopEngineeringSettings.load(tmp_path, {}, config_path=config)
+
+    assert settings.engine.repository == "owner/repository"
+    assert settings.engine.self_improvement.authority_refs == ()

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -155,7 +155,17 @@ def test_product_branch_template_expands_only_issue_placeholder() -> None:
     ).work_branch(123) == "loop/work-123"
 
 
-@pytest.mark.parametrize("template", ("", "feature/{name}", "../work-{issue}", "feature//{issue}"))
+@pytest.mark.parametrize(
+    "template",
+    (
+        "",
+        "feature/{name}",
+        "../work-{issue}",
+        "feature//{issue}",
+        "feature/foo.lock",
+        "feature/.hidden-{issue}",
+    ),
+)
 def test_invalid_product_branch_template_fails_closed(template: str) -> None:
     with pytest.raises(ValueError, match="work_branch_template"):
         LoopEngineConfig(
@@ -221,3 +231,45 @@ def test_settings_load_explicit_self_improvement_sink(tmp_path: Path) -> None:
     assert settings.engine.self_improvement.enabled
     assert settings.engine.self_improvement.repository == "ktan514/loop-engineering"
     assert settings.engine.self_improvement.project_number == 9
+
+
+@pytest.mark.parametrize("enabled", (True, False))
+def test_runtime_environment_round_trips_self_improvement_config(
+    tmp_path: Path, enabled: bool
+) -> None:
+    config = tmp_path / "loop-engineering.ini"
+    _write_config(config, str(tmp_path / "product"))
+    if enabled:
+        with config.open("a", encoding="utf-8") as stream:
+            stream.write(
+                "\n[self_improvement]\n"
+                "enabled = true\nrepository = ktan514/loop-engineering\n"
+                "project_owner = ktan514\nproject_number = 9\n"
+                "label = loop-engineering\narea = Runtime / Infrastructure\n"
+                "issue_level = Work\nauthority_refs = #26, #40\n"
+            )
+    else:
+        with config.open("a", encoding="utf-8") as stream:
+            stream.write("\n[self_improvement]\nenabled = false\n")
+
+    settings = LoopEngineeringSettings.load(tmp_path, {}, config_path=config)
+    round_tripped = LoopEngineConfig.from_environment(settings.runtime_environment({}))
+
+    assert round_tripped.self_improvement.enabled is enabled
+    if enabled:
+        assert round_tripped.self_improvement.repository == "ktan514/loop-engineering"
+        assert round_tripped.self_improvement.owner == "ktan514"
+        assert round_tripped.self_improvement.project_number == 9
+        assert round_tripped.self_improvement.label == "loop-engineering"
+        assert round_tripped.self_improvement.area == "Runtime / Infrastructure"
+        assert round_tripped.self_improvement.issue_level == "Work"
+
+
+def test_legacy_self_target_configuration_is_migrated_only_at_platform_root(tmp_path: Path) -> None:
+    config = tmp_path / "loop-engineering.ini"
+    _write_config(config, str(tmp_path))
+
+    settings = LoopEngineeringSettings.load(tmp_path, {}, config_path=config)
+
+    assert settings.engine.self_improvement.enabled
+    assert settings.engine.self_improvement.repository == "owner/product"


### PR DESCRIPTION
## 概要

Product Workのbranch templateと、Loop Engineering自身の自己改善Issue公開先を設定として分離します。

## 検証

- `pipenv run pytest`（126 passed）
- `pipenv run ruff check src tests`
- `pipenv run mypy --strict src tests`
- `pipenv run python -m compileall -q src tests`
- `git diff --check`