### PR TITLE
fix: Mission Goal参照元をProduct Workspaceから分離する

### DIFF
--- a/config/goals/ktan514__ai-liver-yura.md
+++ b/config/goals/ktan514__ai-liver-yura.md
@@ -1,0 +1,54 @@
+# AI Liver ゆら V2 自律完遂Mission
+
+version: 5
+generation: 1
+
+## Mission
+
+Root #317をMission #450の管理下で完成まで進める。現在状態の正本はGitHub liveのIssue、PR、branch、厳密HEAD、CI、Project #7とする。固定PR番号や固定HEADをGoal本文へ埋め込まず、最新Mission Checkpointとfresh readbackから現在対象を解決する。
+
+## Authorityと安全境界
+
+- Project #7をV2の計画Authorityとする。Project #6は変更しない。
+- Product Repositoryのcanonical designと選択中Work Issueが設計意図を定義する。
+- Loop Engineeringは外部Control Planeとして動作し、Product WorkspaceへLoop専用実装や運用文書を戻さない。
+- Codexは実装者であり、独立Reviewerは実装branchを書き換えない。
+- review、CI、mergeは厳密HEADへ結び付け、HEAD変更後の古い証拠を再利用しない。
+- token、API key、database credential、request header、raw provider failureをRepository、Issue、PR、Checkpoint、通常logへ保存しない。
+- force pushとrebaseによる履歴破壊を行わない。
+
+## 再開判定
+
+branch作成、実装、push、merge、新規PR作成の前にGitHub live、最新Mission/Work Checkpoint、現在trunk、canonical design、active lineage、CI/review状態をfresh確認する。
+
+競合lineage、不明なSHA更新、Authority不一致がある場合は再調整してから進む。会話記憶だけで現在対象を確定しない。
+
+## 制御ループ
+
+観測 → 再調整 → 再開判定 → 選択 → 計画 → 設計 → 実装 → 検証 → レビュー・診断 → 修正・統合 → Checkpoint → 反復・外部待機・介入。
+
+個別Workの完了はMission完了を意味しない。Work完了後はGitHub live dependency graphから次のdependency-ready Workをfresh選択する。
+
+## レビューと修正
+
+- `REQUEST_CHANGES`は通常のfix-loop条件でありMission停止理由にしない。
+- review待ちだけをHuman Intervention扱いにしない。
+- 同一厳密HEADへ重複review依頼を繰り返さない。
+- 独立して進められるWorkがある場合はfresh Resume Gateを通して継続する。
+- test、lint、type check、CIの失敗は修正可能なら通常の修正対象とする。
+
+## Operational State
+
+PostgreSQLはLoop EngineeringのRun、transition、checkpoint、blocker、lease、重複実行防止等のOperational Stateに使用する。GitHub current-state AuthorityやMission GoalをDBの過去状態で上書きしない。
+
+## Mission状態
+
+有用な独立Workが存在する間はMission stateを`ACTIVE`とする。外部結果だけを待つ場合は`YIELD_EXTERNAL`としてRunを終了できる。`PAUSED_FOR_INTERVENTION`は安全に推測できない利用者判断またはAuthority判断が必要な場合だけ使用する。
+
+Missionを完了できるのは、Root #317とMission #450が定義する全体完成条件をGitHub liveと必要なVerification証拠で満たした場合だけとする。
+
+## 復元とidentity
+
+このファイルをYura用Codex Mission GoalのHost側正本とする。Loop EngineeringはこのUTF-8ファイルから`version`、`generation`、SHA-256を取得し、`CODEX_MISSION_GOAL_VERSION`、`CODEX_MISSION_GOAL_GENERATION`、`CODEX_MISSION_GOAL_SHA256`として実行環境へ注入する。
+
+Product Workspace内の旧`docs/operations/loop_mission_goal.md`を通常Authorityとして要求しない。Goalを失った場合も会話要約から再構成せず、このHost側正本から復元する。

--- a/docs/architecture/mission_goal_source.md
+++ b/docs/architecture/mission_goal_source.md
@@ -1,0 +1,133 @@
+# Mission Goal Source境界
+
+管理Issue: #27
+関連: #2 / #3 / #31 / #44
+状態: canonical architecture
+
+## 1. 目的
+
+Loop Engineeringが複数Product Workspaceを扱うとき、Mission Goalの正本をProduct Workspace内の固定pathへ暗黙依存させない。
+
+Mission Goalは実行対象Productの現在Missionを定義する信頼済みHost設定であり、Product source tree、GitHub current-state、PostgreSQL Operational Stateとは別のAuthorityとして扱う。
+
+## 2. Authority分類
+
+Mission Goalは「現在のPR/HEAD」を表すCurrent-state Authorityではない。
+
+役割を次のように分離する。
+
+```text
+GitHub live
+→ Issue / PR / Project / branch / HEAD / CI / reviewの現在状態
+
+Mission Goal Source
+→ Missionの目的、継続条件、安全境界、復元identity
+
+PostgreSQL Operational Store
+→ Run / transition / checkpoint / blocker / lease等の運用状態
+
+Product Workspace
+→ Product source / tests / canonical product design
+```
+
+PostgreSQL Operational Storeの内容だけでMission GoalやGitHub current-stateを上書きしない。
+
+## 3. Bootstrap trust anchor
+
+Mission Goal SourceのpathはHost側Project Registrationが所有する。
+
+現在のINI設定では `[project] mission_goal_path` を使用する。
+
+```ini
+[project]
+key = ai-liver-yura
+workspace_path = /absolute/path/to/product-workspace
+repository = ktan514/ai-liver-yura
+mission_goal_path = /absolute/path/to/trusted/mission-goal.md
+```
+
+`mission_goal_path`は秘密情報ではない。
+
+相対pathを指定した場合はLoop Engineering Platform rootから解決し、Product Workspaceからは解決しない。これによりfeature branch上のProduct fileがHost Mission Goalを自己変更できない。
+
+## 4. Goal identity
+
+Goal Sourceは最低限次を持つ。
+
+```text
+version: <value>
+generation: <value>
+```
+
+起動時にUTF-8 file全体のSHA-256を計算し、次を実行環境へ注入する。
+
+- `CODEX_MISSION_GOAL_VERSION`
+- `CODEX_MISSION_GOAL_GENERATION`
+- `CODEX_MISSION_GOAL_SHA256`
+- `LOOP_MISSION_GOAL_PATH`
+
+事前確認は同じconfigured Goal Sourceを読み、version / generation / SHA-256を照合する。
+
+起動器と事前確認が別pathを参照してはならない。
+
+## 5. Product Workspaceとの境界
+
+Product Workspaceの `docs/operations/loop_mission_goal.md` を標準配置として要求しない。
+
+standalone移行前の互換性のため、`mission_goal_path`未設定時だけ旧path:
+
+```text
+<workspace>/docs/operations/loop_mission_goal.md
+```
+
+を互換fallbackとして読める。
+
+ただし新しいProduct Registrationでは明示的な`mission_goal_path`を使用する。
+
+Product WorkspaceにGoal fileが無いこと自体を異常としない。
+
+## 6. 複数Product
+
+各Projectは別々のGoal Sourceを持てる。
+
+```text
+Project A config → Goal A
+Project B config → Goal B
+Loop Engineering self config → standalone Goal
+```
+
+Platform Coreへ特定ProductのMission番号やGoal本文をハードコードしない。
+
+## 7. PostgreSQLとの境界
+
+PostgreSQLは#44でOperational Stateの永続正本として使用する。
+
+Mission Goal本文をDBだけに保存してbootstrap trust anchorとする設計は採用しない。
+
+理由:
+- DB接続確立前にも実行対象と安全方針を識別できる必要がある
+- DBの古いOperational StateをGoal Authorityへ昇格させない
+- Product RegistrationとGoal Sourceの変更をGit revision/file digestで監査可能にする
+
+DBにはGoal identity（pathを直接保存する必要がある場合は秘密でない正規化参照、version、generation、digest）をRun evidenceとして記録してよいが、Goal本文のAuthorityはHost設定で選ばれたtrusted sourceに残す。
+
+## 8. Fail-closed
+
+次の場合は `MISSION_GOAL` capabilityをBLOCKEDとする。
+
+- configured Goal Sourceが存在しない
+- UTF-8として読めない
+- `version`または`generation`がない
+- 起動時注入identityと事前確認時identityが一致しない
+- Goal Sourceを一意に解決できない
+
+古いGoal、別ProductのGoal、PostgreSQL上の過去Runを暗黙fallbackにしない。
+
+## 9. 完了条件
+
+- Goal SourceがProduct Workspace固定pathから分離される
+- 設定→起動identity注入→Preflightが同じGoal Sourceを使用する
+- 旧Product内pathは互換fallbackに限定される
+- Yuraの最新trunkにLoop専用Goal fileが無くても起動できる
+- standalone self-targetの既存Goalは回帰しない
+- PostgreSQL Operational StoreとGoal Authorityが混同されない

--- a/docs/architecture/mission_goal_source.md
+++ b/docs/architecture/mission_goal_source.md
@@ -34,21 +34,29 @@ PostgreSQL Operational Storeの内容だけでMission GoalやGitHub current-stat
 
 ## 3. Bootstrap trust anchor
 
-Mission Goal SourceのpathはHost側Project Registrationが所有する。
+Mission Goal SourceはHost側から解決し、Productのfeature branch自身に選択させない。
 
-現在のINI設定では `[project] mission_goal_path` を使用する。
+現在の解決順序:
 
-```ini
-[project]
-key = ai-liver-yura
-workspace_path = /absolute/path/to/product-workspace
-repository = ktan514/ai-liver-yura
-mission_goal_path = /absolute/path/to/trusted/mission-goal.md
+1. Host環境で明示された`LOOP_MISSION_GOAL_PATH`
+2. Loop Engineering Platform内のHost registry
+3. standalone移行前互換用のProduct内旧path
+
+Host registryはRepository identityから決定論的に解決する。
+
+```text
+config/goals/<owner>__<repository>.md
 ```
 
-`mission_goal_path`は秘密情報ではない。
+例:
 
-相対pathを指定した場合はLoop Engineering Platform rootから解決し、Product Workspaceからは解決しない。これによりfeature branch上のProduct fileがHost Mission Goalを自己変更できない。
+```text
+config/goals/ktan514__ai-liver-yura.md
+```
+
+`LOOP_MISSION_GOAL_PATH`で相対pathを指定した場合はLoop Engineering Platform rootから解決し、Product Workspaceからは解決しない。
+
+将来Project RegistrationをDB等へ拡張する場合も、Goal Sourceのbootstrap trust anchorをuntrusted Product branchだけへ委譲しない。
 
 ## 4. Goal identity
 
@@ -66,37 +74,33 @@ generation: <value>
 - `CODEX_MISSION_GOAL_SHA256`
 - `LOOP_MISSION_GOAL_PATH`
 
-事前確認は同じconfigured Goal Sourceを読み、version / generation / SHA-256を照合する。
-
-起動器と事前確認が別pathを参照してはならない。
+CLI、起動器、事前確認は同じGoal Source identityを使用する。別pathのGoalを個別に読み直して混在させない。
 
 ## 5. Product Workspaceとの境界
 
 Product Workspaceの `docs/operations/loop_mission_goal.md` を標準配置として要求しない。
 
-standalone移行前の互換性のため、`mission_goal_path`未設定時だけ旧path:
+standalone移行前の互換性のため、明示Host pathもHost registryも存在しない場合だけ旧path:
 
 ```text
 <workspace>/docs/operations/loop_mission_goal.md
 ```
 
-を互換fallbackとして読める。
+を読む。
 
-ただし新しいProduct Registrationでは明示的な`mission_goal_path`を使用する。
-
-Product WorkspaceにGoal fileが無いこと自体を異常としない。
+新しいProductではHost registryまたは明示Host pathを使用する。Product WorkspaceにLoop専用Goal fileが無いこと自体を異常としない。
 
 ## 6. 複数Product
 
 各Projectは別々のGoal Sourceを持てる。
 
 ```text
-Project A config → Goal A
-Project B config → Goal B
-Loop Engineering self config → standalone Goal
+Project A → Goal A
+Project B → Goal B
+Loop Engineering self → standalone Goal
 ```
 
-Platform Coreへ特定ProductのMission番号やGoal本文をハードコードしない。
+Platform Coreへ特定ProductのMission番号やGoal本文をハードコードしない。Product固有GoalをHost registryへ置くことは、Coreへのハードコードとは区別する。
 
 ## 7. PostgreSQLとの境界
 
@@ -107,26 +111,26 @@ Mission Goal本文をDBだけに保存してbootstrap trust anchorとする設�
 理由:
 - DB接続確立前にも実行対象と安全方針を識別できる必要がある
 - DBの古いOperational StateをGoal Authorityへ昇格させない
-- Product RegistrationとGoal Sourceの変更をGit revision/file digestで監査可能にする
+- Product RegistrationとGoal Sourceの変更をfile digestで監査可能にする
 
-DBにはGoal identity（pathを直接保存する必要がある場合は秘密でない正規化参照、version、generation、digest）をRun evidenceとして記録してよいが、Goal本文のAuthorityはHost設定で選ばれたtrusted sourceに残す。
+DBにはGoal identity（version、generation、digest、秘密でないsource ref）をRun evidenceとして記録してよいが、Goal本文のAuthorityはHost側のtrusted sourceに残す。
 
 ## 8. Fail-closed
 
 次の場合は `MISSION_GOAL` capabilityをBLOCKEDとする。
 
-- configured Goal Sourceが存在しない
+- Goal Sourceが存在しない
 - UTF-8として読めない
 - `version`または`generation`がない
 - 起動時注入identityと事前確認時identityが一致しない
 - Goal Sourceを一意に解決できない
 
-古いGoal、別ProductのGoal、PostgreSQL上の過去Runを暗黙fallbackにしない。
+無効な明示pathが指定された場合、別ProductのGoalや旧Goalへ暗黙fallbackしない。古いGoal、PostgreSQL上の過去Run、会話記憶もfallbackにしない。
 
 ## 9. 完了条件
 
 - Goal SourceがProduct Workspace固定pathから分離される
-- 設定→起動identity注入→Preflightが同じGoal Sourceを使用する
+- CLI / 起動identity注入 / Preflightが同じGoal Sourceを使用する
 - 旧Product内pathは互換fallbackに限定される
 - Yuraの最新trunkにLoop専用Goal fileが無くても起動できる
 - standalone self-targetの既存Goalは回帰しない

--- a/src/loop_engineering/__main__.py
+++ b/src/loop_engineering/__main__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from .config import LoopEngineeringSettings
 from .host_runtime import HostTransitionResult, HostTransitionStatus
+from .mission_goal import inject_mission_goal_environment
 from .runtime_console import RuntimeConsole, VisibleSubprocessLocalRunner
 
 _CI_RECHECK_INITIAL_SECONDS = 60.0
@@ -58,8 +59,13 @@ def main() -> int:
         print(f"CONFIGURATION_INVALID: {error}")
         return 3
 
-    environment = settings.runtime_environment(os.environ)
     workspace_root = settings.workspace_path
+    environment = inject_mission_goal_environment(
+        platform_root=platform_root,
+        product_root=workspace_root,
+        repository=settings.engine.repository,
+        environment=settings.runtime_environment(os.environ),
+    )
     console = RuntimeConsole(platform_root, verbose=arguments.verbose)
     runner = VisibleSubprocessLocalRunner(console)
     mode = "once" if arguments.once else "continuous"
@@ -67,6 +73,7 @@ def main() -> int:
     console.event(f"開始 mode={mode}（{mode_label}） project={settings.project_key}")
     console.event(f"設定: {settings.config_path}")
     console.event(f"対象Workspace: {workspace_root}")
+    console.event(f"Mission Goal: {environment['LOOP_MISSION_GOAL_PATH']}")
     console.event(f"ログ: {console.path}")
 
     ci_wait_seconds = _CI_RECHECK_INITIAL_SECONDS

--- a/src/loop_engineering/host_entrypoint.py
+++ b/src/loop_engineering/host_entrypoint.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import re
@@ -23,6 +22,7 @@ from .host_runtime import (
     MissionPort,
     SubprocessLocalRunner,
 )
+from .mission_goal import inject_mission_goal_environment
 from .preflight import (
     EnvironmentCapabilityPreflight,
     PreflightStatus,
@@ -439,14 +439,20 @@ def run_actual_host_transition(
     config: LoopEngineConfig | None = None,
 ) -> HostTransitionResult:
     project_root = root or Path(__file__).resolve().parents[2]
-    values = _canonical_goal_environment(project_root, environment or os.environ)
+    base_values = dict(environment or os.environ)
     try:
-        resolved_config = config or LoopEngineConfig.from_environment(values)
+        resolved_config = config or LoopEngineConfig.from_environment(base_values)
     except ValueError:
         return HostTransitionResult(
             HostTransitionStatus.INTERVENTION_REQUIRED,
             "CONFIGURATION_INVALID",
         )
+    values = inject_mission_goal_environment(
+        platform_root=Path(__file__).resolve().parents[2],
+        product_root=project_root,
+        repository=resolved_config.repository,
+        environment=base_values,
+    )
     preflight = EnvironmentCapabilityPreflight(
         resolved_config,
         SubprocessCommandRunner(),
@@ -482,34 +488,6 @@ def run_actual_host_transition(
         mission,
         implementer,
     ).run_once()
-
-
-def _canonical_goal_environment(
-    root: Path,
-    environment: Mapping[str, str],
-) -> dict[str, str]:
-    values = dict(environment)
-    goal = root / "docs" / "operations" / "loop_mission_goal.md"
-    if not goal.is_file():
-        return values
-    content = goal.read_bytes()
-    lines = content.decode("utf-8").splitlines()
-    version = next(
-        (line.removeprefix("version: ") for line in lines if line.startswith("version: ")),
-        "",
-    )
-    generation = next(
-        (
-            line.removeprefix("generation: ")
-            for line in lines
-            if line.startswith("generation: ")
-        ),
-        "",
-    )
-    values["CODEX_MISSION_GOAL_VERSION"] = version
-    values["CODEX_MISSION_GOAL_GENERATION"] = generation
-    values["CODEX_MISSION_GOAL_SHA256"] = hashlib.sha256(content).hexdigest()
-    return values
 
 
 def _codex_argv(environment: Mapping[str, str]) -> tuple[str, ...]:

--- a/src/loop_engineering/host_launcher.py
+++ b/src/loop_engineering/host_launcher.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import hashlib
 import subprocess
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
+
+from .mission_goal import inject_mission_goal_environment
 
 
 class SecretProvider(Protocol):
@@ -57,6 +58,12 @@ _NON_SECRET_LOOP_KEYS = (
     "LOOP_TRUSTED_REVIEWER_SOCKET",
     "LOOP_CODEX_COMMAND_JSON",
 )
+_GOAL_KEYS = (
+    "LOOP_MISSION_GOAL_PATH",
+    "CODEX_MISSION_GOAL_VERSION",
+    "CODEX_MISSION_GOAL_GENERATION",
+    "CODEX_MISSION_GOAL_SHA256",
+)
 
 
 def build_launch_environment(
@@ -64,29 +71,23 @@ def build_launch_environment(
     secrets: SecretProvider,
     parent: Mapping[str, str],
 ) -> LaunchEnvironment:
-    goal = root / "docs" / "operations" / "loop_mission_goal.md"
-    content = goal.read_bytes()
-    lines = content.decode("utf-8").splitlines()
-    version = next(
-        line.removeprefix("version: ")
-        for line in lines
-        if line.startswith("version: ")
+    platform_root = Path(__file__).resolve().parents[2]
+    goal_environment = inject_mission_goal_environment(
+        platform_root=platform_root,
+        product_root=root,
+        repository=parent.get("LOOP_REPOSITORY", ""),
+        environment=parent,
     )
-    generation = next(
-        line.removeprefix("generation: ")
-        for line in lines
-        if line.startswith("generation: ")
-    )
+    if not all(goal_environment.get(name) for name in _GOAL_KEYS):
+        raise ValueError("Mission Goalを信頼済み参照元から解決できません")
+
     path = parent.get("PATH", "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
     values: dict[str, str] = {
         "PATH": path,
         "GH_TOKEN": secrets.github_token(),
-        "CODEX_MISSION_GOAL_VERSION": version,
-        "CODEX_MISSION_GOAL_GENERATION": generation,
-        "CODEX_MISSION_GOAL_SHA256": hashlib.sha256(content).hexdigest(),
     }
-    for name in _NON_SECRET_LOOP_KEYS:
-        value = parent.get(name)
+    for name in (*_NON_SECRET_LOOP_KEYS, *_GOAL_KEYS):
+        value = goal_environment.get(name)
         if value:
             values[name] = value
     return LaunchEnvironment(values)

--- a/src/loop_engineering/mission_goal.py
+++ b/src/loop_engineering/mission_goal.py
@@ -1,0 +1,100 @@
+"""Mission Goalの信頼済み参照元をProduct Workspaceから分離する。"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class MissionGoalIdentity:
+    path: Path
+    version: str
+    generation: str
+    sha256: str
+
+
+def resolve_mission_goal_path(
+    *,
+    platform_root: Path,
+    product_root: Path,
+    repository: str,
+    environment: Mapping[str, str],
+) -> Path:
+    explicit = environment.get("LOOP_MISSION_GOAL_PATH", "").strip()
+    if explicit:
+        path = Path(explicit).expanduser()
+        if not path.is_absolute():
+            path = platform_root / path
+        return path.resolve(strict=False)
+
+    if "/" in repository:
+        owner, name = repository.split("/", 1)
+        registry = platform_root / "config" / "goals" / f"{owner}__{name}.md"
+        if registry.is_file():
+            return registry.resolve(strict=False)
+
+    return (product_root / "docs" / "operations" / "loop_mission_goal.md").resolve(
+        strict=False
+    )
+
+
+def read_mission_goal_identity(path: Path) -> MissionGoalIdentity | None:
+    if not path.is_file():
+        return None
+    try:
+        content = path.read_bytes()
+        lines = content.decode("utf-8").splitlines()
+    except (OSError, UnicodeError):
+        return None
+
+    version = next(
+        (line.removeprefix("version: ").strip() for line in lines if line.startswith("version: ")),
+        "",
+    )
+    generation = next(
+        (
+            line.removeprefix("generation: ").strip()
+            for line in lines
+            if line.startswith("generation: ")
+        ),
+        "",
+    )
+    if not version or not generation:
+        return None
+    return MissionGoalIdentity(
+        path=path.resolve(strict=False),
+        version=version,
+        generation=generation,
+        sha256=hashlib.sha256(content).hexdigest(),
+    )
+
+
+def inject_mission_goal_environment(
+    *,
+    platform_root: Path,
+    product_root: Path,
+    repository: str,
+    environment: Mapping[str, str],
+) -> dict[str, str]:
+    values = dict(environment)
+    path = resolve_mission_goal_path(
+        platform_root=platform_root,
+        product_root=product_root,
+        repository=repository,
+        environment=values,
+    )
+    values["LOOP_MISSION_GOAL_PATH"] = str(path)
+    identity = read_mission_goal_identity(path)
+    if identity is None:
+        values.pop("CODEX_MISSION_GOAL_VERSION", None)
+        values.pop("CODEX_MISSION_GOAL_GENERATION", None)
+        values.pop("CODEX_MISSION_GOAL_SHA256", None)
+        return values
+
+    values["CODEX_MISSION_GOAL_VERSION"] = identity.version
+    values["CODEX_MISSION_GOAL_GENERATION"] = identity.generation
+    values["CODEX_MISSION_GOAL_SHA256"] = identity.sha256
+    return values

--- a/src/loop_engineering/preflight.py
+++ b/src/loop_engineering/preflight.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import socket
@@ -14,6 +13,7 @@ from typing import Protocol
 from urllib.parse import urlsplit
 
 from .config import LoopEngineConfig, LoopEngineeringSettings
+from .mission_goal import inject_mission_goal_environment, read_mission_goal_identity
 
 
 class PreflightStatus(str, Enum):
@@ -342,18 +342,19 @@ class EnvironmentCapabilityPreflight:
         }
 
     def _mission_goal_matches(self) -> bool:
-        source = self._project_root / "docs" / "operations" / "loop_mission_goal.md"
-        generation = self._environment.get("CODEX_MISSION_GOAL_GENERATION")
-        version = self._environment.get("CODEX_MISSION_GOAL_VERSION")
-        content_hash = self._environment.get("CODEX_MISSION_GOAL_SHA256")
-        if not source.is_file() or not all((generation, version, content_hash)):
+        raw_path = self._environment.get("LOOP_MISSION_GOAL_PATH", "").strip()
+        source = (
+            Path(raw_path).expanduser().resolve(strict=False)
+            if raw_path
+            else self._project_root / "docs" / "operations" / "loop_mission_goal.md"
+        )
+        identity = read_mission_goal_identity(source)
+        if identity is None:
             return False
-        content = source.read_bytes()
-        lines = content.decode("utf-8").splitlines()
         return (
-            f"generation: {generation}" in lines
-            and f"version: {version}" in lines
-            and hashlib.sha256(content).hexdigest() == content_hash
+            self._environment.get("CODEX_MISSION_GOAL_GENERATION") == identity.generation
+            and self._environment.get("CODEX_MISSION_GOAL_VERSION") == identity.version
+            and self._environment.get("CODEX_MISSION_GOAL_SHA256") == identity.sha256
         )
 
     def _run(
@@ -387,7 +388,12 @@ def _repository_from_remote(value: str) -> str | None:
 def main() -> None:
     platform_root = Path(__file__).resolve().parents[2]
     settings = LoopEngineeringSettings.load(platform_root)
-    environment = settings.canonical_environment()
+    environment = inject_mission_goal_environment(
+        platform_root=platform_root,
+        product_root=settings.workspace_path,
+        repository=settings.engine.repository,
+        environment=settings.canonical_environment(),
+    )
     print(
         EnvironmentCapabilityPreflight(
             settings.engine,

--- a/tests/loop_engineering/test_mission_goal.py
+++ b/tests/loop_engineering/test_mission_goal.py
@@ -1,0 +1,131 @@
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from loop_engineering.mission_goal import inject_mission_goal_environment
+from loop_engineering.preflight import CommandResult, EnvironmentCapabilityPreflight
+
+from .conftest import config
+
+
+class UnusedRunner:
+    def run(
+        self,
+        command: Sequence[str],
+        environment: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        del command, environment
+        return CommandResult(True)
+
+
+def _write_goal(path: Path, *, version: str = "5", generation: str = "1") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"# Mission\n\nversion: {version}\ngeneration: {generation}\n",
+        encoding="utf-8",
+    )
+
+
+def test_host_registry_is_used_when_product_has_no_legacy_goal(tmp_path: Path) -> None:
+    platform_root = tmp_path / "platform"
+    product_root = tmp_path / "product"
+    product_root.mkdir()
+    registry = platform_root / "config" / "goals" / "ktan514__ai-liver-yura.md"
+    _write_goal(registry)
+
+    values = inject_mission_goal_environment(
+        platform_root=platform_root,
+        product_root=product_root,
+        repository="ktan514/ai-liver-yura",
+        environment={},
+    )
+
+    assert values["LOOP_MISSION_GOAL_PATH"] == str(registry.resolve())
+    assert values["CODEX_MISSION_GOAL_VERSION"] == "5"
+    assert values["CODEX_MISSION_GOAL_GENERATION"] == "1"
+    assert len(values["CODEX_MISSION_GOAL_SHA256"]) == 64
+
+
+def test_explicit_missing_goal_fails_closed_without_registry_fallback(tmp_path: Path) -> None:
+    platform_root = tmp_path / "platform"
+    product_root = tmp_path / "product"
+    product_root.mkdir()
+    registry = platform_root / "config" / "goals" / "ktan514__ai-liver-yura.md"
+    _write_goal(registry)
+    missing = tmp_path / "missing-goal.md"
+
+    values = inject_mission_goal_environment(
+        platform_root=platform_root,
+        product_root=product_root,
+        repository="ktan514/ai-liver-yura",
+        environment={"LOOP_MISSION_GOAL_PATH": str(missing)},
+    )
+
+    assert values["LOOP_MISSION_GOAL_PATH"] == str(missing.resolve())
+    assert "CODEX_MISSION_GOAL_VERSION" not in values
+    assert "CODEX_MISSION_GOAL_GENERATION" not in values
+    assert "CODEX_MISSION_GOAL_SHA256" not in values
+
+
+def test_legacy_product_goal_remains_compatible_without_host_registry(tmp_path: Path) -> None:
+    platform_root = tmp_path / "platform"
+    product_root = tmp_path / "product"
+    legacy = product_root / "docs" / "operations" / "loop_mission_goal.md"
+    _write_goal(legacy, version="4", generation="9")
+
+    values = inject_mission_goal_environment(
+        platform_root=platform_root,
+        product_root=product_root,
+        repository="owner/product",
+        environment={},
+    )
+
+    assert values["LOOP_MISSION_GOAL_PATH"] == str(legacy.resolve())
+    assert values["CODEX_MISSION_GOAL_VERSION"] == "4"
+    assert values["CODEX_MISSION_GOAL_GENERATION"] == "9"
+
+
+def test_preflight_accepts_injected_host_goal_without_product_goal(tmp_path: Path) -> None:
+    platform_root = tmp_path / "platform"
+    product_root = tmp_path / "product"
+    product_root.mkdir()
+    registry = platform_root / "config" / "goals" / "ktan514__ai-liver-yura.md"
+    _write_goal(registry)
+    values = inject_mission_goal_environment(
+        platform_root=platform_root,
+        product_root=product_root,
+        repository="ktan514/ai-liver-yura",
+        environment={},
+    )
+
+    preflight = EnvironmentCapabilityPreflight(
+        config(),
+        UnusedRunner(),
+        values,
+        project_root=product_root,
+    )
+
+    assert preflight._mission_goal_matches()
+
+
+def test_preflight_rejects_stale_goal_identity(tmp_path: Path) -> None:
+    platform_root = tmp_path / "platform"
+    product_root = tmp_path / "product"
+    product_root.mkdir()
+    registry = platform_root / "config" / "goals" / "ktan514__ai-liver-yura.md"
+    _write_goal(registry)
+    values = inject_mission_goal_environment(
+        platform_root=platform_root,
+        product_root=product_root,
+        repository="ktan514/ai-liver-yura",
+        environment={},
+    )
+    values["CODEX_MISSION_GOAL_SHA256"] = "stale"
+
+    preflight = EnvironmentCapabilityPreflight(
+        config(),
+        UnusedRunner(),
+        values,
+        project_root=product_root,
+    )
+
+    assert not preflight._mission_goal_matches()

--- a/tests/loop_engineering/test_mission_goal.py
+++ b/tests/loop_engineering/test_mission_goal.py
@@ -45,6 +45,48 @@ def test_host_registry_is_used_when_product_has_no_legacy_goal(tmp_path: Path) -
     assert len(values["CODEX_MISSION_GOAL_SHA256"]) == 64
 
 
+def test_host_registry_wins_over_existing_legacy_product_goal(tmp_path: Path) -> None:
+    platform_root = tmp_path / "platform"
+    product_root = tmp_path / "product"
+    legacy = product_root / "docs" / "operations" / "loop_mission_goal.md"
+    registry = platform_root / "config" / "goals" / "ktan514__ai-liver-yura.md"
+    _write_goal(legacy, version="4", generation="8")
+    _write_goal(registry, version="5", generation="1")
+
+    values = inject_mission_goal_environment(
+        platform_root=platform_root,
+        product_root=product_root,
+        repository="ktan514/ai-liver-yura",
+        environment={},
+    )
+
+    assert values["LOOP_MISSION_GOAL_PATH"] == str(registry.resolve())
+    assert values["CODEX_MISSION_GOAL_VERSION"] == "5"
+    assert values["CODEX_MISSION_GOAL_GENERATION"] == "1"
+
+
+def test_explicit_host_goal_wins_over_registry_and_legacy_goal(tmp_path: Path) -> None:
+    platform_root = tmp_path / "platform"
+    product_root = tmp_path / "product"
+    legacy = product_root / "docs" / "operations" / "loop_mission_goal.md"
+    registry = platform_root / "config" / "goals" / "ktan514__ai-liver-yura.md"
+    explicit = tmp_path / "explicit-goal.md"
+    _write_goal(legacy, version="4", generation="8")
+    _write_goal(registry, version="5", generation="1")
+    _write_goal(explicit, version="6", generation="2")
+
+    values = inject_mission_goal_environment(
+        platform_root=platform_root,
+        product_root=product_root,
+        repository="ktan514/ai-liver-yura",
+        environment={"LOOP_MISSION_GOAL_PATH": str(explicit)},
+    )
+
+    assert values["LOOP_MISSION_GOAL_PATH"] == str(explicit.resolve())
+    assert values["CODEX_MISSION_GOAL_VERSION"] == "6"
+    assert values["CODEX_MISSION_GOAL_GENERATION"] == "2"
+
+
 def test_explicit_missing_goal_fails_closed_without_registry_fallback(tmp_path: Path) -> None:
     platform_root = tmp_path / "platform"
     product_root = tmp_path / "product"


### PR DESCRIPTION
## 概要

#27の実運転で発生した `PREFLIGHT_BLOCKED:MISSION_GOAL` を修正します。

standalone移管後、Product WorkspaceからLoop専用 `docs/operations/loop_mission_goal.md` が除去された一方、Preflightが旧固定pathを必須としていたため、Host側Mission Goal registryを追加します。

## 設計

- GitHub live: 現在状態の正本
- Host Mission Goal: Mission目的・安全境界の正本
- PostgreSQL: Operational State（#44で管理基盤化）
- Product Workspace: Product source / tests / canonical design

Goal解決順序:
1. `LOOP_MISSION_GOAL_PATH`
2. `config/goals/<owner>__<repository>.md`
3. 旧Product内path（互換fallbackのみ）

## 実装

- `mission_goal.py`でGoal source解決・version/generation/SHA-256 identity注入を一元化
- CLI起動時にHost Goalを注入
- Preflightは注入された同一Goal identityを検証
- 旧launcherも同一resolverへ統一
- Yura用Host Goalを `config/goals/ktan514__ai-liver-yura.md` に配置
- Product内旧Goalが無いケース、明示path失敗時のfail-closed、旧path互換を回帰試験

## 非対象

- `ai-liver-yura` Repositoryの変更
- PostgreSQL Operational Store必須化（#44）
- #339 Product実装

## 検証

GitHub Actionsのexact-head deterministic CIで確認する。