### PR TITLE
feat: Runtime Operational Stateを実遷移へ接続する

### DIFF
--- a/docs/architecture/v2/runtime_state_reconciliation.md
+++ b/docs/architecture/v2/runtime_state_reconciliation.md
@@ -1,0 +1,136 @@
+# Runtime Operational State / Restart Reconciliation
+
+管理Issue: #44
+関連: #27 / #46
+状態: canonical architecture
+
+## 1. 目的
+
+PostgreSQL Operational Storeを、Loop EngineeringのHost run、遷移履歴、実行排他、再起動復旧、重複副作用防止のために使用する。
+
+この文書はGitHub current-state Authorityを変更しない。Issue、PR、Project、branch、exact HEAD、CI、review、Mission Checkpointの現在状態はfresh GitHub readを正とする。PostgreSQLは過去の運用効果と未確定状態を保持するだけで、DBだけからcurrent Workやmerge可否を決定しない。
+
+## 2. 1 Host遷移の永続境界
+
+各`run_actual_host_transition()`は1つのdurable runとして扱う。
+
+開始順序:
+
+1. 前回の未完了runをPostgreSQLからreadbackする。
+2. 新しい`run_id`を生成し`loop_runs`へ`RUNNING`として記録する。
+3. GitHubからcurrent targetをfresh readする。
+4. 前回未完了runがある場合は、そのrunが記録した観測Checkpointとfresh targetを比較してreconcileする。
+5. current targetの最小snapshotを`loop_checkpoints`へ記録する。
+6. project単位execution leaseを取得する。
+7. Host controllerを1遷移だけ実行する。
+8. 結果を`loop_transitions`へ記録し、必要に応じてblocker / external waitを更新する。
+9. runをterminal statusへ更新しleaseを解放する。
+
+通常終了経路ではrunとleaseを必ずterminalへする。プロセス異常終了では`RUNNING` / `ACTIVE`が残り、次回起動時のreconcile対象になる。
+
+## 3. Restart reconcile
+
+前回runが`RUNNING`のまま残っている場合、Loop Engineeringは副作用が発生しなかったと推定しない。
+
+前回runに記録されたCheckpoint snapshotとfresh GitHub targetを比較する。
+
+### 3.1 GitHub側が前進している場合
+
+次のいずれかが変化していれば、DB上の前回状態はstale operational stateとしてreconcileできる。
+
+- Mission Checkpoint comment identity
+- current Work
+- current PR
+- exact HEAD
+
+fresh GitHub stateを採用し、前回runを`RECONCILED`として閉じ、古いleaseを解放して現在runを継続する。
+
+### 3.2 同一Checkpointのままの場合
+
+前回runが`RUNNING`で、fresh GitHub targetが前回snapshotと同一である場合、副作用の成否は確定できない。
+
+この場合はCodex実行、GitHub write、merge等を再送しない。`OPERATIONAL_STATE_UNCERTAIN`として型付きInterventionへ遷移し、blockerを永続化する。
+
+前回runに観測Checkpoint自体が無い場合も同様に未確定として扱う。
+
+## 4. Execution lease
+
+project単位に1つのlease identityを使用する。
+
+```text
+host-transition:<project-key>
+```
+
+leaseは現在runの`run_id`をholderとする。
+
+- `ACTIVE` leaseが無い場合だけ取得できる。
+- 正常終了時に`RELEASED`へ更新する。
+- 異常終了で残ったleaseは、restart reconcileで前回runを安全にstaleと判定できた場合だけ解放する。
+- 同一Checkpointで未確定の場合は自動解放して再実行しない。
+
+leaseはGitHub Authorityの代替ではなく、同一Host/DBを共有する実行の重複抑止である。
+
+## 5. 保存する状態
+
+### loop_runs
+
+- run identity
+- project key / repository
+- `RUNNING` / `COMPLETED` / `YIELD_EXTERNAL` / `INTERVENTION_REQUIRED` / `RECONCILED`
+- secret-safe metadata
+
+### loop_checkpoints
+
+fresh GitHub観測から次だけ保存する。
+
+- run identity
+- project key
+- Mission Checkpoint comment identity
+- work issue
+- PR number
+- exact HEAD
+
+Issue/PR本文やMission Goal本文そのものは保存しない。
+
+### loop_transitions
+
+Host transition結果の型付き値だけ保存する。
+
+- status
+- detail code
+- work issue
+- PR number
+- exact HEAD
+
+### loop_blockers / loop_external_waits
+
+`INTERVENTION_REQUIRED`はblocker、`YIELD_EXTERNAL`はexternal waitとして記録する。後続runで同一targetが解消した場合はresolvedへ更新する。
+
+## 6. Secret safety
+
+DB操作は#46で導入したPostgreSQL command adapterを通す。
+
+- DSN passwordをargvへ含めない。
+- token、API key、Authorization、provider raw payload、prompt、diffを保存しない。
+- SQLへ埋め込む値は上限付きの内部identity / status / detail / GitHub numeric identity / exact HEADに限定し、SQL literal escapingを必須とする。
+
+## 7. required / optional policy
+
+`required = true`では、run開始後のOperational State read/write/lease失敗もfail-closedする。DBへ永続化できない状態で副作用を開始しない。
+
+`required = false`ではDB unavailableをtyped degraded pathとして扱える。ただしDB-backed leaseや未確定副作用判定が必要な箇所では再送よりyield/interventionを優先する。
+
+Yuraローカル実運転は`required = true`を使用する。
+
+## 8. 完了検証
+
+#44後半の完了条件:
+
+1. Host遷移開始・結果がPostgreSQLへ実記録される。
+2. execution leaseが取得・解放される。
+3. `YIELD_EXTERNAL` / `INTERVENTION_REQUIRED`がdurable stateへ反映される。
+4. 異常終了runを次回起動でreadbackできる。
+5. fresh GitHub targetが前進済みならstale DB stateをreconcileして続行できる。
+6. 同一Checkpointで副作用成否不明なら再送せず`OPERATIONAL_STATE_UNCERTAIN`になる。
+7. DB read/write failureは`required = true`でCodex/GitHub mutation開始前にfail-closedする。
+8. pytest / Ruff / strict Mypy / compileall / diff-check / exact-head CIがPASSする。

--- a/docs/architecture/v2/runtime_state_reconciliation.md
+++ b/docs/architecture/v2/runtime_state_reconciliation.md
@@ -12,21 +12,21 @@ PostgreSQL Operational Storeを、Loop EngineeringのHost run、遷移履歴、�
 
 ## 2. 1 Host遷移の永続境界
 
-各`run_actual_host_transition()`は1つのdurable runとして扱う。
+各Host遷移は1つのdurable runとして扱う。
 
 開始順序:
 
 1. 前回の未完了runをPostgreSQLからreadbackする。
-2. 新しい`run_id`を生成し`loop_runs`へ`RUNNING`として記録する。
-3. GitHubからcurrent targetをfresh readする。
-4. 前回未完了runがある場合は、そのrunが記録した観測Checkpointとfresh targetを比較してreconcileする。
+2. GitHubからcurrent targetをfresh readする。
+3. 前回未完了runがある場合は、そのrunが記録した観測Checkpointとfresh targetを比較してreconcileする。
+4. 現在runの`run_id`を生成し`loop_runs`へ`RUNNING`として記録する。
 5. current targetの最小snapshotを`loop_checkpoints`へ記録する。
 6. project単位execution leaseを取得する。
 7. Host controllerを1遷移だけ実行する。
 8. 結果を`loop_transitions`へ記録し、必要に応じてblocker / external waitを更新する。
 9. runをterminal statusへ更新しleaseを解放する。
 
-通常終了経路ではrunとleaseを必ずterminalへする。プロセス異常終了では`RUNNING` / `ACTIVE`が残り、次回起動時のreconcile対象になる。
+未完了runを安全にreconcileできない場合は新しいrun自体を開始しない。通常終了経路ではrunとleaseをterminalへする。プロセス異常終了では`RUNNING` / `ACTIVE`が残り、次回起動時のreconcile対象になる。
 
 ## 3. Restart reconcile
 
@@ -53,6 +53,10 @@ fresh GitHub stateを採用し、前回runを`RECONCILED`として閉じ、古�
 
 前回runに観測Checkpoint自体が無い場合も同様に未確定として扱う。
 
+### 3.3 terminal transitionだけ記録済みの場合
+
+`loop_transitions`にはterminal結果があるが`loop_runs`が`RUNNING`のままなら、外部副作用の結果は既に型付きで永続化済みである。runをそのterminal statusへ閉じ直し、残存leaseを解放してfresh GitHub stateから続行する。
+
 ## 4. Execution lease
 
 project単位に1つのlease identityを使用する。
@@ -65,7 +69,7 @@ leaseは現在runの`run_id`をholderとする。
 
 - `ACTIVE` leaseが無い場合だけ取得できる。
 - 正常終了時に`RELEASED`へ更新する。
-- 異常終了で残ったleaseは、restart reconcileで前回runを安全にstaleと判定できた場合だけ解放する。
+- 異常終了で残ったleaseは、restart reconcileで前回runを安全にstaleまたはterminalと判定できた場合だけ解放する。
 - 同一Checkpointで未確定の場合は自動解放して再実行しない。
 
 leaseはGitHub Authorityの代替ではなく、同一Host/DBを共有する実行の重複抑止である。
@@ -104,7 +108,9 @@ Host transition結果の型付き値だけ保存する。
 
 ### loop_blockers / loop_external_waits
 
-`INTERVENTION_REQUIRED`はblocker、`YIELD_EXTERNAL`はexternal waitとして記録する。後続runで同一targetが解消した場合はresolvedへ更新する。
+`INTERVENTION_REQUIRED`はblocker、`YIELD_EXTERNAL`はexternal waitとして現在runへ関連付けて記録する。
+
+後続runで新しいterminal operational stateを確立できた場合、そのProject / Repositoryに属する過去runの`OPEN` blocker / external waitを`RESOLVED`へ更新した後、現在runが必要とする新しい`OPEN`状態だけを記録する。これにより履歴を削除せず、現在有効な待機・blockerを判別できる。
 
 ## 6. Secret safety
 
@@ -118,19 +124,40 @@ DB操作は#46で導入したPostgreSQL command adapterを通す。
 
 `required = true`では、run開始後のOperational State read/write/lease失敗もfail-closedする。DBへ永続化できない状態で副作用を開始しない。
 
+外部副作用後のDB commitが確定できない場合は`OPERATIONAL_STORE_COMMIT_UNCERTAIN`とし、安全側へ停止する。
+
 `required = false`ではDB unavailableをtyped degraded pathとして扱える。ただしDB-backed leaseや未確定副作用判定が必要な箇所では再送よりyield/interventionを優先する。
 
 Yuraローカル実運転は`required = true`を使用する。
 
-## 8. 完了検証
+## 8. Product非変更の実機確認
+
+Runtimeを実際にYuraへdispatchする前に、次を実行できる。
+
+```bash
+pipenv run python -m loop_engineering --operational-state-check
+```
+
+この確認はGitHub API mutation、Codex、Product Workspace変更を行わず、`loop_runs`へsynthetic runを書込み、`RUNNING` readback、`COMPLETED`更新、terminal readbackを確認する。
+
+synthetic runの`project_key`は`health:<project-key>` namespaceへ分離する。確認途中で異常終了して`RUNNING`が残っても本番Projectのrestart reconcile対象にはならない。
+
+期待結果:
+
+```text
+OPERATIONAL_STATE_CHECK=PASS detail=ROUND_TRIP_PASS
+```
+
+## 9. 完了検証
 
 #44後半の完了条件:
 
-1. Host遷移開始・結果がPostgreSQLへ実記録される。
-2. execution leaseが取得・解放される。
-3. `YIELD_EXTERNAL` / `INTERVENTION_REQUIRED`がdurable stateへ反映される。
-4. 異常終了runを次回起動でreadbackできる。
-5. fresh GitHub targetが前進済みならstale DB stateをreconcileして続行できる。
-6. 同一Checkpointで副作用成否不明なら再送せず`OPERATIONAL_STATE_UNCERTAIN`になる。
-7. DB read/write failureは`required = true`でCodex/GitHub mutation開始前にfail-closedする。
-8. pytest / Ruff / strict Mypy / compileall / diff-check / exact-head CIがPASSする。
+1. Product非変更のround-trip checkでPostgreSQL write/readbackがPASSする。
+2. Host遷移開始・結果がPostgreSQLへ実記録される。
+3. execution leaseが取得・解放される。
+4. `YIELD_EXTERNAL` / `INTERVENTION_REQUIRED`がdurable stateへ反映される。
+5. 異常終了runを次回起動でreadbackできる。
+6. fresh GitHub targetが前進済みならstale DB stateをreconcileして続行できる。
+7. 同一Checkpointで副作用成否不明なら再送せず`OPERATIONAL_STATE_UNCERTAIN`になる。
+8. DB read/write failureは`required = true`でCodex/GitHub mutation開始前にfail-closedする。
+9. pytest / Ruff / strict Mypy / compileall / diff-check / exact-head CIがPASSする。

--- a/src/loop_engineering/__main__.py
+++ b/src/loop_engineering/__main__.py
@@ -35,6 +35,11 @@ def main() -> int:
         help="設定されたPostgreSQLへ未適用のversioned SQL migrationを明示適用する。",
     )
     parser.add_argument(
+        "--operational-state-check",
+        action="store_true",
+        help="ProductやGitHubを変更せず、Operational Storeのwrite/readbackだけを確認する。",
+    )
+    parser.add_argument(
         "--config",
         help="既定のconfig/loop-engineering.ini以外を使用する場合の設定ファイルpath。",
     )
@@ -95,6 +100,23 @@ def main() -> int:
             f"detail={migration_result.detail} applied={applied}"
         )
         return 0 if migration_result.succeeded else 3
+
+    if arguments.operational_state_check:
+        from .operational_state_check import check_operational_state_round_trip
+        from .postgres_runtime import PostgreSQLCommandAdapter
+        from .preflight import SubprocessCommandRunner
+
+        check_result = check_operational_state_round_trip(
+            PostgreSQLCommandAdapter(SubprocessCommandRunner(), environment),
+            project_key=settings.project_key,
+            repository=settings.engine.repository,
+        )
+        print(
+            "OPERATIONAL_STATE_CHECK="
+            f"{'PASS' if check_result.succeeded else 'FAIL'} "
+            f"detail={check_result.detail}"
+        )
+        return 0 if check_result.succeeded else 3
 
     if arguments.preflight:
         from .preflight import (

--- a/src/loop_engineering/__main__.py
+++ b/src/loop_engineering/__main__.py
@@ -139,6 +139,7 @@ def main() -> int:
                 environment=environment,
                 local_runner=runner,
                 config=settings.engine,
+                project_key=settings.project_key,
             )
             console.event(
                 f"遷移 {transition_number}: "

--- a/src/loop_engineering/__main__.py
+++ b/src/loop_engineering/__main__.py
@@ -113,7 +113,7 @@ def main() -> int:
         print(preflight_result.as_json())
         return 3 if preflight_result.status is PreflightStatus.BLOCKED else 0
 
-    from .host_entrypoint import run_actual_host_transition
+    from .durable_host_entrypoint import run_durable_actual_host_transition
 
     console = RuntimeConsole(platform_root, verbose=arguments.verbose)
     runner = VisibleSubprocessLocalRunner(console)
@@ -134,7 +134,7 @@ def main() -> int:
         while True:
             transition_number += 1
             console.event(f"遷移 {transition_number}: 開始")
-            transition_result = run_actual_host_transition(
+            transition_result = run_durable_actual_host_transition(
                 root=workspace_root,
                 environment=environment,
                 local_runner=runner,

--- a/src/loop_engineering/durable_host_entrypoint.py
+++ b/src/loop_engineering/durable_host_entrypoint.py
@@ -1,0 +1,109 @@
+"""Operational Stateを伴う実ホスト遷移入口。"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+from . import host_entrypoint
+from .config import LoopEngineConfig
+from .host_entrypoint import (
+    PilotAwareMissionPort,
+    PilotPlanningImplementer,
+    ReconciliationAwareHostLoopController,
+    StrictGhMissionPort,
+)
+from .host_runtime import HostTransitionResult, HostTransitionStatus, LocalRunner, SubprocessLocalRunner
+from .mission_goal import inject_mission_goal_environment
+from .postgres_runtime import PostgreSQLCommandAdapter
+from .preflight import EnvironmentCapabilityPreflight, PreflightStatus, SubprocessCommandRunner
+from .runtime_operational_state import (
+    DurableHostTransitionCoordinator,
+    PostgreSQLRuntimeOperationalStore,
+)
+
+
+def run_durable_actual_host_transition(
+    *,
+    root: Path | None = None,
+    environment: Mapping[str, str] | None = None,
+    local_runner: LocalRunner | None = None,
+    config: LoopEngineConfig | None = None,
+    project_key: str | None = None,
+) -> HostTransitionResult:
+    """DB設定済みならdurable coordinatorを通し、未設定なら従来入口へ委譲する。"""
+    base_values = dict(environment or os.environ)
+    required = base_values.get("LOOP_OPERATIONAL_STORE_REQUIRED", "false").strip().lower() == "true"
+    database_configured = bool(
+        base_values.get("LOOP_POSTGRES_DSN", "").strip()
+        or base_values.get("LOOP_DATABASE_URL", "").strip()
+    )
+    if not required and not database_configured:
+        return host_entrypoint.run_actual_host_transition(
+            root=root,
+            environment=base_values,
+            local_runner=local_runner,
+            config=config,
+        )
+
+    project_root = root or Path(__file__).resolve().parents[2]
+    try:
+        resolved_config = config or LoopEngineConfig.from_environment(base_values)
+    except ValueError:
+        return HostTransitionResult(
+            HostTransitionStatus.INTERVENTION_REQUIRED,
+            "CONFIGURATION_INVALID",
+        )
+
+    values = inject_mission_goal_environment(
+        platform_root=Path(__file__).resolve().parents[2],
+        product_root=project_root,
+        repository=resolved_config.repository,
+        environment=base_values,
+    )
+    preflight = EnvironmentCapabilityPreflight(
+        resolved_config,
+        SubprocessCommandRunner(),
+        values,
+        project_root=project_root,
+    ).run()
+    if preflight.status is PreflightStatus.BLOCKED:
+        return HostTransitionResult(
+            HostTransitionStatus.INTERVENTION_REQUIRED,
+            "PREFLIGHT_BLOCKED:" + ",".join(preflight.blocking_for_loop_bootstrap),
+        )
+
+    runner = local_runner or SubprocessLocalRunner()
+    try:
+        argv_prefix = host_entrypoint._codex_argv(values)
+    except ValueError:
+        return HostTransitionResult(
+            HostTransitionStatus.INTERVENTION_REQUIRED,
+            "CODEX_COMMAND_INVALID",
+        )
+
+    strict = StrictGhMissionPort(resolved_config, runner, values)
+    mission = PilotAwareMissionPort(resolved_config, strict)
+    implementer = PilotPlanningImplementer(
+        resolved_config,
+        runner,
+        project_root,
+        values,
+        argv_prefix,
+    )
+    controller = ReconciliationAwareHostLoopController(
+        resolved_config,
+        mission,
+        implementer,
+    )
+    database = PostgreSQLCommandAdapter(SubprocessCommandRunner(), values)
+    store = PostgreSQLRuntimeOperationalStore(database)
+    return DurableHostTransitionCoordinator(
+        project_key=project_key or resolved_config.repository,
+        repository=resolved_config.repository,
+        mission=mission,
+        controller=controller,
+        store=store,
+        required=required,
+    ).run_once()

--- a/src/loop_engineering/durable_host_entrypoint.py
+++ b/src/loop_engineering/durable_host_entrypoint.py
@@ -14,10 +14,19 @@ from .host_entrypoint import (
     ReconciliationAwareHostLoopController,
     StrictGhMissionPort,
 )
-from .host_runtime import HostTransitionResult, HostTransitionStatus, LocalRunner, SubprocessLocalRunner
+from .host_runtime import (
+    HostTransitionResult,
+    HostTransitionStatus,
+    LocalRunner,
+    SubprocessLocalRunner,
+)
 from .mission_goal import inject_mission_goal_environment
 from .postgres_runtime import PostgreSQLCommandAdapter
-from .preflight import EnvironmentCapabilityPreflight, PreflightStatus, SubprocessCommandRunner
+from .preflight import (
+    EnvironmentCapabilityPreflight,
+    PreflightStatus,
+    SubprocessCommandRunner,
+)
 from .runtime_operational_state import (
     DurableHostTransitionCoordinator,
     PostgreSQLRuntimeOperationalStore,
@@ -34,7 +43,10 @@ def run_durable_actual_host_transition(
 ) -> HostTransitionResult:
     """DB設定済みならdurable coordinatorを通し、未設定なら従来入口へ委譲する。"""
     base_values = dict(environment or os.environ)
-    required = base_values.get("LOOP_OPERATIONAL_STORE_REQUIRED", "false").strip().lower() == "true"
+    required = (
+        base_values.get("LOOP_OPERATIONAL_STORE_REQUIRED", "false").strip().lower()
+        == "true"
+    )
     database_configured = bool(
         base_values.get("LOOP_POSTGRES_DSN", "").strip()
         or base_values.get("LOOP_DATABASE_URL", "").strip()

--- a/src/loop_engineering/migrations/0003_runtime_reconciliation.sql
+++ b/src/loop_engineering/migrations/0003_runtime_reconciliation.sql
@@ -7,11 +7,23 @@ ALTER TABLE loop_checkpoints
 ALTER TABLE loop_checkpoints
     ADD COLUMN IF NOT EXISTS head_sha TEXT;
 
+ALTER TABLE loop_blockers
+    ADD COLUMN IF NOT EXISTS run_identity TEXT;
+
+ALTER TABLE loop_external_waits
+    ADD COLUMN IF NOT EXISTS run_identity TEXT;
+
 CREATE INDEX IF NOT EXISTS loop_checkpoints_run_index
     ON loop_checkpoints (run_identity, recorded_at DESC);
 
 CREATE INDEX IF NOT EXISTS loop_runs_project_status_index
     ON loop_runs (project_key, repository, status, started_at DESC);
 
+CREATE INDEX IF NOT EXISTS loop_blockers_run_status_index
+    ON loop_blockers (run_identity, status);
+
 CREATE INDEX IF NOT EXISTS loop_external_waits_target_index
     ON loop_external_waits (kind, target_identity, status);
+
+CREATE INDEX IF NOT EXISTS loop_external_waits_run_status_index
+    ON loop_external_waits (run_identity, status);

--- a/src/loop_engineering/migrations/0003_runtime_reconciliation.sql
+++ b/src/loop_engineering/migrations/0003_runtime_reconciliation.sql
@@ -1,0 +1,17 @@
+ALTER TABLE loop_checkpoints
+    ADD COLUMN IF NOT EXISTS run_identity TEXT;
+
+ALTER TABLE loop_checkpoints
+    ADD COLUMN IF NOT EXISTS pr_number BIGINT;
+
+ALTER TABLE loop_checkpoints
+    ADD COLUMN IF NOT EXISTS head_sha TEXT;
+
+CREATE INDEX IF NOT EXISTS loop_checkpoints_run_index
+    ON loop_checkpoints (run_identity, recorded_at DESC);
+
+CREATE INDEX IF NOT EXISTS loop_runs_project_status_index
+    ON loop_runs (project_key, repository, status, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS loop_external_waits_target_index
+    ON loop_external_waits (kind, target_identity, status);

--- a/src/loop_engineering/operational_state_check.py
+++ b/src/loop_engineering/operational_state_check.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
+from typing import Protocol
 
-from .postgres_runtime import PostgreSQLCommandAdapter
+
+class OperationalStateCheckDatabase(Protocol):
+    def execute_sql(self, sql: str) -> bool: ...
+
+    def query_json_rows(self, select_sql: str) -> list[dict[str, object]] | None: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -15,7 +20,7 @@ class OperationalStateCheckResult:
 
 
 def check_operational_state_round_trip(
-    database: PostgreSQLCommandAdapter,
+    database: OperationalStateCheckDatabase,
     *,
     project_key: str,
     repository: str,

--- a/src/loop_engineering/operational_state_check.py
+++ b/src/loop_engineering/operational_state_check.py
@@ -25,11 +25,13 @@ def check_operational_state_round_trip(
     project_key: str,
     repository: str,
 ) -> OperationalStateCheckResult:
-    """synthetic terminal runを1件だけ記録し、同一値をreadbackする。"""
+    """本番runと別namespaceへsynthetic runを記録し、同一値をreadbackする。"""
     identity = f"health:{uuid.uuid4().hex}"
+    health_project_key = f"health:{project_key}"
     insert = (
         "INSERT INTO loop_runs (identity, project_key, repository, status) VALUES ("
-        f"{_literal(identity)}, {_literal(project_key)}, {_literal(repository)}, 'RUNNING')"
+        f"{_literal(identity)}, {_literal(health_project_key)}, "
+        f"{_literal(repository)}, 'RUNNING')"
     )
     if not database.execute_sql(insert):
         return OperationalStateCheckResult(False, "WRITE_FAILED")
@@ -38,7 +40,7 @@ def check_operational_state_round_trip(
         "SELECT identity, project_key, repository, status FROM loop_runs "
         f"WHERE identity = {_literal(identity)} LIMIT 1"
     )
-    if not _matches(running, identity, project_key, repository, "RUNNING"):
+    if not _matches(running, identity, health_project_key, repository, "RUNNING"):
         return OperationalStateCheckResult(False, "RUNNING_READBACK_FAILED")
 
     completed = database.execute_sql(
@@ -52,7 +54,7 @@ def check_operational_state_round_trip(
         "SELECT identity, project_key, repository, status FROM loop_runs "
         f"WHERE identity = {_literal(identity)} LIMIT 1"
     )
-    if not _matches(terminal, identity, project_key, repository, "COMPLETED"):
+    if not _matches(terminal, identity, health_project_key, repository, "COMPLETED"):
         return OperationalStateCheckResult(False, "TERMINAL_READBACK_FAILED")
     return OperationalStateCheckResult(True, "ROUND_TRIP_PASS")
 

--- a/src/loop_engineering/operational_state_check.py
+++ b/src/loop_engineering/operational_state_check.py
@@ -1,0 +1,76 @@
+"""ProductやGitHubを変更せずOperational Storeのwrite/readbackを確認する。"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from .postgres_runtime import PostgreSQLCommandAdapter
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalStateCheckResult:
+    succeeded: bool
+    detail: str
+
+
+def check_operational_state_round_trip(
+    database: PostgreSQLCommandAdapter,
+    *,
+    project_key: str,
+    repository: str,
+) -> OperationalStateCheckResult:
+    """synthetic terminal runを1件だけ記録し、同一値をreadbackする。"""
+    identity = f"health:{uuid.uuid4().hex}"
+    insert = (
+        "INSERT INTO loop_runs (identity, project_key, repository, status) VALUES ("
+        f"{_literal(identity)}, {_literal(project_key)}, {_literal(repository)}, 'RUNNING')"
+    )
+    if not database.execute_sql(insert):
+        return OperationalStateCheckResult(False, "WRITE_FAILED")
+
+    running = database.query_json_rows(
+        "SELECT identity, project_key, repository, status FROM loop_runs "
+        f"WHERE identity = {_literal(identity)} LIMIT 1"
+    )
+    if not _matches(running, identity, project_key, repository, "RUNNING"):
+        return OperationalStateCheckResult(False, "RUNNING_READBACK_FAILED")
+
+    completed = database.execute_sql(
+        "UPDATE loop_runs SET status = 'COMPLETED', finished_at = now() "
+        f"WHERE identity = {_literal(identity)}"
+    )
+    if not completed:
+        return OperationalStateCheckResult(False, "FINALIZE_FAILED")
+
+    terminal = database.query_json_rows(
+        "SELECT identity, project_key, repository, status FROM loop_runs "
+        f"WHERE identity = {_literal(identity)} LIMIT 1"
+    )
+    if not _matches(terminal, identity, project_key, repository, "COMPLETED"):
+        return OperationalStateCheckResult(False, "TERMINAL_READBACK_FAILED")
+    return OperationalStateCheckResult(True, "ROUND_TRIP_PASS")
+
+
+def _matches(
+    rows: list[dict[str, object]] | None,
+    identity: str,
+    project_key: str,
+    repository: str,
+    status: str,
+) -> bool:
+    if rows is None or len(rows) != 1:
+        return False
+    row = rows[0]
+    return (
+        row.get("identity") == identity
+        and row.get("project_key") == project_key
+        and row.get("repository") == repository
+        and row.get("status") == status
+    )
+
+
+def _literal(value: str) -> str:
+    if "\x00" in value or len(value) > 1024:
+        raise ValueError("Operational State確認値が不正です")
+    return "'" + value.replace("'", "''") + "'"

--- a/src/loop_engineering/postgres_runtime.py
+++ b/src/loop_engineering/postgres_runtime.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, cast
 from urllib.parse import urlsplit
 
 
@@ -99,9 +100,7 @@ class PostgreSQLCommandAdapter:
             "applied_at TIMESTAMPTZ NOT NULL DEFAULT now()"
             ");"
         )
-        if not self._run_client(
-            ("psql", "-v", "ON_ERROR_STOP=1", "-q", "-c", registry_sql), parsed
-        ).succeeded:
+        if not self.execute_sql(registry_sql):
             return MigrationApplyResult(False, (), "MIGRATION_REGISTRY_UNAVAILABLE")
 
         applied = self._applied_migrations(parsed)
@@ -124,13 +123,44 @@ class PostgreSQLCommandAdapter:
                 f"VALUES ('{filename}') ON CONFLICT (filename) DO NOTHING;\n"
                 "COMMIT;"
             )
-            result = self._run_client(
-                ("psql", "-v", "ON_ERROR_STOP=1", "-q", "-c", transaction), parsed
-            )
-            if not result.succeeded:
+            if not self.execute_sql(transaction):
                 return MigrationApplyResult(False, tuple(completed), "MIGRATION_APPLY_FAILED")
             completed.append(path.name)
         return MigrationApplyResult(True, tuple(completed), "MIGRATION_CURRENT")
+
+    def execute_sql(self, sql: str) -> bool:
+        """秘密を含まない内部SQLを1回実行する。"""
+        parsed = self._parsed_dsn()
+        if parsed is None or self._driver not in self._DRIVERS:
+            return False
+        if self._driver == "docker" and not self._container:
+            return False
+        return self._run_client(
+            ("psql", "-v", "ON_ERROR_STOP=1", "-q", "-c", sql),
+            parsed,
+        ).succeeded
+
+    def query_json_rows(self, select_sql: str) -> list[dict[str, object]] | None:
+        """秘密を含まない内部SELECTをJSON配列として読み戻す。"""
+        parsed = self._parsed_dsn()
+        if parsed is None or self._driver not in self._DRIVERS:
+            return None
+        if self._driver == "docker" and not self._container:
+            return None
+        statement = (
+            "SELECT COALESCE(json_agg(row_to_json(loop_query)), '[]'::json)::text "
+            f"FROM ({select_sql}) AS loop_query"
+        )
+        result = self._run_client(("psql", "-Atqc", statement), parsed)
+        if not result.succeeded:
+            return None
+        try:
+            payload = json.loads(result.output.strip() or "[]")
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(payload, list) or not all(isinstance(item, dict) for item in payload):
+            return None
+        return [cast(dict[str, object], item) for item in payload]
 
     def _migrations_current(self, parsed: _ParsedDSN) -> bool:
         expected = {path.name for path in self._migration_files()}

--- a/src/loop_engineering/runtime_operational_state.py
+++ b/src/loop_engineering/runtime_operational_state.py
@@ -298,7 +298,23 @@ class DurableHostTransitionCoordinator:
         run_identity = uuid.uuid4().hex
         try:
             previous = self._store.latest_unfinished(self._project_key, self._repository)
+        except OperationalStateUnavailable:
+            if self._required:
+                return HostTransitionResult(
+                    HostTransitionStatus.INTERVENTION_REQUIRED,
+                    "OPERATIONAL_STORE_UNAVAILABLE",
+                )
+            return self._controller.run_once()
+
+        try:
             fresh = self._mission.current_target()
+        except RuntimeError:
+            return HostTransitionResult(
+                HostTransitionStatus.INTERVENTION_REQUIRED,
+                "GITHUB_OBSERVE_FAILED",
+            )
+
+        try:
             if previous is not None:
                 reconciliation = self._reconcile_previous(previous, fresh)
                 if reconciliation is not None:
@@ -318,7 +334,7 @@ class DurableHostTransitionCoordinator:
                 self._store.record_blocker(run_identity, result)
                 self._store.finish_run(run_identity, result.status.value)
                 return result
-        except (OperationalStateUnavailable, RuntimeError):
+        except OperationalStateUnavailable:
             if self._required:
                 return HostTransitionResult(
                     HostTransitionStatus.INTERVENTION_REQUIRED,

--- a/src/loop_engineering/runtime_operational_state.py
+++ b/src/loop_engineering/runtime_operational_state.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 import uuid
 from dataclasses import dataclass
 from typing import Protocol
@@ -10,7 +9,6 @@ from typing import Protocol
 from .host_runtime import HostTarget, HostTransitionResult, HostTransitionStatus
 from .postgres_runtime import PostgreSQLCommandAdapter
 
-_SAFE_CODE_RE = re.compile(r"^[A-Za-z0-9_.:/#-]{1,256}$")
 _TERMINAL_RUN_STATUS = frozenset(
     {
         HostTransitionStatus.COMPLETED.value,

--- a/src/loop_engineering/runtime_operational_state.py
+++ b/src/loop_engineering/runtime_operational_state.py
@@ -1,0 +1,386 @@
+"""Host遷移のOperational State永続化とrestart reconciliation。"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Protocol
+
+from .host_runtime import HostTarget, HostTransitionResult, HostTransitionStatus
+from .postgres_runtime import PostgreSQLCommandAdapter
+
+_SAFE_CODE_RE = re.compile(r"^[A-Za-z0-9_.:/#-]{1,256}$")
+_TERMINAL_RUN_STATUS = frozenset(
+    {
+        HostTransitionStatus.COMPLETED.value,
+        HostTransitionStatus.YIELD_EXTERNAL.value,
+        HostTransitionStatus.INTERVENTION_REQUIRED.value,
+    }
+)
+
+
+class OperationalStateUnavailable(RuntimeError):
+    """required Operational Storeを安全に読み書きできない。"""
+
+
+@dataclass(frozen=True, slots=True)
+class UnfinishedRun:
+    run_identity: str
+    checkpoint_revision: str | None
+    work_issue: int | None
+    pr_number: int | None
+    head_sha: str | None
+    transition_status: str | None
+
+
+class OperationalStatePort(Protocol):
+    def latest_unfinished(self, project_key: str, repository: str) -> UnfinishedRun | None: ...
+
+    def begin_run(self, run_identity: str, project_key: str, repository: str) -> None: ...
+
+    def finish_run(self, run_identity: str, status: str) -> None: ...
+
+    def mark_reconciled(self, run_identity: str) -> None: ...
+
+    def record_checkpoint(
+        self,
+        run_identity: str,
+        project_key: str,
+        target: HostTarget | None,
+    ) -> None: ...
+
+    def record_transition(
+        self,
+        run_identity: str,
+        sequence_number: int,
+        result: HostTransitionResult,
+    ) -> None: ...
+
+    def acquire_lease(self, project_key: str, run_identity: str) -> bool: ...
+
+    def release_lease(self, project_key: str, run_identity: str) -> None: ...
+
+    def record_blocker(self, run_identity: str, result: HostTransitionResult) -> None: ...
+
+    def record_external_wait(self, run_identity: str, result: HostTransitionResult) -> None: ...
+
+
+class FreshTargetPort(Protocol):
+    def current_target(self) -> HostTarget | None: ...
+
+
+class TransitionController(Protocol):
+    def run_once(self) -> HostTransitionResult: ...
+
+
+class PostgreSQLRuntimeOperationalStore:
+    """#44管理schemaへ上限付きのHost実行状態だけを保存する。"""
+
+    def __init__(self, database: PostgreSQLCommandAdapter) -> None:
+        self._database = database
+
+    def latest_unfinished(self, project_key: str, repository: str) -> UnfinishedRun | None:
+        project = _literal(project_key)
+        repo = _literal(repository)
+        rows = self._query(
+            "SELECT r.identity AS run_identity, "
+            "c.source_revision AS checkpoint_revision, c.work_issue, c.pr_number, c.head_sha, "
+            "t.status AS transition_status "
+            "FROM loop_runs AS r "
+            "LEFT JOIN LATERAL ("
+            "SELECT source_revision, work_issue, pr_number, head_sha "
+            "FROM loop_checkpoints WHERE run_identity = r.identity "
+            "ORDER BY recorded_at DESC LIMIT 1"
+            ") AS c ON true "
+            "LEFT JOIN LATERAL ("
+            "SELECT status FROM loop_transitions WHERE run_identity = r.identity "
+            "ORDER BY sequence_number DESC LIMIT 1"
+            ") AS t ON true "
+            f"WHERE r.project_key = {project} AND r.repository = {repo} AND r.status = 'RUNNING' "
+            "ORDER BY r.started_at DESC LIMIT 1"
+        )
+        if not rows:
+            return None
+        row = rows[0]
+        run_identity = _row_string(row, "run_identity")
+        if run_identity is None:
+            raise OperationalStateUnavailable("OPERATIONAL_RUN_ID_INVALID")
+        return UnfinishedRun(
+            run_identity=run_identity,
+            checkpoint_revision=_row_string(row, "checkpoint_revision"),
+            work_issue=_row_int(row, "work_issue"),
+            pr_number=_row_int(row, "pr_number"),
+            head_sha=_row_string(row, "head_sha"),
+            transition_status=_row_string(row, "transition_status"),
+        )
+
+    def begin_run(self, run_identity: str, project_key: str, repository: str) -> None:
+        self._execute(
+            "INSERT INTO loop_runs (identity, project_key, repository, status) VALUES ("
+            f"{_literal(run_identity)}, {_literal(project_key)}, {_literal(repository)}, 'RUNNING') "
+            "ON CONFLICT (identity) DO NOTHING"
+        )
+
+    def finish_run(self, run_identity: str, status: str) -> None:
+        if status not in _TERMINAL_RUN_STATUS and status != "RECONCILED":
+            raise OperationalStateUnavailable("OPERATIONAL_RUN_STATUS_INVALID")
+        self._execute(
+            "UPDATE loop_runs SET "
+            f"status = {_literal(status)}, finished_at = now() "
+            f"WHERE identity = {_literal(run_identity)}"
+        )
+
+    def mark_reconciled(self, run_identity: str) -> None:
+        self.finish_run(run_identity, "RECONCILED")
+
+    def record_checkpoint(
+        self,
+        run_identity: str,
+        project_key: str,
+        target: HostTarget | None,
+    ) -> None:
+        identity = f"checkpoint:{run_identity}"
+        revision = str(target.checkpoint_comment_id) if target is not None else None
+        work_issue = target.work_issue if target is not None else None
+        pr_number = target.pr_number if target is not None else None
+        head_sha = target.head_sha if target is not None else None
+        self._execute(
+            "INSERT INTO loop_checkpoints "
+            "(identity, run_identity, project_key, work_issue, source_revision, pr_number, head_sha) "
+            "VALUES ("
+            f"{_literal(identity)}, {_literal(run_identity)}, {_literal(project_key)}, "
+            f"{_nullable_int(work_issue)}, {_nullable_literal(revision)}, "
+            f"{_nullable_int(pr_number)}, {_nullable_literal(head_sha)}) "
+            "ON CONFLICT (identity) DO UPDATE SET "
+            "work_issue = EXCLUDED.work_issue, source_revision = EXCLUDED.source_revision, "
+            "pr_number = EXCLUDED.pr_number, head_sha = EXCLUDED.head_sha, recorded_at = now()"
+        )
+
+    def record_transition(
+        self,
+        run_identity: str,
+        sequence_number: int,
+        result: HostTransitionResult,
+    ) -> None:
+        if sequence_number < 1:
+            raise OperationalStateUnavailable("OPERATIONAL_SEQUENCE_INVALID")
+        identity = f"transition:{run_identity}:{sequence_number}"
+        self._execute(
+            "INSERT INTO loop_transitions "
+            "(identity, run_identity, sequence_number, status, detail, work_issue, pr_number, head_sha) "
+            "VALUES ("
+            f"{_literal(identity)}, {_literal(run_identity)}, {sequence_number}, "
+            f"{_literal(result.status.value)}, {_literal(result.detail)}, "
+            f"{_nullable_int(result.work_issue)}, {_nullable_int(result.pr_number)}, "
+            f"{_nullable_literal(result.head_sha)}) "
+            "ON CONFLICT (identity) DO NOTHING"
+        )
+
+    def acquire_lease(self, project_key: str, run_identity: str) -> bool:
+        identity = f"host-transition:{project_key}"
+        self._execute(
+            "INSERT INTO loop_leases "
+            "(identity, scope, subject_identity, holder_identity, status) VALUES ("
+            f"{_literal(identity)}, 'host-transition', {_literal(project_key)}, "
+            f"{_literal(run_identity)}, 'ACTIVE') "
+            "ON CONFLICT (identity) DO UPDATE SET "
+            "holder_identity = EXCLUDED.holder_identity, status = 'ACTIVE', "
+            "acquired_at = now(), released_at = NULL "
+            "WHERE loop_leases.status <> 'ACTIVE'"
+        )
+        rows = self._query(
+            "SELECT holder_identity, status FROM loop_leases "
+            f"WHERE identity = {_literal(identity)} LIMIT 1"
+        )
+        if not rows:
+            return False
+        return (
+            _row_string(rows[0], "holder_identity") == run_identity
+            and _row_string(rows[0], "status") == "ACTIVE"
+        )
+
+    def release_lease(self, project_key: str, run_identity: str) -> None:
+        identity = f"host-transition:{project_key}"
+        self._execute(
+            "UPDATE loop_leases SET status = 'RELEASED', released_at = now() "
+            f"WHERE identity = {_literal(identity)} AND holder_identity = {_literal(run_identity)} "
+            "AND status = 'ACTIVE'"
+        )
+
+    def record_blocker(self, run_identity: str, result: HostTransitionResult) -> None:
+        target = _result_target_identity(result)
+        identity = f"blocker:{run_identity}:1"
+        self._execute(
+            "INSERT INTO loop_blockers "
+            "(identity, scope, subject_identity, kind, reason_code, status) VALUES ("
+            f"{_literal(identity)}, 'host-transition', {_literal(target)}, "
+            f"'INTERVENTION_REQUIRED', {_literal(result.detail)}, 'OPEN') "
+            "ON CONFLICT (identity) DO UPDATE SET status = 'OPEN', resolved_at = NULL"
+        )
+
+    def record_external_wait(self, run_identity: str, result: HostTransitionResult) -> None:
+        target = _result_target_identity(result)
+        identity = f"external-wait:{run_identity}:1"
+        self._execute(
+            "INSERT INTO loop_external_waits "
+            "(identity, kind, target_identity, status) VALUES ("
+            f"{_literal(identity)}, {_literal(result.detail)}, {_literal(target)}, 'OPEN') "
+            "ON CONFLICT (identity) DO UPDATE SET status = 'OPEN', resolved_at = NULL"
+        )
+
+    def _execute(self, sql: str) -> None:
+        if not self._database.execute_sql(sql):
+            raise OperationalStateUnavailable("OPERATIONAL_STORE_WRITE_FAILED")
+
+    def _query(self, sql: str) -> list[dict[str, object]]:
+        rows = self._database.query_json_rows(sql)
+        if rows is None:
+            raise OperationalStateUnavailable("OPERATIONAL_STORE_READ_FAILED")
+        return rows
+
+
+class DurableHostTransitionCoordinator:
+    """fresh GitHub stateとdurable Operational Stateを調整して1遷移を実行する。"""
+
+    def __init__(
+        self,
+        *,
+        project_key: str,
+        repository: str,
+        mission: FreshTargetPort,
+        controller: TransitionController,
+        store: OperationalStatePort,
+        required: bool,
+    ) -> None:
+        self._project_key = project_key
+        self._repository = repository
+        self._mission = mission
+        self._controller = controller
+        self._store = store
+        self._required = required
+
+    def run_once(self) -> HostTransitionResult:
+        run_identity = uuid.uuid4().hex
+        try:
+            previous = self._store.latest_unfinished(self._project_key, self._repository)
+            fresh = self._mission.current_target()
+            if previous is not None:
+                reconciliation = self._reconcile_previous(previous, fresh)
+                if reconciliation is not None:
+                    return reconciliation
+
+            self._store.begin_run(run_identity, self._project_key, self._repository)
+            self._store.record_checkpoint(run_identity, self._project_key, fresh)
+            if not self._store.acquire_lease(self._project_key, run_identity):
+                result = HostTransitionResult(
+                    HostTransitionStatus.INTERVENTION_REQUIRED,
+                    "OPERATIONAL_LEASE_UNAVAILABLE",
+                    fresh.work_issue if fresh else None,
+                    fresh.pr_number if fresh else None,
+                    fresh.head_sha if fresh else None,
+                )
+                self._store.record_transition(run_identity, 1, result)
+                self._store.record_blocker(run_identity, result)
+                self._store.finish_run(run_identity, result.status.value)
+                return result
+        except (OperationalStateUnavailable, RuntimeError):
+            if self._required:
+                return HostTransitionResult(
+                    HostTransitionStatus.INTERVENTION_REQUIRED,
+                    "OPERATIONAL_STORE_UNAVAILABLE",
+                )
+            return self._controller.run_once()
+
+        result = self._controller.run_once()
+        try:
+            self._store.record_transition(run_identity, 1, result)
+            if result.status is HostTransitionStatus.INTERVENTION_REQUIRED:
+                self._store.record_blocker(run_identity, result)
+            elif result.status is HostTransitionStatus.YIELD_EXTERNAL:
+                self._store.record_external_wait(run_identity, result)
+            self._store.finish_run(run_identity, result.status.value)
+            self._store.release_lease(self._project_key, run_identity)
+        except OperationalStateUnavailable:
+            if self._required:
+                return HostTransitionResult(
+                    HostTransitionStatus.INTERVENTION_REQUIRED,
+                    "OPERATIONAL_STORE_COMMIT_UNCERTAIN",
+                    result.work_issue,
+                    result.pr_number,
+                    result.head_sha,
+                )
+        return result
+
+    def _reconcile_previous(
+        self,
+        previous: UnfinishedRun,
+        fresh: HostTarget | None,
+    ) -> HostTransitionResult | None:
+        if previous.transition_status in _TERMINAL_RUN_STATUS:
+            self._store.finish_run(previous.run_identity, previous.transition_status)
+            self._store.release_lease(self._project_key, previous.run_identity)
+            return None
+
+        if _checkpoint_advanced(previous, fresh):
+            self._store.mark_reconciled(previous.run_identity)
+            self._store.release_lease(self._project_key, previous.run_identity)
+            return None
+
+        result = HostTransitionResult(
+            HostTransitionStatus.INTERVENTION_REQUIRED,
+            "OPERATIONAL_STATE_UNCERTAIN",
+            fresh.work_issue if fresh else previous.work_issue,
+            fresh.pr_number if fresh else previous.pr_number,
+            fresh.head_sha if fresh else previous.head_sha,
+        )
+        self._store.record_blocker(previous.run_identity, result)
+        return result
+
+
+def _checkpoint_advanced(previous: UnfinishedRun, fresh: HostTarget | None) -> bool:
+    if previous.checkpoint_revision is None:
+        return False
+    if fresh is None:
+        return False
+    return (
+        str(fresh.checkpoint_comment_id) != previous.checkpoint_revision
+        or fresh.work_issue != previous.work_issue
+        or fresh.pr_number != previous.pr_number
+        or fresh.head_sha != previous.head_sha
+    )
+
+
+def _result_target_identity(result: HostTransitionResult) -> str:
+    return (
+        f"work:{result.work_issue or '-'}|pr:{result.pr_number or '-'}|"
+        f"head:{result.head_sha or '-'}"
+    )
+
+
+def _literal(value: str) -> str:
+    if "\x00" in value or len(value) > 1024:
+        raise OperationalStateUnavailable("OPERATIONAL_VALUE_INVALID")
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _nullable_literal(value: str | None) -> str:
+    return "NULL" if value is None else _literal(value)
+
+
+def _nullable_int(value: int | None) -> str:
+    if value is None:
+        return "NULL"
+    if value < 0:
+        raise OperationalStateUnavailable("OPERATIONAL_VALUE_INVALID")
+    return str(value)
+
+
+def _row_string(row: dict[str, object], key: str) -> str | None:
+    value = row.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _row_int(row: dict[str, object], key: str) -> int | None:
+    value = row.get(key)
+    return value if isinstance(value, int) and not isinstance(value, bool) else None

--- a/src/loop_engineering/runtime_operational_state.py
+++ b/src/loop_engineering/runtime_operational_state.py
@@ -59,6 +59,13 @@ class OperationalStatePort(Protocol):
 
     def release_lease(self, project_key: str, run_identity: str) -> None: ...
 
+    def resolve_open_states(
+        self,
+        project_key: str,
+        repository: str,
+        current_run_identity: str,
+    ) -> None: ...
+
     def record_blocker(self, run_identity: str, result: HostTransitionResult) -> None: ...
 
     def record_external_wait(self, run_identity: str, result: HostTransitionResult) -> None: ...
@@ -209,14 +216,39 @@ class PostgreSQLRuntimeOperationalStore:
             "AND status = 'ACTIVE'"
         )
 
+    def resolve_open_states(
+        self,
+        project_key: str,
+        repository: str,
+        current_run_identity: str,
+    ) -> None:
+        project = _literal(project_key)
+        repo = _literal(repository)
+        current = _literal(current_run_identity)
+        prior_runs = (
+            "SELECT identity FROM loop_runs "
+            f"WHERE project_key = {project} AND repository = {repo} "
+            f"AND identity <> {current}"
+        )
+        self._execute(
+            "UPDATE loop_blockers SET status = 'RESOLVED', resolved_at = now() "
+            "WHERE status = 'OPEN' AND run_identity IN ("
+            f"{prior_runs})"
+        )
+        self._execute(
+            "UPDATE loop_external_waits SET status = 'RESOLVED', resolved_at = now() "
+            "WHERE status = 'OPEN' AND run_identity IN ("
+            f"{prior_runs})"
+        )
+
     def record_blocker(self, run_identity: str, result: HostTransitionResult) -> None:
         target = _result_target_identity(result)
         identity = f"blocker:{run_identity}:1"
         self._execute(
             "INSERT INTO loop_blockers "
-            "(identity, scope, subject_identity, kind, reason_code, status) VALUES ("
-            f"{_literal(identity)}, 'host-transition', {_literal(target)}, "
-            f"'INTERVENTION_REQUIRED', {_literal(result.detail)}, 'OPEN') "
+            "(identity, run_identity, scope, subject_identity, kind, reason_code, status) VALUES ("
+            f"{_literal(identity)}, {_literal(run_identity)}, 'host-transition', "
+            f"{_literal(target)}, 'INTERVENTION_REQUIRED', {_literal(result.detail)}, 'OPEN') "
             "ON CONFLICT (identity) DO UPDATE SET status = 'OPEN', resolved_at = NULL"
         )
 
@@ -225,8 +257,9 @@ class PostgreSQLRuntimeOperationalStore:
         identity = f"external-wait:{run_identity}:1"
         self._execute(
             "INSERT INTO loop_external_waits "
-            "(identity, kind, target_identity, status) VALUES ("
-            f"{_literal(identity)}, {_literal(result.detail)}, {_literal(target)}, 'OPEN') "
+            "(identity, run_identity, kind, target_identity, status) VALUES ("
+            f"{_literal(identity)}, {_literal(run_identity)}, {_literal(result.detail)}, "
+            f"{_literal(target)}, 'OPEN') "
             "ON CONFLICT (identity) DO UPDATE SET status = 'OPEN', resolved_at = NULL"
         )
 
@@ -296,6 +329,11 @@ class DurableHostTransitionCoordinator:
         result = self._controller.run_once()
         try:
             self._store.record_transition(run_identity, 1, result)
+            self._store.resolve_open_states(
+                self._project_key,
+                self._repository,
+                run_identity,
+            )
             if result.status is HostTransitionStatus.INTERVENTION_REQUIRED:
                 self._store.record_blocker(run_identity, result)
             elif result.status is HostTransitionStatus.YIELD_EXTERNAL:

--- a/src/loop_engineering/runtime_operational_state.py
+++ b/src/loop_engineering/runtime_operational_state.py
@@ -116,7 +116,8 @@ class PostgreSQLRuntimeOperationalStore:
     def begin_run(self, run_identity: str, project_key: str, repository: str) -> None:
         self._execute(
             "INSERT INTO loop_runs (identity, project_key, repository, status) VALUES ("
-            f"{_literal(run_identity)}, {_literal(project_key)}, {_literal(repository)}, 'RUNNING') "
+            f"{_literal(run_identity)}, {_literal(project_key)}, "
+            f"{_literal(repository)}, 'RUNNING') "
             "ON CONFLICT (identity) DO NOTHING"
         )
 
@@ -145,7 +146,8 @@ class PostgreSQLRuntimeOperationalStore:
         head_sha = target.head_sha if target is not None else None
         self._execute(
             "INSERT INTO loop_checkpoints "
-            "(identity, run_identity, project_key, work_issue, source_revision, pr_number, head_sha) "
+            "(identity, run_identity, project_key, work_issue, "
+            "source_revision, pr_number, head_sha) "
             "VALUES ("
             f"{_literal(identity)}, {_literal(run_identity)}, {_literal(project_key)}, "
             f"{_nullable_int(work_issue)}, {_nullable_literal(revision)}, "
@@ -166,7 +168,8 @@ class PostgreSQLRuntimeOperationalStore:
         identity = f"transition:{run_identity}:{sequence_number}"
         self._execute(
             "INSERT INTO loop_transitions "
-            "(identity, run_identity, sequence_number, status, detail, work_issue, pr_number, head_sha) "
+            "(identity, run_identity, sequence_number, status, detail, "
+            "work_issue, pr_number, head_sha) "
             "VALUES ("
             f"{_literal(identity)}, {_literal(run_identity)}, {sequence_number}, "
             f"{_literal(result.status.value)}, {_literal(result.detail)}, "

--- a/tests/loop_engineering/test_operational_state_check.py
+++ b/tests/loop_engineering/test_operational_state_check.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from loop_engineering.operational_state_check import check_operational_state_round_trip
+
+
+@dataclass(frozen=True)
+class Result:
+    succeeded: bool
+    output: str = ""
+
+
+class FakeDatabase:
+    def __init__(self, *, fail_write: bool = False) -> None:
+        self.fail_write = fail_write
+        self.rows: dict[str, dict[str, object]] = {}
+
+    def execute_sql(self, sql: str) -> bool:
+        if self.fail_write:
+            return False
+        if "INSERT INTO loop_runs" in sql:
+            identity = _between(sql, "VALUES ('", "', '")
+            values = sql.split("VALUES (", 1)[1].rsplit(")", 1)[0]
+            parts = [part.strip().strip("'") for part in values.split(",")]
+            self.rows[identity] = {
+                "identity": parts[0],
+                "project_key": parts[1],
+                "repository": parts[2],
+                "status": parts[3],
+            }
+        elif "UPDATE loop_runs SET status = 'COMPLETED'" in sql:
+            identity = _between(sql, "WHERE identity = '", "'")
+            self.rows[identity]["status"] = "COMPLETED"
+        return True
+
+    def query_json_rows(self, select_sql: str) -> list[dict[str, object]] | None:
+        identity = _between(select_sql, "WHERE identity = '", "'")
+        row = self.rows.get(identity)
+        return [dict(row)] if row is not None else []
+
+
+def _between(value: str, start: str, end: str) -> str:
+    return value.split(start, 1)[1].split(end, 1)[0]
+
+
+def test_round_trip_writes_reads_and_finalizes_without_product_effect() -> None:
+    database = FakeDatabase()
+
+    result = check_operational_state_round_trip(
+        database,  # type: ignore[arg-type]
+        project_key="ai-liver-yura",
+        repository="ktan514/ai-liver-yura",
+    )
+
+    assert result.succeeded
+    assert result.detail == "ROUND_TRIP_PASS"
+    assert len(database.rows) == 1
+    assert next(iter(database.rows.values()))["status"] == "COMPLETED"
+
+
+def test_round_trip_write_failure_is_typed() -> None:
+    database = FakeDatabase(fail_write=True)
+
+    result = check_operational_state_round_trip(
+        database,  # type: ignore[arg-type]
+        project_key="ai-liver-yura",
+        repository="ktan514/ai-liver-yura",
+    )
+
+    assert not result.succeeded
+    assert result.detail == "WRITE_FAILED"

--- a/tests/loop_engineering/test_operational_state_check.py
+++ b/tests/loop_engineering/test_operational_state_check.py
@@ -48,7 +48,10 @@ def test_round_trip_writes_reads_and_finalizes_without_product_effect() -> None:
     assert result.succeeded
     assert result.detail == "ROUND_TRIP_PASS"
     assert len(database.rows) == 1
-    assert next(iter(database.rows.values()))["status"] == "COMPLETED"
+    row = next(iter(database.rows.values()))
+    assert row["project_key"] == "health:ai-liver-yura"
+    assert row["repository"] == "ktan514/ai-liver-yura"
+    assert row["status"] == "COMPLETED"
 
 
 def test_round_trip_write_failure_is_typed() -> None:

--- a/tests/loop_engineering/test_operational_state_check.py
+++ b/tests/loop_engineering/test_operational_state_check.py
@@ -1,15 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
-
 from loop_engineering.operational_state_check import check_operational_state_round_trip
-
-
-@dataclass(frozen=True)
-class Result:
-    succeeded: bool
-    output: str = ""
 
 
 class FakeDatabase:
@@ -49,7 +40,7 @@ def test_round_trip_writes_reads_and_finalizes_without_product_effect() -> None:
     database = FakeDatabase()
 
     result = check_operational_state_round_trip(
-        database,  # type: ignore[arg-type]
+        database,
         project_key="ai-liver-yura",
         repository="ktan514/ai-liver-yura",
     )
@@ -64,7 +55,7 @@ def test_round_trip_write_failure_is_typed() -> None:
     database = FakeDatabase(fail_write=True)
 
     result = check_operational_state_round_trip(
-        database,  # type: ignore[arg-type]
+        database,
         project_key="ai-liver-yura",
         repository="ktan514/ai-liver-yura",
     )

--- a/tests/loop_engineering/test_runtime_operational_state.py
+++ b/tests/loop_engineering/test_runtime_operational_state.py
@@ -55,6 +55,7 @@ class FakeStore:
     transitions: list[HostTransitionResult] = field(default_factory=list)
     acquired: list[str] = field(default_factory=list)
     released: list[str] = field(default_factory=list)
+    resolved: list[tuple[str, str, str]] = field(default_factory=list)
     blockers: list[HostTransitionResult] = field(default_factory=list)
     waits: list[HostTransitionResult] = field(default_factory=list)
 
@@ -101,6 +102,14 @@ class FakeStore:
         del project_key
         self.released.append(run_identity)
 
+    def resolve_open_states(
+        self,
+        project_key: str,
+        repository: str,
+        current_run_identity: str,
+    ) -> None:
+        self.resolved.append((project_key, repository, current_run_identity))
+
     def record_blocker(self, run_identity: str, result: HostTransitionResult) -> None:
         del run_identity
         self.blockers.append(result)
@@ -145,6 +154,9 @@ def test_completed_transition_is_durably_recorded_and_lease_released() -> None:
     assert len(store.begun) == 1
     assert store.checkpoints[0][1] == observed
     assert store.transitions == [result]
+    assert store.resolved == [
+        ("ai-liver-yura", "ktan514/ai-liver-yura", store.begun[0])
+    ]
     assert store.finished[0][1] == "COMPLETED"
     assert store.released == store.acquired
 
@@ -174,6 +186,7 @@ def test_same_checkpoint_unfinished_run_blocks_duplicate_side_effect() -> None:
     assert actual.detail == "OPERATIONAL_STATE_UNCERTAIN"
     assert controller.calls == 0
     assert store.begun == []
+    assert store.resolved == []
     assert store.blockers[-1].detail == "OPERATIONAL_STATE_UNCERTAIN"
 
 
@@ -204,6 +217,7 @@ def test_advanced_github_checkpoint_reconciles_old_run_then_continues() -> None:
     assert store.reconciled == ["old-run"]
     assert "old-run" in store.released
     assert controller.calls == 1
+    assert len(store.resolved) == 1
     assert store.waits == [result]
 
 
@@ -233,6 +247,7 @@ def test_terminal_transition_on_unfinished_run_is_closed_without_duplicate() -> 
     assert ("old-run", "YIELD_EXTERNAL") in store.finished
     assert "old-run" in store.released
     assert controller.calls == 1
+    assert len(store.resolved) == 1
 
 
 def test_required_store_read_failure_fails_closed_before_controller() -> None:

--- a/tests/loop_engineering/test_runtime_operational_state.py
+++ b/tests/loop_engineering/test_runtime_operational_state.py
@@ -160,7 +160,12 @@ def test_same_checkpoint_unfinished_run_blocks_duplicate_side_effect() -> None:
         None,
     )
     mission = FakeMission(observed)
-    controller = FakeController(HostTransitionResult(HostTransitionStatus.COMPLETED, "SHOULD_NOT_RUN"))
+    controller = FakeController(
+        HostTransitionResult(
+            HostTransitionStatus.COMPLETED,
+            "SHOULD_NOT_RUN",
+        )
+    )
     store = FakeStore(previous=previous)
 
     actual = coordinator(mission, controller, store).run_once()
@@ -182,7 +187,13 @@ def test_advanced_github_checkpoint_reconciles_old_run_then_continues() -> None:
         None,
     )
     observed = target(checkpoint=124, head="b" * 40)
-    result = HostTransitionResult(HostTransitionStatus.YIELD_EXTERNAL, "CI_PENDING", 339, 500, "b" * 40)
+    result = HostTransitionResult(
+        HostTransitionStatus.YIELD_EXTERNAL,
+        "CI_PENDING",
+        339,
+        500,
+        "b" * 40,
+    )
     mission = FakeMission(observed)
     controller = FakeController(result)
     store = FakeStore(previous=previous)
@@ -205,7 +216,13 @@ def test_terminal_transition_on_unfinished_run_is_closed_without_duplicate() -> 
         "a" * 40,
         "YIELD_EXTERNAL",
     )
-    result = HostTransitionResult(HostTransitionStatus.YIELD_EXTERNAL, "CI_PENDING", 339, 500, "a" * 40)
+    result = HostTransitionResult(
+        HostTransitionStatus.YIELD_EXTERNAL,
+        "CI_PENDING",
+        339,
+        500,
+        "a" * 40,
+    )
     mission = FakeMission(target(checkpoint=123, head="a" * 40))
     controller = FakeController(result)
     store = FakeStore(previous=previous)
@@ -220,7 +237,12 @@ def test_terminal_transition_on_unfinished_run_is_closed_without_duplicate() -> 
 
 def test_required_store_read_failure_fails_closed_before_controller() -> None:
     mission = FakeMission(target())
-    controller = FakeController(HostTransitionResult(HostTransitionStatus.COMPLETED, "SHOULD_NOT_RUN"))
+    controller = FakeController(
+        HostTransitionResult(
+            HostTransitionStatus.COMPLETED,
+            "SHOULD_NOT_RUN",
+        )
+    )
     store = FakeStore(fail_on_latest=True)
 
     actual = coordinator(mission, controller, store).run_once()

--- a/tests/loop_engineering/test_runtime_operational_state.py
+++ b/tests/loop_engineering/test_runtime_operational_state.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from loop_engineering.host_runtime import HostTarget, HostTransitionResult, HostTransitionStatus
+from loop_engineering.runtime_operational_state import (
+    DurableHostTransitionCoordinator,
+    OperationalStateUnavailable,
+    UnfinishedRun,
+)
+
+
+def target(*, checkpoint: int = 100, head: str | None = None) -> HostTarget:
+    return HostTarget(
+        work_issue=339,
+        issue_open=True,
+        pr_number=500 if head is not None else None,
+        head_sha=head,
+        draft=False,
+        merged=False,
+        checkpoint_comment_id=checkpoint,
+        checkpoint_head_sha=head,
+    )
+
+
+@dataclass
+class FakeMission:
+    value: HostTarget | None
+    calls: int = 0
+
+    def current_target(self) -> HostTarget | None:
+        self.calls += 1
+        return self.value
+
+
+@dataclass
+class FakeController:
+    result: HostTransitionResult
+    calls: int = 0
+
+    def run_once(self) -> HostTransitionResult:
+        self.calls += 1
+        return self.result
+
+
+@dataclass
+class FakeStore:
+    previous: UnfinishedRun | None = None
+    lease_available: bool = True
+    fail_on_latest: bool = False
+    begun: list[str] = field(default_factory=list)
+    finished: list[tuple[str, str]] = field(default_factory=list)
+    reconciled: list[str] = field(default_factory=list)
+    checkpoints: list[tuple[str, HostTarget | None]] = field(default_factory=list)
+    transitions: list[HostTransitionResult] = field(default_factory=list)
+    acquired: list[str] = field(default_factory=list)
+    released: list[str] = field(default_factory=list)
+    blockers: list[HostTransitionResult] = field(default_factory=list)
+    waits: list[HostTransitionResult] = field(default_factory=list)
+
+    def latest_unfinished(self, project_key: str, repository: str) -> UnfinishedRun | None:
+        del project_key, repository
+        if self.fail_on_latest:
+            raise OperationalStateUnavailable("read failed")
+        return self.previous
+
+    def begin_run(self, run_identity: str, project_key: str, repository: str) -> None:
+        del project_key, repository
+        self.begun.append(run_identity)
+
+    def finish_run(self, run_identity: str, status: str) -> None:
+        self.finished.append((run_identity, status))
+
+    def mark_reconciled(self, run_identity: str) -> None:
+        self.reconciled.append(run_identity)
+
+    def record_checkpoint(
+        self,
+        run_identity: str,
+        project_key: str,
+        observed: HostTarget | None,
+    ) -> None:
+        del project_key
+        self.checkpoints.append((run_identity, observed))
+
+    def record_transition(
+        self,
+        run_identity: str,
+        sequence_number: int,
+        result: HostTransitionResult,
+    ) -> None:
+        del run_identity, sequence_number
+        self.transitions.append(result)
+
+    def acquire_lease(self, project_key: str, run_identity: str) -> bool:
+        del project_key
+        self.acquired.append(run_identity)
+        return self.lease_available
+
+    def release_lease(self, project_key: str, run_identity: str) -> None:
+        del project_key
+        self.released.append(run_identity)
+
+    def record_blocker(self, run_identity: str, result: HostTransitionResult) -> None:
+        del run_identity
+        self.blockers.append(result)
+
+    def record_external_wait(self, run_identity: str, result: HostTransitionResult) -> None:
+        del run_identity
+        self.waits.append(result)
+
+
+def coordinator(
+    mission: FakeMission,
+    controller: FakeController,
+    store: FakeStore,
+    *,
+    required: bool = True,
+) -> DurableHostTransitionCoordinator:
+    return DurableHostTransitionCoordinator(
+        project_key="ai-liver-yura",
+        repository="ktan514/ai-liver-yura",
+        mission=mission,
+        controller=controller,
+        store=store,
+        required=required,
+    )
+
+
+def test_completed_transition_is_durably_recorded_and_lease_released() -> None:
+    observed = target()
+    result = HostTransitionResult(
+        HostTransitionStatus.COMPLETED,
+        "IMPLEMENTER_DISPATCHED",
+        339,
+    )
+    mission = FakeMission(observed)
+    controller = FakeController(result)
+    store = FakeStore()
+
+    actual = coordinator(mission, controller, store).run_once()
+
+    assert actual == result
+    assert controller.calls == 1
+    assert len(store.begun) == 1
+    assert store.checkpoints[0][1] == observed
+    assert store.transitions == [result]
+    assert store.finished[0][1] == "COMPLETED"
+    assert store.released == store.acquired
+
+
+def test_same_checkpoint_unfinished_run_blocks_duplicate_side_effect() -> None:
+    observed = target(checkpoint=123, head="a" * 40)
+    previous = UnfinishedRun(
+        "old-run",
+        "123",
+        339,
+        500,
+        "a" * 40,
+        None,
+    )
+    mission = FakeMission(observed)
+    controller = FakeController(HostTransitionResult(HostTransitionStatus.COMPLETED, "SHOULD_NOT_RUN"))
+    store = FakeStore(previous=previous)
+
+    actual = coordinator(mission, controller, store).run_once()
+
+    assert actual.status is HostTransitionStatus.INTERVENTION_REQUIRED
+    assert actual.detail == "OPERATIONAL_STATE_UNCERTAIN"
+    assert controller.calls == 0
+    assert store.begun == []
+    assert store.blockers[-1].detail == "OPERATIONAL_STATE_UNCERTAIN"
+
+
+def test_advanced_github_checkpoint_reconciles_old_run_then_continues() -> None:
+    previous = UnfinishedRun(
+        "old-run",
+        "123",
+        339,
+        500,
+        "a" * 40,
+        None,
+    )
+    observed = target(checkpoint=124, head="b" * 40)
+    result = HostTransitionResult(HostTransitionStatus.YIELD_EXTERNAL, "CI_PENDING", 339, 500, "b" * 40)
+    mission = FakeMission(observed)
+    controller = FakeController(result)
+    store = FakeStore(previous=previous)
+
+    actual = coordinator(mission, controller, store).run_once()
+
+    assert actual == result
+    assert store.reconciled == ["old-run"]
+    assert "old-run" in store.released
+    assert controller.calls == 1
+    assert store.waits == [result]
+
+
+def test_terminal_transition_on_unfinished_run_is_closed_without_duplicate() -> None:
+    previous = UnfinishedRun(
+        "old-run",
+        "123",
+        339,
+        500,
+        "a" * 40,
+        "YIELD_EXTERNAL",
+    )
+    result = HostTransitionResult(HostTransitionStatus.YIELD_EXTERNAL, "CI_PENDING", 339, 500, "a" * 40)
+    mission = FakeMission(target(checkpoint=123, head="a" * 40))
+    controller = FakeController(result)
+    store = FakeStore(previous=previous)
+
+    actual = coordinator(mission, controller, store).run_once()
+
+    assert actual == result
+    assert ("old-run", "YIELD_EXTERNAL") in store.finished
+    assert "old-run" in store.released
+    assert controller.calls == 1
+
+
+def test_required_store_read_failure_fails_closed_before_controller() -> None:
+    mission = FakeMission(target())
+    controller = FakeController(HostTransitionResult(HostTransitionStatus.COMPLETED, "SHOULD_NOT_RUN"))
+    store = FakeStore(fail_on_latest=True)
+
+    actual = coordinator(mission, controller, store).run_once()
+
+    assert actual.status is HostTransitionStatus.INTERVENTION_REQUIRED
+    assert actual.detail == "OPERATIONAL_STORE_UNAVAILABLE"
+    assert controller.calls == 0
+
+
+def test_optional_store_read_failure_uses_existing_controller_path() -> None:
+    expected = HostTransitionResult(HostTransitionStatus.YIELD_EXTERNAL, "CI_PENDING")
+    mission = FakeMission(target())
+    controller = FakeController(expected)
+    store = FakeStore(fail_on_latest=True)
+
+    actual = coordinator(mission, controller, store, required=False).run_once()
+
+    assert actual == expected
+    assert controller.calls == 1


### PR DESCRIPTION
## 概要

#44後半として、PostgreSQL Operational Storeを実際のHost transitionへ接続します。

## 設計境界

- GitHub liveのIssue / PR / Project / branch / exact HEAD / CI / reviewがcurrent-state Authority
- PostgreSQLはRun / transition / observed checkpoint / blocker / external wait / execution leaseのOperational State
- DBだけからcurrent WorkやHEADを決めない

## 実装

- `runtime_state_reconciliation.md`でrestart reconcileを正本化
- `0003_runtime_reconciliation.sql`でcheckpoint / blocker / external waitをrunへ関連付け、索引を追加
- PostgreSQL command adapterへsecret-safeな内部SQL execute / JSON readback境界を追加
- 各Host遷移をdurable runとして記録
- fresh GitHub targetの最小snapshotをrun開始前に保存
- project単位execution leaseを取得・解放
- COMPLETED / YIELD_EXTERNAL / INTERVENTION_REQUIREDをtransitionへ保存
- YIELDをexternal wait、Interventionをblockerとして永続化
- 後続runで過去のOPEN blocker / external waitをRESOLVEDへ更新し、現在runの状態だけをOPENにする
- 前回runがterminal transition記録後にfinishだけ失敗していた場合は安全に閉じ直す
- 前回run未完了でもfresh GitHub checkpointが前進済みならstale Operational Stateとしてreconcile
- 前回run未完了かつ同一checkpointなら副作用成否不明として`OPERATIONAL_STATE_UNCERTAIN`で再送を停止
- `required = true`時のread/write failureはCodex/GitHub mutation前にfail-closed
- DB未設定optional経路は従来Host入口へ委譲
- `--operational-state-check`でProduct/GitHub/Codexを変更せずDB write/readbackを実機確認可能
- health checkは`health:<project-key>` namespaceへ隔離し、本番restart reconcileへ混入しない

## 非対象

- GitHub current-state AuthorityのDB化
- Product DB/Repositoryの変更
- Trusted Reviewer brokerの有効化

## 検証

Draftでexact-head CIを通し、current-head review後に実機で`0003` migration、Preflight、`--operational-state-check`を確認する。Product実装を起動する`--once`/continuous runは#44のDB-only確認完了後に#27の実運転として別Gateで行う。