### PR TITLE
feat: Docker PostgreSQLをOperational Store管理基盤として有効化する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ OPENAI_API_KEY=
 
 # GitHub
 GH_TOKEN=
+
+# PostgreSQL Operational Store
+LOOP_POSTGRES_DSN=

--- a/config/loop-engineering.example.ini
+++ b/config/loop-engineering.example.ini
@@ -42,6 +42,10 @@ github_token_env = GH_TOKEN
 
 [operational_store]
 dsn_env = LOOP_POSTGRES_DSN
+required = false
+driver = host
+docker_container =
+migration_policy = required
 
 [runtime]
 trusted_reviewer_socket_env = LOOP_TRUSTED_REVIEWER_SOCKET

--- a/docs/architecture/v2/loop_operational_store.md
+++ b/docs/architecture/v2/loop_operational_store.md
@@ -1,30 +1,188 @@
-# Loop運用記憶
+# Loop運用記憶 / PostgreSQL管理基盤
 
-## 正本性と可用性
+管理Issue: #44
+関連: #27 / #3 / #31 / source `ktan514/ai-liver-yura#470`
+状態: canonical architecture
 
-PostgreSQLはLoop Engineの運用記憶であり、GitHub Issue/PR/Project #7の状態、CI、レビュー対象の現在HEAD、Repository正本設計の正本ではない。GitHubまたはRepositoryの現在状態と矛盾した場合は現在状態を優先し、古い運用行は再調整するか古い状態として扱う。
+## 1. 目的
 
-運用記憶は、安全な観測とGitHub上に永続化されるCheckpoint経路では任意である。利用できない場合、排他的な永続予約が必要な処理は`DB_UNAVAILABLE`/`YIELD_EXTERNAL`、または文書化されたGitHubだけの縮退経路を返す。ローカル記録がないことだけを理由に「変更は発生しなかった」と推定してはならない。
+PostgreSQLをLoop Engineeringの運用状態（Operational State）の永続正本として使用する。
 
-## 表と識別情報
+GitHub liveのIssue、PR、Project、branch、厳密HEAD、CI、reviewは引き続き現在状態の正本であり、PostgreSQLへ複製した過去値で上書きしない。Mission GoalとProject Registrationのbootstrap trust anchorもDBだけへ依存させない。
 
-| 表 | 一意識別情報 | 目的 |
-| --- | --- | --- |
-| `review_jobs` | レビュー対象と試行キー | 予約、提供元の実行状態、重複抑止 |
-| `review_results` | レビュー試行キー | 秘密情報を除外した最終結果と指摘管理情報 |
-| `api_usage` | 提供元呼出identity | 上限付きのモデル・token・所要時間・費用証拠だけを保持 |
-| `loop_events` | 事象identity | 遷移、Checkpoint、健全性、復旧証拠 |
+```text
+GitHub live
+→ Productの現在状態
 
-どの表にも認証情報、認可情報、提供元の生応答・生エラー、指示文、差分、要求本文、制限のないIssue/PR本文を保存しない。利用量項目は値がない場合にnullを許可し、不在を0で表現しない。
+Host Mission Goal / Project Registration
+→ 実行対象と安全境界
 
-## 取引と復旧契約
+PostgreSQL Operational Store
+→ Run / transition / checkpoint / blocker / lease / idempotency等の運用状態
+```
 
-移行はAlembicが所有し、通常観測とは分離して実行する。すべての書込みは値の上限を検証し、取引内で処理し、一意識別情報を持つ。処理中予約は提供元処理より先に永続化し、提供元結果は最終結果より先に永続化する。異常終了後の不確定記録はGitHub/仲介器の現在証拠と再調整し、ローカル結果がないという理由だけで再送しない。
+## 2. ローカル実運転の接続方式
 
-保持期限による削除は、重複防止に必要な最低限の識別・監査証拠を残したうえで古い運用行だけを削除する。GitHubの正本情報を削除しない。PostgreSQLの助言ロック（advisory lock）は実行排他を補助するだけであり、Missionの正本でも複数ホスト同時能動運転の仕組みでもない。
+ローカル実運転ではDocker上のPostgreSQLを標準とする。
 
-## データベース失敗の正規化
+macOSホストへ`psql`や`pg_isready`を別途導入することを要求しない。Loop Engineeringは既に必須CapabilityであるDocker CLIを通して、設定されたPostgreSQLコンテナ内の`psql` / `pg_isready`を実行する。
 
-運用記憶は任意機能なので、データベース接続層の失敗でLoop Engineプロセスを終了させない。接続生成、cursor取得、文実行、commit、rollback、closeはすべて接続層側の処理である。これらDB-API境界で発生した失敗は`DB_UNAVAILABLE`へ正規化する。後片付けは可能な範囲で行い、後片付けの失敗で型付き縮退結果を置き換えない。
+接続方式は設定で選択できる。
 
-管理情報の直列化はデータベース効果より前に行う。安全に直列化できない値は`INVALID`とし、データベース接続を開始しない。任意のPostgreSQL記憶が利用できないという理由だけで、成功したGitHub/Checkpoint遷移を失敗へ変換しない。
+```ini
+[operational_store]
+dsn_env = LOOP_POSTGRES_DSN
+required = true
+driver = docker
+docker_container = <PostgreSQL container name>
+migration_policy = required
+```
+
+`dsn_env`には秘密値ではなく環境変数名だけを書く。DSN実値はGit管理外`.env`またはHost secret sourceから供給する。
+
+`driver`:
+- `docker`: Dockerコンテナ内のPostgreSQL clientを使用する。
+- `host`: 互換用途としてホスト上の`psql` / `pg_isready`を使用する。
+
+Yuraのローカル実運転では`driver = docker`、`required = true`を使用する。
+
+## 3. 秘密情報の受け渡し
+
+DSNから接続に必要な値を解析しても、passwordをcommand lineへ直接埋め込まない。
+
+Docker方式ではHost subprocess環境へ`PGUSER` / `PGPASSWORD` / `PGDATABASE`等を限定的に設定し、`docker exec -e PGPASSWORD`のように環境変数名だけをargvへ渡す。password実値を通常log、Issue、PR、Checkpoint、command表示へ出さない。
+
+認証情報、token、API key、request header、providerの生応答・生エラー、無制限のIssue/PR本文はOperational Storeへ保存しない。
+
+## 4. required / optional policy
+
+`required = true`の場合、次はbootstrap blockerである。
+
+- Docker/選択driverを利用できない
+- PostgreSQL clientを利用できない
+- PostgreSQL serverへ到達できない
+- 対象databaseへ接続できない
+- 必須migrationが未適用
+
+この場合、Product実装CodexやGit mutationを開始しない。
+
+`required = false`の場合は従来どおりWork単位の縮退能力として扱える。ただし排他的な永続予約やDB-backed idempotencyが必須の遷移は個別に`DB_UNAVAILABLE` / `YIELD_EXTERNAL`へ落とす。
+
+DBが使えないことだけを理由に「外部変更は発生しなかった」と推定しない。
+
+## 5. Migration Authority
+
+Migrationの正本はRepository内のversioned SQLとする。
+
+```text
+src/loop_engineering/migrations/*.sql
+```
+
+Alembicを必須にしない。現在の実装に`alembic.ini`が存在しない状態と事前確認契約を一致させる。
+
+Migration runnerは最初に管理表を用意する。
+
+```text
+loop_schema_migrations
+- filename primary key
+- applied_at
+```
+
+その後、ファイル名順で未適用SQLだけを実行し、成功したmigration名を同一運用単位で記録する。既に記録済みのmigrationを再実行しない。
+
+事前確認はRepositoryに存在する全migration filenameが`loop_schema_migrations`に存在する場合だけ`postgresql_migration = true`とする。
+
+Migrationは通常の観測とは分離した明示操作で行い、事前確認がschemaを書き換えてはならない。
+
+## 6. 管理対象
+
+既存表:
+
+| 表 | 目的 |
+| --- | --- |
+| `review_jobs` | review試行予約と重複抑止 |
+| `review_results` | secret-safeなreview結果 |
+| `api_usage` | 上限付き利用量・費用証拠 |
+| `loop_events` | Loop事象・監査証拠 |
+
+管理基盤として追加する表:
+
+| 表 | 目的 |
+| --- | --- |
+| `loop_runs` | 1回のHost run identityと開始・終了状態 |
+| `loop_transitions` | run内の遷移結果と対象identity |
+| `loop_checkpoints` | durable checkpointの最小metadata |
+| `loop_blockers` | Runtime blockerと解消状態 |
+| `loop_leases` | execution lease / 排他identity |
+| `loop_dispatches` | Codex/review等のdispatch重複抑止 |
+| `loop_external_waits` | review/CI/Human等の待機identity |
+
+ProductのIssue/PR本文やcanonical design本文をDBへ丸ごとmirrorしない。必要な場合はstable identity、revision、digest、状態値、secret-safe metadataだけを保存する。
+
+## 7. restart / reconcile
+
+再起動時にDBだけからcurrent Workを決めない。
+
+```text
+Operational State readback
++ fresh GitHub live state
++ Host Mission Goal / Project Registration
+→ RECONCILE
+→ Resume Gate
+```
+
+DBは「前回どこまでeffectを要求・確認したか」「重複送信してよいか」「blocker/leaseが残っているか」を提供する。
+
+GitHub liveとDBが不一致なら、現在状態はGitHubを優先し、不一致自体をtyped conflict/evidenceとして記録する。
+
+## 8. idempotency / transaction
+
+すべての永続効果は安定したidentityを持つ。
+
+例:
+- run: `run_id`
+- transition: `run_id + sequence`
+- dispatch: `kind + target exact identity + attempt`
+- review: exact HEAD + review attempt
+- lease: scope + subject identity
+
+同じidentityの再挿入は二重効果を起こさず、既存状態を読み戻せるようにする。
+
+途中失敗で「成功した」と扱わない。書込み失敗は`DB_UNAVAILABLE`等の型付き結果へ正規化する。
+
+## 9. Preflight capability
+
+事前確認は最低限次を分離して表示する。
+
+- `docker`
+- `postgresql_client`
+- `postgresql_server`
+- `postgresql_database`
+- `postgresql_migration`
+
+Docker方式では`postgresql_client`は対象コンテナ内の`psql`利用可否を意味する。
+
+`required = true`ではPostgreSQL関連項目を`blocking_for_loop_bootstrap`へ含める。`required = false`では`work_scoped_unavailable`へ含める。
+
+## 10. 実機検証
+
+Yura Product Workspaceを対象に次を確認する。
+
+1. Hostへ`psql`を導入していない状態でもDocker方式のclient probeがPASSする。
+2. Docker PostgreSQLが起動していればserver/database probeがPASSする。
+3. migration適用前は`postgresql_migration = false`になる。
+4. 明示migration後に`postgresql_migration = true`になる。
+5. `required = true`でDB停止時はCodex開始前にbootstrapをBLOCKEDにする。
+6. DB復旧後、fresh GitHub stateと再調整して再開できる。
+7. DSN/passwordが通常logへ出ない。
+
+## 11. Hard invariants
+
+- PostgreSQL Operational State != GitHub current-state Authority
+- Mission Goalの正本をDBだけへ移さない
+- Product Workspaceへ管理DB credentialを保存しない
+- passwordをcommand argvへ埋め込まない
+- Preflightはmigrationを自動適用しない
+- required DB不成立時にProduct mutationへ進まない
+- migrationの正本をversioned SQLへ一意化する
+- restartはDB readbackだけでなくfresh GitHub observationを必ず行う

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = []
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+loop_engineering = ["migrations/*.sql"]
+
 [tool.pytest.ini_options]
 addopts = "-q"
 pythonpath = ["src"]

--- a/src/loop_engineering/__main__.py
+++ b/src/loop_engineering/__main__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from .config import LoopEngineeringSettings
 from .host_runtime import HostTransitionResult, HostTransitionStatus
 from .mission_goal import inject_mission_goal_environment
+from .operational_config import inject_operational_store_environment
 from .runtime_console import RuntimeConsole, VisibleSubprocessLocalRunner
 
 _CI_RECHECK_INITIAL_SECONDS = 60.0
@@ -22,6 +23,16 @@ def main() -> int:
         "--validate-installation",
         action="store_true",
         help="外部システムを観測・変更せずに制御系パッケージの導入状態を確認する。",
+    )
+    parser.add_argument(
+        "--preflight",
+        action="store_true",
+        help="CodexやGit mutationを開始せず、現在のHost能力だけを事前確認する。",
+    )
+    parser.add_argument(
+        "--migrate-operational-store",
+        action="store_true",
+        help="設定されたPostgreSQLへ未適用のversioned SQL migrationを明示適用する。",
     )
     parser.add_argument(
         "--config",
@@ -45,8 +56,6 @@ def main() -> int:
         print("LOOP_ENGINE_INSTALLATION=PASS")
         return 0
 
-    from .host_entrypoint import run_actual_host_transition
-
     platform_root = Path(__file__).resolve().parents[2]
     selected_config = Path(arguments.config) if arguments.config else None
     try:
@@ -54,6 +63,10 @@ def main() -> int:
             platform_root,
             os.environ,
             config_path=selected_config,
+        )
+        environment = inject_operational_store_environment(
+            settings.config_path,
+            settings.runtime_environment(os.environ),
         )
     except ValueError as error:
         print(f"CONFIGURATION_INVALID: {error}")
@@ -64,8 +77,43 @@ def main() -> int:
         platform_root=platform_root,
         product_root=workspace_root,
         repository=settings.engine.repository,
-        environment=settings.runtime_environment(os.environ),
+        environment=environment,
     )
+
+    if arguments.migrate_operational_store:
+        from .postgres_runtime import PostgreSQLCommandAdapter
+        from .preflight import SubprocessCommandRunner
+
+        result = PostgreSQLCommandAdapter(
+            SubprocessCommandRunner(),
+            environment,
+        ).apply_migrations()
+        applied = ",".join(result.applied) if result.applied else "なし"
+        print(
+            f"OPERATIONAL_STORE_MIGRATION={'PASS' if result.succeeded else 'FAIL'} "
+            f"detail={result.detail} applied={applied}"
+        )
+        return 0 if result.succeeded else 3
+
+    if arguments.preflight:
+        from .preflight import (
+            EnvironmentCapabilityPreflight,
+            PreflightStatus,
+            SubprocessCommandRunner,
+        )
+
+        result = EnvironmentCapabilityPreflight(
+            settings.engine,
+            SubprocessCommandRunner(),
+            environment,
+            project_root=workspace_root,
+        ).run()
+        print(f"MISSION_GOAL_PATH = {environment.get('LOOP_MISSION_GOAL_PATH', '')}")
+        print(result.as_json())
+        return 3 if result.status is PreflightStatus.BLOCKED else 0
+
+    from .host_entrypoint import run_actual_host_transition
+
     console = RuntimeConsole(platform_root, verbose=arguments.verbose)
     runner = VisibleSubprocessLocalRunner(console)
     mode = "once" if arguments.once else "continuous"

--- a/src/loop_engineering/__main__.py
+++ b/src/loop_engineering/__main__.py
@@ -84,16 +84,17 @@ def main() -> int:
         from .postgres_runtime import PostgreSQLCommandAdapter
         from .preflight import SubprocessCommandRunner
 
-        result = PostgreSQLCommandAdapter(
+        migration_result = PostgreSQLCommandAdapter(
             SubprocessCommandRunner(),
             environment,
         ).apply_migrations()
-        applied = ",".join(result.applied) if result.applied else "なし"
+        applied = ",".join(migration_result.applied) if migration_result.applied else "なし"
         print(
-            f"OPERATIONAL_STORE_MIGRATION={'PASS' if result.succeeded else 'FAIL'} "
-            f"detail={result.detail} applied={applied}"
+            "OPERATIONAL_STORE_MIGRATION="
+            f"{'PASS' if migration_result.succeeded else 'FAIL'} "
+            f"detail={migration_result.detail} applied={applied}"
         )
-        return 0 if result.succeeded else 3
+        return 0 if migration_result.succeeded else 3
 
     if arguments.preflight:
         from .preflight import (
@@ -102,15 +103,15 @@ def main() -> int:
             SubprocessCommandRunner,
         )
 
-        result = EnvironmentCapabilityPreflight(
+        preflight_result = EnvironmentCapabilityPreflight(
             settings.engine,
             SubprocessCommandRunner(),
             environment,
             project_root=workspace_root,
         ).run()
         print(f"MISSION_GOAL_PATH = {environment.get('LOOP_MISSION_GOAL_PATH', '')}")
-        print(result.as_json())
-        return 3 if result.status is PreflightStatus.BLOCKED else 0
+        print(preflight_result.as_json())
+        return 3 if preflight_result.status is PreflightStatus.BLOCKED else 0
 
     from .host_entrypoint import run_actual_host_transition
 
@@ -133,7 +134,7 @@ def main() -> int:
         while True:
             transition_number += 1
             console.event(f"遷移 {transition_number}: 開始")
-            result = run_actual_host_transition(
+            transition_result = run_actual_host_transition(
                 root=workspace_root,
                 environment=environment,
                 local_runner=runner,
@@ -141,19 +142,19 @@ def main() -> int:
             )
             console.event(
                 f"遷移 {transition_number}: "
-                f"{result.status.value} 詳細={result.detail}"
+                f"{transition_result.status.value} 詳細={transition_result.detail}"
             )
 
             if arguments.once:
-                print(result.as_json())
-                return _exit_code(result)
+                print(transition_result.as_json())
+                return _exit_code(transition_result)
 
-            if result.status is HostTransitionStatus.COMPLETED:
+            if transition_result.status is HostTransitionStatus.COMPLETED:
                 completed_key = (
-                    result.detail,
-                    result.work_issue,
-                    result.pr_number,
-                    result.head_sha,
+                    transition_result.detail,
+                    transition_result.work_issue,
+                    transition_result.pr_number,
+                    transition_result.head_sha,
                 )
                 if completed_key == previous_completed:
                     identical_completed += 1
@@ -164,9 +165,9 @@ def main() -> int:
                     blocked = HostTransitionResult(
                         HostTransitionStatus.INTERVENTION_REQUIRED,
                         "NO_PROGRESS_GUARD",
-                        result.work_issue,
-                        result.pr_number,
-                        result.head_sha,
+                        transition_result.work_issue,
+                        transition_result.pr_number,
+                        transition_result.head_sha,
                     )
                     console.event("進捗停止検知: 同一の完了遷移が繰り返されました")
                     print(blocked.as_json())
@@ -179,8 +180,8 @@ def main() -> int:
             identical_completed = 0
 
             if (
-                result.status is HostTransitionStatus.YIELD_EXTERNAL
-                and result.detail == "CI_PENDING"
+                transition_result.status is HostTransitionStatus.YIELD_EXTERNAL
+                and transition_result.detail == "CI_PENDING"
             ):
                 console.event(
                     f"CI待機: {int(ci_wait_seconds)}秒後に自動再開します"
@@ -192,8 +193,8 @@ def main() -> int:
                 )
                 continue
 
-            print(result.as_json())
-            return _exit_code(result)
+            print(transition_result.as_json())
+            return _exit_code(transition_result)
     except KeyboardInterrupt:
         console.event("操作者の要求により停止します")
         return 130

--- a/src/loop_engineering/migrations/0002_management_state.sql
+++ b/src/loop_engineering/migrations/0002_management_state.sql
@@ -1,0 +1,80 @@
+CREATE TABLE IF NOT EXISTS loop_runs (
+    identity TEXT PRIMARY KEY,
+    project_key TEXT NOT NULL,
+    repository TEXT NOT NULL,
+    status TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS loop_transitions (
+    identity TEXT PRIMARY KEY,
+    run_identity TEXT NOT NULL,
+    sequence_number INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    detail TEXT NOT NULL,
+    work_issue BIGINT,
+    pr_number BIGINT,
+    head_sha TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (run_identity, sequence_number)
+);
+
+CREATE TABLE IF NOT EXISTS loop_checkpoints (
+    identity TEXT PRIMARY KEY,
+    project_key TEXT NOT NULL,
+    work_issue BIGINT,
+    source_revision TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS loop_blockers (
+    identity TEXT PRIMARY KEY,
+    scope TEXT NOT NULL,
+    subject_identity TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    reason_code TEXT NOT NULL,
+    status TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS loop_leases (
+    identity TEXT PRIMARY KEY,
+    scope TEXT NOT NULL,
+    subject_identity TEXT NOT NULL,
+    holder_identity TEXT NOT NULL,
+    status TEXT NOT NULL,
+    acquired_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    released_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS loop_dispatches (
+    identity TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    target_identity TEXT NOT NULL,
+    status TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS loop_external_waits (
+    identity TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    target_identity TEXT NOT NULL,
+    status TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS loop_transitions_run_index
+    ON loop_transitions (run_identity, sequence_number);
+CREATE INDEX IF NOT EXISTS loop_blockers_subject_index
+    ON loop_blockers (scope, subject_identity, status);
+CREATE INDEX IF NOT EXISTS loop_leases_subject_index
+    ON loop_leases (scope, subject_identity, status);

--- a/src/loop_engineering/operational_config.py
+++ b/src/loop_engineering/operational_config.py
@@ -1,0 +1,62 @@
+"""PostgreSQL Operational Storeの非秘密Host設定。"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from configparser import ConfigParser
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalStoreSettings:
+    required: bool = False
+    driver: str = "host"
+    docker_container: str | None = None
+    migration_policy: str = "required"
+
+    def __post_init__(self) -> None:
+        if self.driver not in {"host", "docker"}:
+            raise ValueError("operational_store.driverはhostまたはdockerを指定してください")
+        if self.driver == "docker" and not self.docker_container:
+            raise ValueError("docker方式にはoperational_store.docker_containerが必要です")
+        if self.migration_policy not in {"required", "ignore"}:
+            raise ValueError(
+                "operational_store.migration_policyはrequiredまたはignoreを指定してください"
+            )
+
+
+def load_operational_store_settings(config_path: Path) -> OperationalStoreSettings:
+    parser = ConfigParser(interpolation=None)
+    try:
+        with config_path.open("r", encoding="utf-8") as stream:
+            parser.read_file(stream)
+    except (OSError, UnicodeError) as error:
+        raise ValueError("設定ファイルを読み取れません") from error
+
+    if not parser.has_section("operational_store"):
+        return OperationalStoreSettings()
+    section = parser["operational_store"]
+    container = section.get("docker_container", "").strip() or None
+    return OperationalStoreSettings(
+        required=section.getboolean("required", fallback=False),
+        driver=section.get("driver", "host").strip() or "host",
+        docker_container=container,
+        migration_policy=section.get("migration_policy", "required").strip() or "required",
+    )
+
+
+def inject_operational_store_environment(
+    config_path: Path,
+    environment: Mapping[str, str],
+) -> dict[str, str]:
+    settings = load_operational_store_settings(config_path)
+    values = dict(environment)
+    values["LOOP_OPERATIONAL_STORE_REQUIRED"] = "true" if settings.required else "false"
+    values["LOOP_POSTGRES_DRIVER"] = settings.driver
+    values["LOOP_POSTGRES_MIGRATION_POLICY"] = settings.migration_policy
+    if settings.docker_container is None:
+        values.pop("LOOP_POSTGRES_CONTAINER", None)
+    else:
+        values["LOOP_POSTGRES_CONTAINER"] = settings.docker_container
+    return values

--- a/src/loop_engineering/postgres_runtime.py
+++ b/src/loop_engineering/postgres_runtime.py
@@ -71,7 +71,7 @@ class PostgreSQLCommandAdapter:
             return PostgreSQLCapabilities(False, False, False, False)
 
         client = self._run_client(("psql", "--version"), parsed).succeeded
-        server = client and self._run_client(("pg_isready", "-q"), parsed).succeeded
+        server = client and self._run_client(("pg_isready",), parsed).succeeded
         database = server and self._run_client(
             ("psql", "-Atqc", "SELECT 1"), parsed
         ).succeeded
@@ -88,7 +88,7 @@ class PostgreSQLCommandAdapter:
             return MigrationApplyResult(False, (), "POSTGRES_CONTAINER_UNSET")
         if not self._run_client(("psql", "--version"), parsed).succeeded:
             return MigrationApplyResult(False, (), "POSTGRES_CLIENT_UNAVAILABLE")
-        if not self._run_client(("pg_isready", "-q"), parsed).succeeded:
+        if not self._run_client(("pg_isready",), parsed).succeeded:
             return MigrationApplyResult(False, (), "POSTGRES_SERVER_UNAVAILABLE")
         if not self._run_client(("psql", "-Atqc", "SELECT 1"), parsed).succeeded:
             return MigrationApplyResult(False, (), "POSTGRES_DATABASE_UNAVAILABLE")

--- a/src/loop_engineering/postgres_runtime.py
+++ b/src/loop_engineering/postgres_runtime.py
@@ -57,7 +57,10 @@ class PostgreSQLCommandAdapter:
         self._environment = environment
         self._driver = environment.get("LOOP_POSTGRES_DRIVER", "host").strip() or "host"
         self._container = environment.get("LOOP_POSTGRES_CONTAINER", "").strip()
-        self._dsn = environment.get("LOOP_POSTGRES_DSN", "").strip()
+        self._dsn = (
+            environment.get("LOOP_POSTGRES_DSN", "").strip()
+            or environment.get("LOOP_DATABASE_URL", "").strip()
+        )
         self._migration_dir = migration_dir or Path(__file__).with_name("migrations")
 
     def probe(self) -> PostgreSQLCapabilities:

--- a/src/loop_engineering/postgres_runtime.py
+++ b/src/loop_engineering/postgres_runtime.py
@@ -1,0 +1,215 @@
+"""Dockerまたはホスト経由でPostgreSQL管理基盤を検査・移行する。"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import urlsplit
+
+
+class CommandResultLike(Protocol):
+    @property
+    def succeeded(self) -> bool: ...
+
+    @property
+    def output(self) -> str: ...
+
+
+class PostgreSQLCommandRunner(Protocol):
+    def run(
+        self,
+        command: Sequence[str],
+        environment: Mapping[str, str] | None = None,
+    ) -> CommandResultLike: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PostgreSQLCapabilities:
+    client: bool
+    server: bool
+    database: bool
+    migration: bool
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationApplyResult:
+    succeeded: bool
+    applied: tuple[str, ...]
+    detail: str
+
+
+class PostgreSQLCommandAdapter:
+    """秘密値をargvへ埋め込まずPostgreSQLを操作する接続層。"""
+
+    _DRIVERS = frozenset({"docker", "host"})
+
+    def __init__(
+        self,
+        runner: PostgreSQLCommandRunner,
+        environment: Mapping[str, str],
+        *,
+        migration_dir: Path | None = None,
+    ) -> None:
+        self._runner = runner
+        self._environment = environment
+        self._driver = environment.get("LOOP_POSTGRES_DRIVER", "host").strip() or "host"
+        self._container = environment.get("LOOP_POSTGRES_CONTAINER", "").strip()
+        self._dsn = environment.get("LOOP_POSTGRES_DSN", "").strip()
+        self._migration_dir = migration_dir or Path(__file__).with_name("migrations")
+
+    def probe(self) -> PostgreSQLCapabilities:
+        parsed = self._parsed_dsn()
+        if parsed is None or self._driver not in self._DRIVERS:
+            return PostgreSQLCapabilities(False, False, False, False)
+        if self._driver == "docker" and not self._container:
+            return PostgreSQLCapabilities(False, False, False, False)
+
+        client = self._run_client(("psql", "--version"), parsed).succeeded
+        server = client and self._run_client(("pg_isready", "-q"), parsed).succeeded
+        database = server and self._run_client(
+            ("psql", "-Atqc", "SELECT 1"), parsed
+        ).succeeded
+        migration = database and self._migrations_current(parsed)
+        return PostgreSQLCapabilities(client, server, database, migration)
+
+    def apply_migrations(self) -> MigrationApplyResult:
+        parsed = self._parsed_dsn()
+        if parsed is None:
+            return MigrationApplyResult(False, (), "POSTGRES_DSN_INVALID")
+        if self._driver not in self._DRIVERS:
+            return MigrationApplyResult(False, (), "POSTGRES_DRIVER_INVALID")
+        if self._driver == "docker" and not self._container:
+            return MigrationApplyResult(False, (), "POSTGRES_CONTAINER_UNSET")
+        if not self._run_client(("psql", "--version"), parsed).succeeded:
+            return MigrationApplyResult(False, (), "POSTGRES_CLIENT_UNAVAILABLE")
+        if not self._run_client(("pg_isready", "-q"), parsed).succeeded:
+            return MigrationApplyResult(False, (), "POSTGRES_SERVER_UNAVAILABLE")
+        if not self._run_client(("psql", "-Atqc", "SELECT 1"), parsed).succeeded:
+            return MigrationApplyResult(False, (), "POSTGRES_DATABASE_UNAVAILABLE")
+
+        registry_sql = (
+            "CREATE TABLE IF NOT EXISTS loop_schema_migrations ("
+            "filename TEXT PRIMARY KEY, "
+            "applied_at TIMESTAMPTZ NOT NULL DEFAULT now()"
+            ");"
+        )
+        if not self._run_client(
+            ("psql", "-v", "ON_ERROR_STOP=1", "-q", "-c", registry_sql), parsed
+        ).succeeded:
+            return MigrationApplyResult(False, (), "MIGRATION_REGISTRY_UNAVAILABLE")
+
+        applied = self._applied_migrations(parsed)
+        if applied is None:
+            return MigrationApplyResult(False, (), "MIGRATION_STATE_UNAVAILABLE")
+
+        completed: list[str] = []
+        for path in self._migration_files():
+            if path.name in applied:
+                continue
+            try:
+                sql = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeError):
+                return MigrationApplyResult(False, tuple(completed), "MIGRATION_SOURCE_UNREADABLE")
+            filename = path.name.replace("'", "''")
+            transaction = (
+                "BEGIN;\n"
+                f"{sql}\n"
+                "INSERT INTO loop_schema_migrations (filename) "
+                f"VALUES ('{filename}') ON CONFLICT (filename) DO NOTHING;\n"
+                "COMMIT;"
+            )
+            result = self._run_client(
+                ("psql", "-v", "ON_ERROR_STOP=1", "-q", "-c", transaction), parsed
+            )
+            if not result.succeeded:
+                return MigrationApplyResult(False, tuple(completed), "MIGRATION_APPLY_FAILED")
+            completed.append(path.name)
+        return MigrationApplyResult(True, tuple(completed), "MIGRATION_CURRENT")
+
+    def _migrations_current(self, parsed: _ParsedDSN) -> bool:
+        expected = {path.name for path in self._migration_files()}
+        if not expected:
+            return False
+        applied = self._applied_migrations(parsed)
+        return applied is not None and expected.issubset(applied)
+
+    def _applied_migrations(self, parsed: _ParsedDSN) -> set[str] | None:
+        result = self._run_client(
+            (
+                "psql",
+                "-Atqc",
+                "SELECT filename FROM loop_schema_migrations ORDER BY filename",
+            ),
+            parsed,
+        )
+        if not result.succeeded:
+            return None
+        return {line.strip() for line in result.output.splitlines() if line.strip()}
+
+    def _migration_files(self) -> tuple[Path, ...]:
+        if not self._migration_dir.is_dir():
+            return ()
+        return tuple(sorted(self._migration_dir.glob("*.sql"), key=lambda path: path.name))
+
+    def _run_client(self, command: Sequence[str], parsed: _ParsedDSN) -> CommandResultLike:
+        environment = self._database_environment(parsed)
+        if self._driver == "docker":
+            docker_command = (
+                "docker",
+                "exec",
+                "-e",
+                "PGUSER",
+                "-e",
+                "PGPASSWORD",
+                "-e",
+                "PGDATABASE",
+                self._container,
+                *command,
+            )
+            return self._runner.run(docker_command, environment)
+        return self._runner.run(command, environment)
+
+    def _database_environment(self, parsed: _ParsedDSN) -> dict[str, str]:
+        names = ("PATH", "HOME", "DOCKER_HOST", "DOCKER_CONTEXT", "DOCKER_CONFIG")
+        values = {name: self._environment[name] for name in names if self._environment.get(name)}
+        values.setdefault("PATH", os.defpath)
+        values["PGUSER"] = parsed.username
+        values["PGPASSWORD"] = parsed.password
+        values["PGDATABASE"] = parsed.database
+        if self._driver == "host":
+            values["PGHOST"] = parsed.hostname
+            values["PGPORT"] = str(parsed.port)
+        return values
+
+    def _parsed_dsn(self) -> _ParsedDSN | None:
+        if not self._dsn:
+            return None
+        parsed = urlsplit(self._dsn)
+        if parsed.scheme not in {"postgres", "postgresql"} or not parsed.hostname:
+            return None
+        try:
+            port = parsed.port or 5432
+        except ValueError:
+            return None
+        database = parsed.path.lstrip("/")
+        if not database:
+            return None
+        return _ParsedDSN(
+            parsed.hostname,
+            port,
+            parsed.username or "",
+            parsed.password or "",
+            database,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _ParsedDSN:
+    hostname: str
+    port: int
+    username: str
+    password: str
+    database: str

--- a/src/loop_engineering/preflight.py
+++ b/src/loop_engineering/preflight.py
@@ -14,6 +14,8 @@ from urllib.parse import urlsplit
 
 from .config import LoopEngineConfig, LoopEngineeringSettings
 from .mission_goal import inject_mission_goal_environment, read_mission_goal_identity
+from .operational_config import inject_operational_store_environment
+from .postgres_runtime import PostgreSQLCommandAdapter
 
 
 class PreflightStatus(str, Enum):
@@ -132,7 +134,8 @@ class EnvironmentCapabilityPreflight:
         capability["project_venv"] = sys.prefix != sys.base_prefix
         capability["trusted_reviewer"] = self._reviewer_available()
         capability.update(self._postgresql_capabilities())
-        blocking_names = (
+
+        blocking_names: tuple[str, ...] = (
             "workspace_path",
             "workspace_git_root",
             "workspace_repository_match",
@@ -152,14 +155,27 @@ class EnvironmentCapabilityPreflight:
             "compileall",
             "codex_cli",
         )
-        scoped_names = (
-            "trusted_reviewer",
-            "docker",
+        scoped_names: tuple[str, ...] = ("trusted_reviewer",)
+        postgres_names = (
             "postgresql_client",
             "postgresql_server",
             "postgresql_database",
             "postgresql_migration",
         )
+        postgres_required = (
+            self._environment.get("LOOP_OPERATIONAL_STORE_REQUIRED", "false").strip().lower()
+            == "true"
+        )
+        postgres_driver = self._environment.get("LOOP_POSTGRES_DRIVER", "host").strip()
+        if postgres_required:
+            blocking_names += postgres_names
+            if postgres_driver == "docker":
+                blocking_names += ("docker",)
+        else:
+            scoped_names += postgres_names
+            if postgres_driver == "docker":
+                scoped_names += ("docker",)
+
         blocking = tuple(name.upper() for name in blocking_names if not capability[name])
         scoped = tuple(name.upper() for name in scoped_names if not capability[name])
         status = (
@@ -207,7 +223,6 @@ class EnvironmentCapabilityPreflight:
             "compileall": (sys.executable, "-m", "compileall", "--help"),
             "codex_cli": ("codex", "--version"),
             "docker": ("docker", "version"),
-            "postgresql_client": ("psql", "--version"),
         }
         capability = {
             name: self._run(name, command).succeeded for name, command in probes.items()
@@ -292,53 +307,18 @@ class EnvironmentCapabilityPreflight:
         return bool(socket_path and self._reviewer_probe.check(socket_path, 10.0))
 
     def _postgresql_capabilities(self) -> dict[str, bool]:
-        url = self._environment.get("LOOP_POSTGRES_DSN") or self._environment.get(
-            "LOOP_DATABASE_URL"
-        )
-        if not url:
-            return self._empty_database_capabilities()
-        parsed = urlsplit(url)
-        if parsed.scheme not in {"postgres", "postgresql"} or not parsed.hostname:
-            return self._empty_database_capabilities()
-        try:
-            port = parsed.port
-        except ValueError:
-            return self._empty_database_capabilities()
-        database_env = {
-            "PATH": self._environment.get("PATH", os.defpath),
-            "PGHOST": parsed.hostname,
-            "PGPORT": str(port or 5432),
-            "PGUSER": parsed.username or "",
-            "PGPASSWORD": parsed.password or "",
-            "PGDATABASE": parsed.path.lstrip("/"),
-        }
-        server = self._run("postgresql_server", ("pg_isready",), database_env).succeeded
-        database = server and self._run(
-            "postgresql_database",
-            ("psql", "-Atqc", "SELECT 1"),
-            database_env,
-        ).succeeded
-        migration = (
-            database
-            and (self._project_root / "alembic.ini").is_file()
-            and self._run(
-                "postgresql_migration",
-                (sys.executable, "-m", "alembic", "current"),
-                database_env,
-            ).succeeded
-        )
+        capabilities = PostgreSQLCommandAdapter(self._runner, self._environment).probe()
+        migration = capabilities.migration
+        if (
+            self._environment.get("LOOP_POSTGRES_MIGRATION_POLICY", "required").strip()
+            == "ignore"
+        ):
+            migration = capabilities.database
         return {
-            "postgresql_server": server,
-            "postgresql_database": database,
+            "postgresql_client": capabilities.client,
+            "postgresql_server": capabilities.server,
+            "postgresql_database": capabilities.database,
             "postgresql_migration": migration,
-        }
-
-    @staticmethod
-    def _empty_database_capabilities() -> dict[str, bool]:
-        return {
-            "postgresql_server": False,
-            "postgresql_database": False,
-            "postgresql_migration": False,
         }
 
     def _mission_goal_matches(self) -> bool:
@@ -388,11 +368,15 @@ def _repository_from_remote(value: str) -> str | None:
 def main() -> None:
     platform_root = Path(__file__).resolve().parents[2]
     settings = LoopEngineeringSettings.load(platform_root)
+    environment = inject_operational_store_environment(
+        settings.config_path,
+        settings.canonical_environment(),
+    )
     environment = inject_mission_goal_environment(
         platform_root=platform_root,
         product_root=settings.workspace_path,
         repository=settings.engine.repository,
-        environment=settings.canonical_environment(),
+        environment=environment,
     )
     print(
         EnvironmentCapabilityPreflight(

--- a/tests/loop_engineering/test_cli.py
+++ b/tests/loop_engineering/test_cli.py
@@ -31,6 +31,11 @@ def install_fake_settings(monkeypatch: MonkeyPatch) -> None:
         "load",
         classmethod(lambda cls, *args, **kwargs: FakeSettings()),
     )
+    monkeypatch.setattr(
+        cli,
+        "inject_operational_store_environment",
+        lambda config_path, environment: dict(environment),
+    )
 
 
 def test_cli_validates_installation_without_external_mutation() -> None:

--- a/tests/loop_engineering/test_operational_config.py
+++ b/tests/loop_engineering/test_operational_config.py
@@ -16,12 +16,12 @@ def test_docker_required_settings_are_injected_without_dsn_value(tmp_path: Path)
     config = tmp_path / "loop-engineering.ini"
     _write_config(
         config,
-        """[operational_store]\n"
+        "[operational_store]\n"
         "dsn_env = LOOP_POSTGRES_DSN\n"
         "required = true\n"
         "driver = docker\n"
         "docker_container = local-postgres\n"
-        "migration_policy = required\n""",
+        "migration_policy = required\n",
     )
 
     settings = load_operational_store_settings(config)

--- a/tests/loop_engineering/test_operational_config.py
+++ b/tests/loop_engineering/test_operational_config.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+
+from loop_engineering.operational_config import (
+    inject_operational_store_environment,
+    load_operational_store_settings,
+)
+
+
+def _write_config(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+
+
+def test_docker_required_settings_are_injected_without_dsn_value(tmp_path: Path) -> None:
+    config = tmp_path / "loop-engineering.ini"
+    _write_config(
+        config,
+        """[operational_store]\n"
+        "dsn_env = LOOP_POSTGRES_DSN\n"
+        "required = true\n"
+        "driver = docker\n"
+        "docker_container = local-postgres\n"
+        "migration_policy = required\n""",
+    )
+
+    settings = load_operational_store_settings(config)
+    values = inject_operational_store_environment(config, {"LOOP_POSTGRES_DSN": "secret-dsn"})
+
+    assert settings.required
+    assert settings.driver == "docker"
+    assert settings.docker_container == "local-postgres"
+    assert values["LOOP_OPERATIONAL_STORE_REQUIRED"] == "true"
+    assert values["LOOP_POSTGRES_DRIVER"] == "docker"
+    assert values["LOOP_POSTGRES_CONTAINER"] == "local-postgres"
+    assert values["LOOP_POSTGRES_DSN"] == "secret-dsn"
+
+
+def test_optional_host_is_backward_compatible_default(tmp_path: Path) -> None:
+    config = tmp_path / "loop-engineering.ini"
+    _write_config(config, "[operational_store]\ndsn_env = LOOP_POSTGRES_DSN\n")
+
+    settings = load_operational_store_settings(config)
+
+    assert not settings.required
+    assert settings.driver == "host"
+    assert settings.docker_container is None
+    assert settings.migration_policy == "required"
+
+
+def test_docker_driver_requires_explicit_container(tmp_path: Path) -> None:
+    config = tmp_path / "loop-engineering.ini"
+    _write_config(config, "[operational_store]\ndriver = docker\n")
+
+    with pytest.raises(ValueError, match="docker_container"):
+        load_operational_store_settings(config)
+
+
+def test_invalid_migration_policy_is_rejected(tmp_path: Path) -> None:
+    config = tmp_path / "loop-engineering.ini"
+    _write_config(
+        config,
+        "[operational_store]\nmigration_policy = auto-mutate\n",
+    )
+
+    with pytest.raises(ValueError, match="migration_policy"):
+        load_operational_store_settings(config)

--- a/tests/loop_engineering/test_postgres_preflight_policy.py
+++ b/tests/loop_engineering/test_postgres_preflight_policy.py
@@ -1,0 +1,116 @@
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from loop_engineering.preflight import (
+    CommandResult,
+    EnvironmentCapabilityPreflight,
+    PreflightStatus,
+)
+
+from .conftest import config
+
+
+class NoopRunner:
+    def run(
+        self,
+        command: Sequence[str],
+        environment: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        del command, environment
+        return CommandResult(True)
+
+
+class PolicyPreflight(EnvironmentCapabilityPreflight):
+    def __init__(self, environment: Mapping[str, str], *, postgres_ok: bool) -> None:
+        super().__init__(
+            config(),
+            NoopRunner(),
+            environment,
+            project_root=Path("."),
+        )
+        self._postgres_ok = postgres_ok
+
+    def _command_capabilities(self) -> dict[str, bool]:
+        return {
+            "github_cli": True,
+            "github_repo_read": True,
+            "github_project_read": True,
+            "python": True,
+            "pytest": True,
+            "ruff": True,
+            "mypy": True,
+            "compileall": True,
+            "codex_cli": True,
+            "docker": True,
+        }
+
+    def _workspace_capabilities(self) -> dict[str, bool]:
+        return {
+            "workspace_path": True,
+            "workspace_git_root": True,
+            "workspace_repository_match": True,
+            "workspace_head_readable": True,
+            "workspace_state_readable": True,
+        }
+
+    def _repository_write_allowed(self) -> bool:
+        return True
+
+    def _project_write_allowed(self) -> bool:
+        return True
+
+    def _mission_goal_matches(self) -> bool:
+        return True
+
+    def _reviewer_available(self) -> bool:
+        return True
+
+    def _postgresql_capabilities(self) -> dict[str, bool]:
+        return {
+            "postgresql_client": self._postgres_ok,
+            "postgresql_server": self._postgres_ok,
+            "postgresql_database": self._postgres_ok,
+            "postgresql_migration": self._postgres_ok,
+        }
+
+
+def test_required_postgres_failure_blocks_bootstrap() -> None:
+    result = PolicyPreflight(
+        {
+            "LOOP_OPERATIONAL_STORE_REQUIRED": "true",
+            "LOOP_POSTGRES_DRIVER": "docker",
+        },
+        postgres_ok=False,
+    ).run()
+
+    assert result.status is PreflightStatus.BLOCKED
+    assert "POSTGRESQL_CLIENT" in result.blocking_for_loop_bootstrap
+    assert "POSTGRESQL_MIGRATION" in result.blocking_for_loop_bootstrap
+    assert "POSTGRESQL_CLIENT" not in result.work_scoped_unavailable
+
+
+def test_optional_postgres_failure_is_degraded_only() -> None:
+    result = PolicyPreflight(
+        {
+            "LOOP_OPERATIONAL_STORE_REQUIRED": "false",
+            "LOOP_POSTGRES_DRIVER": "docker",
+        },
+        postgres_ok=False,
+    ).run()
+
+    assert result.status is PreflightStatus.DEGRADED
+    assert "POSTGRESQL_CLIENT" not in result.blocking_for_loop_bootstrap
+    assert "POSTGRESQL_CLIENT" in result.work_scoped_unavailable
+
+
+def test_required_postgres_passes_when_database_and_migration_are_current() -> None:
+    result = PolicyPreflight(
+        {
+            "LOOP_OPERATIONAL_STORE_REQUIRED": "true",
+            "LOOP_POSTGRES_DRIVER": "docker",
+        },
+        postgres_ok=True,
+    ).run()
+
+    assert result.status is PreflightStatus.PASS
+    assert result.blocking_for_loop_bootstrap == ()

--- a/tests/loop_engineering/test_postgres_runtime.py
+++ b/tests/loop_engineering/test_postgres_runtime.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from loop_engineering.postgres_runtime import PostgreSQLCommandAdapter
+
+
+@dataclass(frozen=True)
+class Result:
+    succeeded: bool
+    output: str = ""
+
+
+class RecordingRunner:
+    def __init__(self, migration_output: str = "") -> None:
+        self.calls: list[tuple[tuple[str, ...], Mapping[str, str] | None]] = []
+        self.migration_output = migration_output
+
+    def run(
+        self,
+        command: Sequence[str],
+        environment: Mapping[str, str] | None = None,
+    ) -> Result:
+        call = tuple(command)
+        self.calls.append((call, environment))
+        if "SELECT filename FROM loop_schema_migrations" in call:
+            return Result(True, self.migration_output)
+        return Result(True, "1\n")
+
+
+def _environment() -> dict[str, str]:
+    return {
+        "PATH": "/usr/bin",
+        "HOME": "/Users/test",
+        "LOOP_POSTGRES_DSN": "postgresql://loop:secret-password@127.0.0.1:5432/loop_db",
+        "LOOP_POSTGRES_DRIVER": "docker",
+        "LOOP_POSTGRES_CONTAINER": "local-postgres",
+    }
+
+
+def test_docker_probe_uses_container_client_without_password_in_argv(tmp_path: Path) -> None:
+    (tmp_path / "0001.sql").write_text("SELECT 1;", encoding="utf-8")
+    runner = RecordingRunner("0001.sql\n")
+
+    capabilities = PostgreSQLCommandAdapter(
+        runner,
+        _environment(),
+        migration_dir=tmp_path,
+    ).probe()
+
+    assert capabilities.client
+    assert capabilities.server
+    assert capabilities.database
+    assert capabilities.migration
+    assert all(call[:2] == ("docker", "exec") for call, _ in runner.calls)
+    assert all("secret-password" not in part for call, _ in runner.calls for part in call)
+    database_environment = runner.calls[-1][1]
+    assert database_environment is not None
+    assert database_environment["PGPASSWORD"] == "secret-password"
+    assert "OPENAI_API_KEY" not in database_environment
+
+
+def test_host_driver_remains_supported_for_compatibility(tmp_path: Path) -> None:
+    (tmp_path / "0001.sql").write_text("SELECT 1;", encoding="utf-8")
+    runner = RecordingRunner("0001.sql\n")
+    environment = _environment() | {"LOOP_POSTGRES_DRIVER": "host"}
+
+    capabilities = PostgreSQLCommandAdapter(
+        runner,
+        environment,
+        migration_dir=tmp_path,
+    ).probe()
+
+    assert capabilities.migration
+    assert runner.calls[0][0] == ("psql", "--version")
+    assert runner.calls[0][1] is not None
+    assert runner.calls[0][1]["PGHOST"] == "127.0.0.1"
+
+
+def test_legacy_database_url_is_accepted_as_compatibility_alias(tmp_path: Path) -> None:
+    (tmp_path / "0001.sql").write_text("SELECT 1;", encoding="utf-8")
+    runner = RecordingRunner("0001.sql\n")
+    environment = _environment()
+    environment["LOOP_DATABASE_URL"] = environment.pop("LOOP_POSTGRES_DSN")
+
+    capabilities = PostgreSQLCommandAdapter(
+        runner,
+        environment,
+        migration_dir=tmp_path,
+    ).probe()
+
+    assert capabilities.database
+
+
+def test_apply_migrations_records_only_unapplied_files(tmp_path: Path) -> None:
+    (tmp_path / "0001.sql").write_text("CREATE TABLE one (id INT);", encoding="utf-8")
+    (tmp_path / "0002.sql").write_text("CREATE TABLE two (id INT);", encoding="utf-8")
+    runner = RecordingRunner("0001.sql\n")
+
+    result = PostgreSQLCommandAdapter(
+        runner,
+        _environment(),
+        migration_dir=tmp_path,
+    ).apply_migrations()
+
+    assert result.succeeded
+    assert result.applied == ("0002.sql",)
+    migration_commands = [call for call, _ in runner.calls if "BEGIN;" in " ".join(call)]
+    assert len(migration_commands) == 1
+    assert "0002.sql" in " ".join(migration_commands[0])
+    assert "0001.sql" not in " ".join(migration_commands[0])
+
+
+def test_invalid_dsn_fails_without_running_commands(tmp_path: Path) -> None:
+    runner = RecordingRunner()
+    environment = _environment() | {"LOOP_POSTGRES_DSN": "not-a-postgres-url"}
+
+    result = PostgreSQLCommandAdapter(
+        runner,
+        environment,
+        migration_dir=tmp_path,
+    ).apply_migrations()
+
+    assert not result.succeeded
+    assert result.detail == "POSTGRES_DSN_INVALID"
+    assert runner.calls == []

--- a/tests/loop_engineering/test_postgres_runtime.py
+++ b/tests/loop_engineering/test_postgres_runtime.py
@@ -25,7 +25,7 @@ class RecordingRunner:
     ) -> Result:
         call = tuple(command)
         self.calls.append((call, environment))
-        if "SELECT filename FROM loop_schema_migrations" in call:
+        if any("SELECT filename FROM loop_schema_migrations" in part for part in call):
             return Result(True, self.migration_output)
         return Result(True, "1\n")
 


### PR DESCRIPTION
## 概要

#44の第一実装単位です。ローカルDocker上のPostgreSQLをLoop EngineeringのOperational Storeとして利用できるよう、接続・schema migration・事前確認Gateをstandalone側へ実装します。

## 設計境界

- GitHub live: Issue / PR / Project / branch / HEAD / CI / reviewの現在状態の正本
- Host Mission Goal / Project Registration: bootstrap trust anchor
- PostgreSQL: Run / transition / checkpoint / blocker / lease等のOperational State
- DBの過去値だけでcurrent WorkやHEADを確定しない

## 実装

- Docker CLI経由でPostgreSQLコンテナ内の`psql` / `pg_isready`を使用
- macOSホストへのPostgreSQL client導入を不要化
- password実値をcommand argvへ含めず、限定した環境変数で受け渡す
- `[operational_store]`へ`required / driver / docker_container / migration_policy`を追加
- `required = true`時はDB client/server/database/migration不成立をbootstrap blocker化
- `required = false`は従来どおりDEGRADED扱い
- Alembic前提を廃止し、`src/loop_engineering/migrations/*.sql`をmigration正本化
- `loop_schema_migrations`で適用済みmigrationを追跡
- `--preflight`と`--migrate-operational-store` CLIを追加
- run / transition / checkpoint / blocker / lease / dispatch / external wait用schemaを追加
- 旧`LOOP_DATABASE_URL`は移行互換aliasとして維持

## 非対象

- GitHub current-stateをDB正本へ変更すること
- Mission Goal本文をDBだけへ移すこと
- `ai-liver-yura` Product Repositoryの変更
- ローカル固有のcontainer名やDSNをRepositoryへ固定すること

## 次の実機確認

CI PASS後、ローカルの`config/loop-engineering.ini`へDocker container名と`required = true`を設定し、`.env`の`LOOP_POSTGRES_DSN`を使って`--preflight`→明示migration→`--preflight`を確認します。