### PR TITLE
#48 GitHub Project rate limitで停止せず自動再開する

### DIFF
--- a/docs/architecture/v2/github_project_rate_limit_contract.md
+++ b/docs/architecture/v2/github_project_rate_limit_contract.md
@@ -1,0 +1,79 @@
+# GitHub Project Rate Limit / External Wait Contract
+
+Owner Issue: #48
+Parent: #9
+運用Authority: #26
+
+## 1. 目的
+
+長時間のcontinuous runでGitHub Projects v2のGraphQL quotaが一時的に枯渇しても、認証・権限不備と誤分類して人間介入停止せず、安全なexternal waitを経てfresh readから自動再開する。
+
+GitHub live Issue / PR / Projectはcurrent-state Authorityのままとし、rate limit中にPostgreSQLや過去snapshotを現在状態の代替Authorityとして使用しない。
+
+## 2. Failure classification
+
+GitHub Project capability確認は次を区別する。
+
+- `AVAILABLE`: Projectをreadでき、必要なwrite authorityも確認できる
+- `RATE_LIMITED`: GitHub APIが明示的にrate limit exhaustionを返した
+- `UNAVAILABLE`: 認証、権限、Project identity、CLI、network等の理由で必要capabilityを証明できない
+
+`RATE_LIMITED`だけは一時的external waitとして扱う。`UNAVAILABLE`は従来どおりfail-closedで`INTERVENTION_REQUIRED`とする。
+
+## 3. Preflight request budget
+
+PreflightはProject contentsを取得する場所ではなくcapability gateである。
+
+各PreflightでProject read/writeを確認するために、同一Projectへ複数の`project view` / `field-list` / `item-list`を実行しない。`projectV2`の存在と`viewerCanUpdate`を取得する小さな単一GraphQL queryを使用する。
+
+Project item一覧はWork選択等、実際にProject current-stateが必要なtransitionでのみ取得する。同一Codex transition内ではfull item-listを原則1回だけfresh取得し、そのtransition内の照合に再利用する。
+
+## 4. Runtime transition
+
+PreflightでProject API rate limitを検出した場合:
+
+```text
+HostTransitionStatus.YIELD_EXTERNAL
+Detail = GITHUB_PROJECT_RATE_LIMIT
+```
+
+とする。
+
+- GitHub mutationを開始しない
+- Codexをdispatchしない
+- Product Workspaceを変更しない
+- Operational Storeには通常のexternal wait / transition evidenceとして記録可能
+- continuous CLIはbounded backoff後に新しいtransitionを開始し、必ずfresh Project readを再試行する
+
+rate limit以外の`GITHUB_PROJECT_READ` / `GITHUB_PROJECT_WRITE` failureは`PREFLIGHT_BLOCKED:*`のままにする。
+
+## 5. Backoff
+
+reset時刻を信頼できる形で取得できない場合でもbusy loopしない。continuous CLIはProject rate limit専用のbounded exponential backoffを使用する。
+
+初期値は5分、最大15分とする。成功した通常transition後は初期値へ戻す。
+
+## 6. Console
+
+構造ラベル・status・detailは英語を基本とし、人間向け説明を日本語にする。
+
+例:
+
+```text
+Transition 17: YIELD_EXTERNAL detail=GITHUB_PROJECT_RATE_LIMIT
+External Wait: GitHub Project API rate limitのため300秒後に再開します
+```
+
+正常なpredicate resultを`失敗`と誤表示する問題は別のconsole改善責務として扱う。
+
+## 7. Verification
+
+- Project capability probeがPreflightあたり1 GraphQL requestである
+- Project存在 + `viewerCanUpdate=true`でread/write PASS
+- `viewerCanUpdate=false`はwrite blocker
+- explicit API rate limitはtyped diagnosticとなる
+- rate limitはdurable hostで`YIELD_EXTERNAL`へ変換される
+- auth/permission/identity failureは`INTERVENTION_REQUIRED`のまま
+- continuous CLIがProject rate limitで自動再開する
+- retry時にfresh probeを実行する
+- Project cache / PostgreSQLだけでcurrent stateを代替しない

--- a/src/loop_engineering/__main__.py
+++ b/src/loop_engineering/__main__.py
@@ -13,6 +13,8 @@ from .runtime_console import RuntimeConsole, VisibleSubprocessLocalRunner
 
 _CI_RECHECK_INITIAL_SECONDS = 60.0
 _CI_RECHECK_MAX_SECONDS = 300.0
+_PROJECT_RECHECK_INITIAL_SECONDS = 300.0
+_PROJECT_RECHECK_MAX_SECONDS = 900.0
 _MAX_IDENTICAL_COMPLETED = 3
 
 
@@ -141,13 +143,14 @@ def main() -> int:
     runner = VisibleSubprocessLocalRunner(console)
     mode = "once" if arguments.once else "continuous"
     mode_label = "1回実行" if arguments.once else "継続実行"
-    console.event(f"開始 mode={mode}（{mode_label}） project={settings.project_key}")
-    console.event(f"設定: {settings.config_path}")
-    console.event(f"対象Workspace: {workspace_root}")
+    console.event(f"Start: mode={mode}（{mode_label}） project={settings.project_key}")
+    console.event(f"Config: {settings.config_path}")
+    console.event(f"Target Workspace: {workspace_root}")
     console.event(f"Mission Goal: {environment['LOOP_MISSION_GOAL_PATH']}")
-    console.event(f"ログ: {console.path}")
+    console.event(f"Log: {console.path}")
 
     ci_wait_seconds = _CI_RECHECK_INITIAL_SECONDS
+    project_wait_seconds = _PROJECT_RECHECK_INITIAL_SECONDS
     previous_completed: tuple[str, int | None, int | None, str | None] | None = None
     identical_completed = 0
     transition_number = 0
@@ -155,7 +158,7 @@ def main() -> int:
     try:
         while True:
             transition_number += 1
-            console.event(f"遷移 {transition_number}: 開始")
+            console.event(f"Transition {transition_number}: Start")
             transition_result = run_durable_actual_host_transition(
                 root=workspace_root,
                 environment=environment,
@@ -164,8 +167,8 @@ def main() -> int:
                 project_key=settings.project_key,
             )
             console.event(
-                f"遷移 {transition_number}: "
-                f"{transition_result.status.value} 詳細={transition_result.detail}"
+                f"Transition {transition_number}: "
+                f"{transition_result.status.value} detail={transition_result.detail}"
             )
 
             if arguments.once:
@@ -192,11 +195,12 @@ def main() -> int:
                         transition_result.pr_number,
                         transition_result.head_sha,
                     )
-                    console.event("進捗停止検知: 同一の完了遷移が繰り返されました")
+                    console.event("Progress Guard: 同一の完了遷移が繰り返されました")
                     print(blocked.as_json())
                     return 3
                 ci_wait_seconds = _CI_RECHECK_INITIAL_SECONDS
-                console.event("継続: 現在状態を再観測します")
+                project_wait_seconds = _PROJECT_RECHECK_INITIAL_SECONDS
+                console.event("Continue: 現在状態をfresh observeします")
                 continue
 
             previous_completed = None
@@ -207,7 +211,7 @@ def main() -> int:
                 and transition_result.detail == "CI_PENDING"
             ):
                 console.event(
-                    f"CI待機: {int(ci_wait_seconds)}秒後に自動再開します"
+                    f"CI Wait: {int(ci_wait_seconds)}秒後に自動再開します"
                 )
                 time.sleep(ci_wait_seconds)
                 ci_wait_seconds = min(
@@ -216,10 +220,25 @@ def main() -> int:
                 )
                 continue
 
+            if (
+                transition_result.status is HostTransitionStatus.YIELD_EXTERNAL
+                and transition_result.detail == "GITHUB_PROJECT_RATE_LIMIT"
+            ):
+                console.event(
+                    "External Wait: GitHub Project API rate limitのため"
+                    f"{int(project_wait_seconds)}秒後にfresh readから自動再開します"
+                )
+                time.sleep(project_wait_seconds)
+                project_wait_seconds = min(
+                    project_wait_seconds * 2,
+                    _PROJECT_RECHECK_MAX_SECONDS,
+                )
+                continue
+
             print(transition_result.as_json())
             return _exit_code(transition_result)
     except KeyboardInterrupt:
-        console.event("操作者の要求により停止します")
+        console.event("Operator Stop: 操作者の要求により停止します")
         return 130
 
 

--- a/src/loop_engineering/durable_host_entrypoint.py
+++ b/src/loop_engineering/durable_host_entrypoint.py
@@ -24,6 +24,7 @@ from .mission_goal import inject_mission_goal_environment
 from .postgres_runtime import PostgreSQLCommandAdapter
 from .preflight import (
     EnvironmentCapabilityPreflight,
+    PreflightResult,
     PreflightStatus,
     SubprocessCommandRunner,
 )
@@ -129,11 +130,10 @@ def run_durable_actual_host_transition(
     ).run_once()
 
 
-def _project_rate_limit_is_only_blocker(preflight: object) -> bool:
-    diagnostics = getattr(preflight, "diagnostics", ())
-    blockers = set(getattr(preflight, "blocking_for_loop_bootstrap", ()))
+def _project_rate_limit_is_only_blocker(preflight: PreflightResult) -> bool:
+    blockers = set(preflight.blocking_for_loop_bootstrap)
     return (
-        _PROJECT_RATE_LIMIT_DIAGNOSTIC in diagnostics
+        _PROJECT_RATE_LIMIT_DIAGNOSTIC in preflight.diagnostics
         and bool(blockers)
         and blockers <= _PROJECT_BLOCKERS
     )

--- a/src/loop_engineering/durable_host_entrypoint.py
+++ b/src/loop_engineering/durable_host_entrypoint.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import uuid
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -30,6 +31,8 @@ from .preflight import (
 )
 from .runtime_operational_state import (
     DurableHostTransitionCoordinator,
+    OperationalStatePort,
+    OperationalStateUnavailable,
     PostgreSQLRuntimeOperationalStore,
 )
 
@@ -78,6 +81,10 @@ def run_durable_actual_host_transition(
         repository=resolved_config.repository,
         environment=base_values,
     )
+    database = PostgreSQLCommandAdapter(SubprocessCommandRunner(), values)
+    store = PostgreSQLRuntimeOperationalStore(database)
+    resolved_project_key = project_key or resolved_config.repository
+
     preflight = EnvironmentCapabilityPreflight(
         resolved_config,
         SubprocessCommandRunner(),
@@ -86,10 +93,22 @@ def run_durable_actual_host_transition(
     ).run()
     if preflight.status is PreflightStatus.BLOCKED:
         if _project_rate_limit_is_only_blocker(preflight):
-            return HostTransitionResult(
+            wait_result = HostTransitionResult(
                 HostTransitionStatus.YIELD_EXTERNAL,
                 "GITHUB_PROJECT_RATE_LIMIT",
             )
+            if not _record_preflight_external_wait(
+                store,
+                project_key=resolved_project_key,
+                repository=resolved_config.repository,
+                result=wait_result,
+                required=required,
+            ):
+                return HostTransitionResult(
+                    HostTransitionStatus.INTERVENTION_REQUIRED,
+                    "OPERATIONAL_STORE_UNAVAILABLE",
+                )
+            return wait_result
         return HostTransitionResult(
             HostTransitionStatus.INTERVENTION_REQUIRED,
             "PREFLIGHT_BLOCKED:" + ",".join(preflight.blocking_for_loop_bootstrap),
@@ -118,10 +137,8 @@ def run_durable_actual_host_transition(
         mission,
         implementer,
     )
-    database = PostgreSQLCommandAdapter(SubprocessCommandRunner(), values)
-    store = PostgreSQLRuntimeOperationalStore(database)
     return DurableHostTransitionCoordinator(
-        project_key=project_key or resolved_config.repository,
+        project_key=resolved_project_key,
         repository=resolved_config.repository,
         mission=mission,
         controller=controller,
@@ -137,3 +154,22 @@ def _project_rate_limit_is_only_blocker(preflight: PreflightResult) -> bool:
         and bool(blockers)
         and blockers <= _PROJECT_BLOCKERS
     )
+
+
+def _record_preflight_external_wait(
+    store: OperationalStatePort,
+    *,
+    project_key: str,
+    repository: str,
+    result: HostTransitionResult,
+    required: bool,
+) -> bool:
+    run_identity = uuid.uuid4().hex
+    try:
+        store.begin_run(run_identity, project_key, repository)
+        store.record_transition(run_identity, 1, result)
+        store.record_external_wait(run_identity, result)
+        store.finish_run(run_identity, result.status.value)
+    except OperationalStateUnavailable:
+        return not required
+    return True

--- a/src/loop_engineering/durable_host_entrypoint.py
+++ b/src/loop_engineering/durable_host_entrypoint.py
@@ -32,6 +32,9 @@ from .runtime_operational_state import (
     PostgreSQLRuntimeOperationalStore,
 )
 
+_PROJECT_RATE_LIMIT_DIAGNOSTIC = "GITHUB_PROJECT_RATE_LIMITED"
+_PROJECT_BLOCKERS = {"GITHUB_PROJECT_READ", "GITHUB_PROJECT_WRITE"}
+
 
 def run_durable_actual_host_transition(
     *,
@@ -81,6 +84,11 @@ def run_durable_actual_host_transition(
         project_root=project_root,
     ).run()
     if preflight.status is PreflightStatus.BLOCKED:
+        if _project_rate_limit_is_only_blocker(preflight):
+            return HostTransitionResult(
+                HostTransitionStatus.YIELD_EXTERNAL,
+                "GITHUB_PROJECT_RATE_LIMIT",
+            )
         return HostTransitionResult(
             HostTransitionStatus.INTERVENTION_REQUIRED,
             "PREFLIGHT_BLOCKED:" + ",".join(preflight.blocking_for_loop_bootstrap),
@@ -119,3 +127,13 @@ def run_durable_actual_host_transition(
         store=store,
         required=required,
     ).run_once()
+
+
+def _project_rate_limit_is_only_blocker(preflight: object) -> bool:
+    diagnostics = getattr(preflight, "diagnostics", ())
+    blockers = set(getattr(preflight, "blocking_for_loop_bootstrap", ()))
+    return (
+        _PROJECT_RATE_LIMIT_DIAGNOSTIC in diagnostics
+        and bool(blockers)
+        and blockers <= _PROJECT_BLOCKERS
+    )

--- a/src/loop_engineering/durable_host_entrypoint.py
+++ b/src/loop_engineering/durable_host_entrypoint.py
@@ -6,6 +6,7 @@ import os
 import uuid
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Protocol
 
 from . import host_entrypoint
 from .config import LoopEngineConfig
@@ -31,13 +32,29 @@ from .preflight import (
 )
 from .runtime_operational_state import (
     DurableHostTransitionCoordinator,
-    OperationalStatePort,
     OperationalStateUnavailable,
     PostgreSQLRuntimeOperationalStore,
 )
 
 _PROJECT_RATE_LIMIT_DIAGNOSTIC = "GITHUB_PROJECT_RATE_LIMITED"
 _PROJECT_BLOCKERS = {"GITHUB_PROJECT_READ", "GITHUB_PROJECT_WRITE"}
+
+
+class PreflightWaitStore(Protocol):
+    """Preflightで外部待ちになった事実だけを永続化する最小Port。"""
+
+    def begin_run(self, run_identity: str, project_key: str, repository: str) -> None: ...
+
+    def record_transition(
+        self,
+        run_identity: str,
+        sequence_number: int,
+        result: HostTransitionResult,
+    ) -> None: ...
+
+    def record_external_wait(self, run_identity: str, result: HostTransitionResult) -> None: ...
+
+    def finish_run(self, run_identity: str, status: str) -> None: ...
 
 
 def run_durable_actual_host_transition(
@@ -157,7 +174,7 @@ def _project_rate_limit_is_only_blocker(preflight: PreflightResult) -> bool:
 
 
 def _record_preflight_external_wait(
-    store: OperationalStatePort,
+    store: PreflightWaitStore,
     *,
     project_key: str,
     repository: str,

--- a/src/loop_engineering/host_entrypoint.py
+++ b/src/loop_engineering/host_entrypoint.py
@@ -48,6 +48,8 @@ _NEXT_WORK_SELECTION_RE = re.compile(
     r"(?im)^.*?(?:next\s+action|次(?:の)?action|次の作業)(?:\s*(?:は|:))?\s*"
     r".*?(?:next\s+.*?Work|次.*?Work).*?(?:select|選択)"
 )
+_PROJECT_RATE_LIMIT_DIAGNOSTIC = "GITHUB_PROJECT_RATE_LIMITED"
+_PROJECT_BLOCKERS = {"GITHUB_PROJECT_READ", "GITHUB_PROJECT_WRITE"}
 
 
 class StrictGhMissionPort(GhMissionPort):
@@ -243,6 +245,8 @@ class PilotPlanningImplementer(CodexImplementer):
             f"{task}"
             "GitHubの現在状態、最新Mission Checkpoint、現在基幹、Repository正本、"
             "Work固有の再開確認と依存状態をfresh readしてください。"
+            "Projectのfull item-listが必要な場合は1遷移につき1回だけ取得し、"
+            "同じ遷移内ではそのfresh結果を再利用してください。"
             "設計→コード→テストの順序を守ってください。"
             "コードや文書内の人間向け文章は日本語で記述してください。"
             "Gitのbranch作成・切替・merge・add・commit・push・rebase・force pushは"
@@ -268,6 +272,7 @@ class PilotPlanningImplementer(CodexImplementer):
             f"統合Work #{integration} は基盤統合後の実製品試験証拠待ちです。"
             f"Project #{self._config.project_number}とGitHub上の現在Issue/PRをfresh readし、"
             "依存関係を満たした製品Workまたは統合Workを1件選択してください。"
+            "Projectのfull item-listはこの遷移で1回だけ取得し、同じfresh結果を再利用してください。"
             f"#{integration}自身とLoop Engineering基盤責務は試験候補から除外してください。"
             "依存関係を満たした製品Workが無い場合は、外部または依存待ちをCheckpointへ明示してください。"
             "Repositoryコード・設計file・branch・PRを変更せず、mergeやreviewも実行しないでください。"
@@ -460,6 +465,16 @@ def run_actual_host_transition(
         project_root=project_root,
     ).run()
     if preflight.status is PreflightStatus.BLOCKED:
+        blockers = set(preflight.blocking_for_loop_bootstrap)
+        if (
+            _PROJECT_RATE_LIMIT_DIAGNOSTIC in preflight.diagnostics
+            and bool(blockers)
+            and blockers <= _PROJECT_BLOCKERS
+        ):
+            return HostTransitionResult(
+                HostTransitionStatus.YIELD_EXTERNAL,
+                "GITHUB_PROJECT_RATE_LIMIT",
+            )
         return HostTransitionResult(
             HostTransitionStatus.INTERVENTION_REQUIRED,
             "PREFLIGHT_BLOCKED:" + ",".join(preflight.blocking_for_loop_bootstrap),

--- a/src/loop_engineering/preflight.py
+++ b/src/loop_engineering/preflight.py
@@ -28,8 +28,8 @@ class PreflightStatus(str, Enum):
 class CommandResult:
     succeeded: bool
     output: str = ""
-    error: str = ""
     timed_out: bool = False
+    error: str = ""
 
 
 class CommandRunner(Protocol):
@@ -68,7 +68,7 @@ class SubprocessCommandRunner:
         return CommandResult(
             result.returncode == 0,
             result.stdout,
-            result.stderr,
+            error=result.stderr,
         )
 
 

--- a/src/loop_engineering/preflight.py
+++ b/src/loop_engineering/preflight.py
@@ -28,6 +28,7 @@ class PreflightStatus(str, Enum):
 class CommandResult:
     succeeded: bool
     output: str = ""
+    error: str = ""
     timed_out: bool = False
 
 
@@ -55,7 +56,7 @@ class SubprocessCommandRunner:
                 check=False,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
                 text=True,
                 env=dict(environment) if environment is not None else None,
                 timeout=self._TIMEOUT_SECONDS,
@@ -64,7 +65,11 @@ class SubprocessCommandRunner:
             return CommandResult(False, timed_out=True)
         except OSError:
             return CommandResult(False)
-        return CommandResult(result.returncode == 0, result.stdout)
+        return CommandResult(
+            result.returncode == 0,
+            result.stdout,
+            result.stderr,
+        )
 
 
 class TrustedReviewerBrokerProbe(Protocol):
@@ -124,12 +129,15 @@ class EnvironmentCapabilityPreflight:
         self._reviewer_probe = reviewer_probe or UnixSocketTrustedReviewerBrokerProbe()
         self._project_root = (project_root or Path.cwd()).resolve(strict=False)
         self._timeouts: list[str] = []
+        self._github_project_rate_limited = False
 
     def run(self) -> PreflightResult:
         capability = self._command_capabilities()
         capability.update(self._workspace_capabilities())
         capability["github_repo_write"] = self._repository_write_allowed()
-        capability["github_project_write"] = self._project_write_allowed()
+        project_read, project_write = self._project_access()
+        capability["github_project_read"] = project_read
+        capability["github_project_write"] = project_write
         capability["mission_goal"] = self._mission_goal_matches()
         capability["project_venv"] = sys.prefix != sys.base_prefix
         capability["trusted_reviewer"] = self._reviewer_available()
@@ -185,37 +193,23 @@ class EnvironmentCapabilityPreflight:
             if scoped
             else PreflightStatus.PASS
         )
+        rate_limit_diagnostic = (
+            ("GITHUB_PROJECT_RATE_LIMITED",)
+            if self._github_project_rate_limited
+            else ()
+        )
         return PreflightResult(
             status,
             capability,
             blocking,
             scoped,
-            blocking + scoped + tuple(self._timeouts),
+            blocking + scoped + tuple(self._timeouts) + rate_limit_diagnostic,
         )
 
     def _command_capabilities(self) -> dict[str, bool]:
-        project = str(self._config.project_number)
-        owner = self._config.owner
         probes = {
             "github_cli": ("gh", "auth", "status"),
             "github_repo_read": ("gh", "repo", "view", self._config.repository),
-            "github_project_view": ("gh", "project", "view", project, "--owner", owner),
-            "github_project_fields": (
-                "gh",
-                "project",
-                "field-list",
-                project,
-                "--owner",
-                owner,
-            ),
-            "github_project_items": (
-                "gh",
-                "project",
-                "item-list",
-                project,
-                "--owner",
-                owner,
-            ),
             "python": (sys.executable, "--version"),
             "pytest": (sys.executable, "-m", "pytest", "--version"),
             "ruff": (sys.executable, "-m", "ruff", "--version"),
@@ -224,18 +218,9 @@ class EnvironmentCapabilityPreflight:
             "codex_cli": ("codex", "--version"),
             "docker": ("docker", "version"),
         }
-        capability = {
+        return {
             name: self._run(name, command).succeeded for name, command in probes.items()
         }
-        capability["github_project_read"] = all(
-            capability.pop(name)
-            for name in (
-                "github_project_view",
-                "github_project_fields",
-                "github_project_items",
-            )
-        )
-        return capability
 
     def _workspace_capabilities(self) -> dict[str, bool]:
         root = self._project_root
@@ -283,24 +268,29 @@ class EnvironmentCapabilityPreflight:
         except (KeyError, TypeError, json.JSONDecodeError):
             return False
 
-    def _project_write_allowed(self) -> bool:
+    def _project_access(self) -> tuple[bool, bool]:
         query = (
             "query { user(login: "
             f'"{self._config.owner}"'
             ") { projectV2(number: "
             f"{self._config.project_number}"
-            ") { viewerCanUpdate } } }"
+            ") { id viewerCanUpdate } } }"
         )
         result = self._run(
-            "github_project_write",
+            "github_project_access",
             ("gh", "api", "graphql", "-f", f"query={query}"),
         )
+        if not result.succeeded:
+            if _is_github_rate_limit(result):
+                self._github_project_rate_limited = True
+            return False, False
         try:
-            return result.succeeded and bool(
-                json.loads(result.output)["data"]["user"]["projectV2"]["viewerCanUpdate"]
-            )
+            project = json.loads(result.output)["data"]["user"]["projectV2"]
         except (KeyError, TypeError, json.JSONDecodeError):
-            return False
+            return False, False
+        if not isinstance(project, dict) or not isinstance(project.get("id"), str):
+            return False, False
+        return True, project.get("viewerCanUpdate") is True
 
     def _reviewer_available(self) -> bool:
         socket_path = self._environment.get("LOOP_TRUSTED_REVIEWER_SOCKET")
@@ -347,6 +337,14 @@ class EnvironmentCapabilityPreflight:
         if result.timed_out:
             self._timeouts.append(f"{name.upper()}_TIMEOUT")
         return result
+
+
+def _is_github_rate_limit(result: CommandResult) -> bool:
+    diagnostic = f"{result.output}\n{result.error}".lower()
+    return (
+        "api rate limit exceeded" in diagnostic
+        or "secondary rate limit" in diagnostic
+    )
 
 
 def _repository_from_remote(value: str) -> str | None:

--- a/src/loop_engineering/preflight.py
+++ b/src/loop_engineering/preflight.py
@@ -268,12 +268,14 @@ class EnvironmentCapabilityPreflight:
             return False
 
     def _project_access(self) -> tuple[bool, bool]:
+        owner = self._config.owner
+        number = self._config.project_number
         query = (
-            "query { user(login: "
-            f'"{self._config.owner}"'
-            ") { projectV2(number: "
-            f"{self._config.project_number}"
-            ") { viewerCanUpdate } } }"
+            "query { "
+            f'user(login: "{owner}") {{ projectV2(number: {number}) {{ viewerCanUpdate }} }} '
+            f'organization(login: "{owner}") '
+            f"{{ projectV2(number: {number}) {{ viewerCanUpdate }} }} "
+            "}"
         )
         result = self._run(
             "github_project_access",
@@ -284,12 +286,19 @@ class EnvironmentCapabilityPreflight:
                 self._github_project_rate_limited = True
             return False, False
         try:
-            project = json.loads(result.output)["data"]["user"]["projectV2"]
+            data = json.loads(result.output)["data"]
         except (KeyError, TypeError, json.JSONDecodeError):
             return False, False
-        if not isinstance(project, dict):
+        if not isinstance(data, dict):
             return False, False
-        return True, project.get("viewerCanUpdate") is True
+        for owner_kind in ("user", "organization"):
+            owner_value = data.get(owner_kind)
+            if not isinstance(owner_value, dict):
+                continue
+            project = owner_value.get("projectV2")
+            if isinstance(project, dict):
+                return True, project.get("viewerCanUpdate") is True
+        return False, False
 
     def _reviewer_available(self) -> bool:
         socket_path = self._environment.get("LOOP_TRUSTED_REVIEWER_SOCKET")

--- a/src/loop_engineering/preflight.py
+++ b/src/loop_engineering/preflight.py
@@ -55,8 +55,7 @@ class SubprocessCommandRunner:
                 command,
                 check=False,
                 stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                capture_output=True,
                 text=True,
                 env=dict(environment) if environment is not None else None,
                 timeout=self._TIMEOUT_SECONDS,
@@ -274,7 +273,7 @@ class EnvironmentCapabilityPreflight:
             f'"{self._config.owner}"'
             ") { projectV2(number: "
             f"{self._config.project_number}"
-            ") { id viewerCanUpdate } } }"
+            ") { viewerCanUpdate } } }"
         )
         result = self._run(
             "github_project_access",
@@ -288,7 +287,7 @@ class EnvironmentCapabilityPreflight:
             project = json.loads(result.output)["data"]["user"]["projectV2"]
         except (KeyError, TypeError, json.JSONDecodeError):
             return False, False
-        if not isinstance(project, dict) or not isinstance(project.get("id"), str):
+        if not isinstance(project, dict):
             return False, False
         return True, project.get("viewerCanUpdate") is True
 

--- a/tests/loop_engineering/test_cli.py
+++ b/tests/loop_engineering/test_cli.py
@@ -90,9 +90,9 @@ def test_once_cli_runs_one_actual_host_transition(
     assert '"status": "YIELD_EXTERNAL"' in output
     assert '"detail": "CI_PENDING"' in output
     assert received["verbose"] is False
-    assert events[0] == "開始 mode=once（1回実行） project=test-project"
-    assert "遷移 1: 開始" in events
-    assert events[-1] == "遷移 1: YIELD_EXTERNAL 詳細=CI_PENDING"
+    assert events[0] == "Start: mode=once（1回実行） project=test-project"
+    assert "Transition 1: Start" in events
+    assert events[-1] == "Transition 1: YIELD_EXTERNAL detail=CI_PENDING"
     assert received["root"] == Path("/product")
     assert received["config"] == config()
     assert "local_runner" in received
@@ -166,10 +166,63 @@ def test_default_cli_continues_completed_and_ci_pending_without_operator(
     assert output.count("\n") == 1
     assert '"detail": "HUMAN_VERIFICATION_PENDING"' in output
     assert sleeps == [60.0]
-    assert events[0] == "開始 mode=continuous（継続実行） project=test-project"
-    assert events.count("継続: 現在状態を再観測します") == 2
-    assert "CI待機: 60秒後に自動再開します" in events
-    assert "遷移 4: YIELD_EXTERNAL 詳細=HUMAN_VERIFICATION_PENDING" in events
+    assert events[0] == "Start: mode=continuous（継続実行） project=test-project"
+    assert events.count("Continue: 現在状態をfresh observeします") == 2
+    assert "CI Wait: 60秒後に自動再開します" in events
+    assert "Transition 4: YIELD_EXTERNAL detail=HUMAN_VERIFICATION_PENDING" in events
+
+
+def test_continuous_cli_retries_project_rate_limit_with_bounded_wait(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    events: list[str] = []
+    sleeps: list[float] = []
+    results = iter(
+        (
+            HostTransitionResult(
+                HostTransitionStatus.YIELD_EXTERNAL,
+                "GITHUB_PROJECT_RATE_LIMIT",
+            ),
+            HostTransitionResult(
+                HostTransitionStatus.YIELD_EXTERNAL,
+                "GITHUB_PROJECT_RATE_LIMIT",
+            ),
+            HostTransitionResult(
+                HostTransitionStatus.YIELD_EXTERNAL,
+                "HUMAN_VERIFICATION_PENDING",
+            ),
+        )
+    )
+
+    class FakeConsole:
+        def __init__(self, root: Path, *, verbose: bool = False) -> None:
+            del verbose
+            self.path = root / "test.log"
+
+        def event(self, message: str) -> None:
+            events.append(message)
+
+    class FakeRunner:
+        def __init__(self, console: object) -> None:
+            del console
+
+    def fake_transition(**kwargs: object) -> HostTransitionResult:
+        del kwargs
+        return next(results)
+
+    install_fake_settings(monkeypatch)
+    monkeypatch.setattr(cli, "RuntimeConsole", FakeConsole)
+    monkeypatch.setattr(cli, "VisibleSubprocessLocalRunner", FakeRunner)
+    monkeypatch.setattr(time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(
+        "loop_engineering.host_entrypoint.run_actual_host_transition", fake_transition
+    )
+    monkeypatch.setattr(sys, "argv", ["loop_engineering"])
+
+    assert cli.main() == 2
+    assert sleeps == [300.0, 600.0]
+    assert sum(event.startswith("External Wait:") for event in events) == 2
+    assert '"detail": "HUMAN_VERIFICATION_PENDING"' in capsys.readouterr().out
 
 
 def test_continuous_cli_stops_repeated_completed_no_progress(

--- a/tests/loop_engineering/test_github_project_rate_limit.py
+++ b/tests/loop_engineering/test_github_project_rate_limit.py
@@ -186,7 +186,7 @@ def test_preflight_external_wait_is_persisted_as_terminal_yield() -> None:
     )
 
     assert _record_preflight_external_wait(
-        store,  # type: ignore[arg-type]
+        store,
         project_key="ai-liver-yura",
         repository="ktan514/ai-liver-yura",
         result=result,
@@ -203,7 +203,7 @@ def test_required_store_failure_blocks_preflight_wait_recording() -> None:
     )
 
     assert not _record_preflight_external_wait(
-        WaitStore(fail=True),  # type: ignore[arg-type]
+        WaitStore(fail=True),
         project_key="ai-liver-yura",
         repository="ktan514/ai-liver-yura",
         result=result,

--- a/tests/loop_engineering/test_github_project_rate_limit.py
+++ b/tests/loop_engineering/test_github_project_rate_limit.py
@@ -3,13 +3,18 @@ import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
-from loop_engineering.durable_host_entrypoint import _project_rate_limit_is_only_blocker
+from loop_engineering.durable_host_entrypoint import (
+    _project_rate_limit_is_only_blocker,
+    _record_preflight_external_wait,
+)
+from loop_engineering.host_runtime import HostTransitionResult, HostTransitionStatus
 from loop_engineering.preflight import (
     CommandResult,
     EnvironmentCapabilityPreflight,
     PreflightResult,
     PreflightStatus,
 )
+from loop_engineering.runtime_operational_state import OperationalStateUnavailable
 
 from .conftest import config
 
@@ -41,7 +46,6 @@ class ProjectProbeRunner:
                         "data": {
                             "user": {
                                 "projectV2": {
-                                    "id": "PVT_test",
                                     "viewerCanUpdate": True,
                                 }
                             }
@@ -64,6 +68,35 @@ class ReviewerProbe:
     def check(self, socket_path: str, timeout_seconds: float) -> bool:
         del socket_path, timeout_seconds
         return True
+
+
+class WaitStore:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.events: list[tuple[str, str]] = []
+
+    def begin_run(self, run_identity: str, project_key: str, repository: str) -> None:
+        del project_key, repository
+        self.events.append(("begin", run_identity))
+        if self.fail:
+            raise OperationalStateUnavailable("test")
+
+    def record_transition(
+        self,
+        run_identity: str,
+        sequence_number: int,
+        result: HostTransitionResult,
+    ) -> None:
+        assert sequence_number == 1
+        self.events.append(("transition", f"{run_identity}:{result.detail}"))
+
+    def record_external_wait(
+        self, run_identity: str, result: HostTransitionResult
+    ) -> None:
+        self.events.append(("wait", f"{run_identity}:{result.detail}"))
+
+    def finish_run(self, run_identity: str, status: str) -> None:
+        self.events.append(("finish", f"{run_identity}:{status}"))
 
 
 def _environment(root: Path) -> dict[str, str]:
@@ -143,3 +176,36 @@ def test_only_project_rate_limit_blockers_are_external_wait_eligible() -> None:
 
     assert _project_rate_limit_is_only_blocker(rate_limited)
     assert not _project_rate_limit_is_only_blocker(mixed)
+
+
+def test_preflight_external_wait_is_persisted_as_terminal_yield() -> None:
+    store = WaitStore()
+    result = HostTransitionResult(
+        HostTransitionStatus.YIELD_EXTERNAL,
+        "GITHUB_PROJECT_RATE_LIMIT",
+    )
+
+    assert _record_preflight_external_wait(
+        store,  # type: ignore[arg-type]
+        project_key="ai-liver-yura",
+        repository="ktan514/ai-liver-yura",
+        result=result,
+        required=True,
+    )
+    assert [kind for kind, _ in store.events] == ["begin", "transition", "wait", "finish"]
+    assert store.events[-1][1].endswith(":YIELD_EXTERNAL")
+
+
+def test_required_store_failure_blocks_preflight_wait_recording() -> None:
+    result = HostTransitionResult(
+        HostTransitionStatus.YIELD_EXTERNAL,
+        "GITHUB_PROJECT_RATE_LIMIT",
+    )
+
+    assert not _record_preflight_external_wait(
+        WaitStore(fail=True),  # type: ignore[arg-type]
+        project_key="ai-liver-yura",
+        repository="ktan514/ai-liver-yura",
+        result=result,
+        required=True,
+    )

--- a/tests/loop_engineering/test_github_project_rate_limit.py
+++ b/tests/loop_engineering/test_github_project_rate_limit.py
@@ -1,0 +1,145 @@
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from loop_engineering.durable_host_entrypoint import _project_rate_limit_is_only_blocker
+from loop_engineering.preflight import (
+    CommandResult,
+    EnvironmentCapabilityPreflight,
+    PreflightResult,
+    PreflightStatus,
+)
+
+from .conftest import config
+
+
+class ProjectProbeRunner:
+    def __init__(self, root: Path, *, rate_limited: bool = False) -> None:
+        self.root = root
+        self.rate_limited = rate_limited
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(
+        self,
+        command: Sequence[str],
+        environment: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        del environment
+        call = tuple(command)
+        self.calls.append(call)
+        if call[:3] == ("gh", "api", "graphql"):
+            if self.rate_limited:
+                return CommandResult(
+                    False,
+                    error="GraphQL: API rate limit exceeded for user ID 1.",
+                )
+            return CommandResult(
+                True,
+                json.dumps(
+                    {
+                        "data": {
+                            "user": {
+                                "projectV2": {
+                                    "id": "PVT_test",
+                                    "viewerCanUpdate": True,
+                                }
+                            }
+                        }
+                    }
+                ),
+            )
+        if call == ("gh", "api", "repos/ktan514/ai-liver-yura"):
+            return CommandResult(True, json.dumps({"permissions": {"push": True}}))
+        if call[-2:] == ("rev-parse", "--show-toplevel"):
+            return CommandResult(True, str(self.root))
+        if call[-3:] == ("remote", "get-url", "origin"):
+            return CommandResult(True, "git@github.com:ktan514/ai-liver-yura.git")
+        if call[-2:] == ("rev-parse", "HEAD"):
+            return CommandResult(True, "a" * 40)
+        return CommandResult(True)
+
+
+class ReviewerProbe:
+    def check(self, socket_path: str, timeout_seconds: float) -> bool:
+        del socket_path, timeout_seconds
+        return True
+
+
+def _environment(root: Path) -> dict[str, str]:
+    goal = root / "docs" / "operations" / "loop_mission_goal.md"
+    goal.parent.mkdir(parents=True, exist_ok=True)
+    content = b"version: 2\ngeneration: 7\nmission\n"
+    goal.write_bytes(content)
+    return {
+        "LOOP_TRUSTED_REVIEWER_SOCKET": "/tmp/reviewer.sock",
+        "CODEX_MISSION_GOAL_GENERATION": "7",
+        "CODEX_MISSION_GOAL_VERSION": "2",
+        "CODEX_MISSION_GOAL_SHA256": hashlib.sha256(content).hexdigest(),
+    }
+
+
+def test_project_capability_uses_one_small_graphql_probe(tmp_path: Path) -> None:
+    runner = ProjectProbeRunner(tmp_path)
+    result = EnvironmentCapabilityPreflight(
+        config(),
+        runner,
+        _environment(tmp_path),
+        reviewer_probe=ReviewerProbe(),
+        project_root=tmp_path,
+    ).run()
+
+    graphql_calls = [call for call in runner.calls if call[:3] == ("gh", "api", "graphql")]
+    assert len(graphql_calls) == 1
+    assert result.capabilities["github_project_read"]
+    assert result.capabilities["github_project_write"]
+    assert not any(
+        len(call) >= 3
+        and call[:2] == ("gh", "project")
+        and call[2] in {"view", "field-list", "item-list"}
+        for call in runner.calls
+    )
+
+
+def test_project_rate_limit_is_typed_without_exposing_raw_error(tmp_path: Path) -> None:
+    runner = ProjectProbeRunner(tmp_path, rate_limited=True)
+    result = EnvironmentCapabilityPreflight(
+        config(),
+        runner,
+        _environment(tmp_path),
+        reviewer_probe=ReviewerProbe(),
+        project_root=tmp_path,
+    ).run()
+
+    assert not result.capabilities["github_project_read"]
+    assert not result.capabilities["github_project_write"]
+    assert "GITHUB_PROJECT_RATE_LIMITED" in result.diagnostics
+    assert "user ID 1" not in result.as_json()
+
+
+def test_only_project_rate_limit_blockers_are_external_wait_eligible() -> None:
+    rate_limited = PreflightResult(
+        PreflightStatus.BLOCKED,
+        {},
+        ("GITHUB_PROJECT_READ", "GITHUB_PROJECT_WRITE"),
+        (),
+        (
+            "GITHUB_PROJECT_READ",
+            "GITHUB_PROJECT_WRITE",
+            "GITHUB_PROJECT_RATE_LIMITED",
+        ),
+    )
+    mixed = PreflightResult(
+        PreflightStatus.BLOCKED,
+        {},
+        ("GITHUB_PROJECT_READ", "GITHUB_REPO_READ"),
+        (),
+        (
+            "GITHUB_PROJECT_READ",
+            "GITHUB_REPO_READ",
+            "GITHUB_PROJECT_RATE_LIMITED",
+        ),
+    )
+
+    assert _project_rate_limit_is_only_blocker(rate_limited)
+    assert not _project_rate_limit_is_only_blocker(mixed)

--- a/tests/loop_engineering/test_github_project_rate_limit.py
+++ b/tests/loop_engineering/test_github_project_rate_limit.py
@@ -3,6 +3,9 @@ import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
+from pytest import MonkeyPatch
+
+from loop_engineering import host_entrypoint
 from loop_engineering.durable_host_entrypoint import (
     _project_rate_limit_is_only_blocker,
     _record_preflight_external_wait,
@@ -112,6 +115,20 @@ def _environment(root: Path) -> dict[str, str]:
     }
 
 
+def _rate_limited_preflight() -> PreflightResult:
+    return PreflightResult(
+        PreflightStatus.BLOCKED,
+        {},
+        ("GITHUB_PROJECT_READ", "GITHUB_PROJECT_WRITE"),
+        (),
+        (
+            "GITHUB_PROJECT_READ",
+            "GITHUB_PROJECT_WRITE",
+            "GITHUB_PROJECT_RATE_LIMITED",
+        ),
+    )
+
+
 def test_project_capability_uses_one_small_graphql_probe(tmp_path: Path) -> None:
     runner = ProjectProbeRunner(tmp_path)
     result = EnvironmentCapabilityPreflight(
@@ -151,17 +168,7 @@ def test_project_rate_limit_is_typed_without_exposing_raw_error(tmp_path: Path) 
 
 
 def test_only_project_rate_limit_blockers_are_external_wait_eligible() -> None:
-    rate_limited = PreflightResult(
-        PreflightStatus.BLOCKED,
-        {},
-        ("GITHUB_PROJECT_READ", "GITHUB_PROJECT_WRITE"),
-        (),
-        (
-            "GITHUB_PROJECT_READ",
-            "GITHUB_PROJECT_WRITE",
-            "GITHUB_PROJECT_RATE_LIMITED",
-        ),
-    )
+    rate_limited = _rate_limited_preflight()
     mixed = PreflightResult(
         PreflightStatus.BLOCKED,
         {},
@@ -176,6 +183,33 @@ def test_only_project_rate_limit_blockers_are_external_wait_eligible() -> None:
 
     assert _project_rate_limit_is_only_blocker(rate_limited)
     assert not _project_rate_limit_is_only_blocker(mixed)
+
+
+def test_non_durable_host_maps_project_rate_limit_to_external_wait(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    class RateLimitedPreflight:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+
+        def run(self) -> PreflightResult:
+            return _rate_limited_preflight()
+
+    monkeypatch.setattr(host_entrypoint, "EnvironmentCapabilityPreflight", RateLimitedPreflight)
+    monkeypatch.setattr(
+        host_entrypoint,
+        "inject_mission_goal_environment",
+        lambda **kwargs: dict(kwargs["environment"]),
+    )
+
+    result = host_entrypoint.run_actual_host_transition(
+        root=tmp_path,
+        environment={},
+        config=config(),
+    )
+
+    assert result.status is HostTransitionStatus.YIELD_EXTERNAL
+    assert result.detail == "GITHUB_PROJECT_RATE_LIMIT"
 
 
 def test_preflight_external_wait_is_persisted_as_terminal_yield() -> None:

--- a/tests/loop_engineering/test_postgres_preflight_policy.py
+++ b/tests/loop_engineering/test_postgres_preflight_policy.py
@@ -34,7 +34,6 @@ class PolicyPreflight(EnvironmentCapabilityPreflight):
         return {
             "github_cli": True,
             "github_repo_read": True,
-            "github_project_read": True,
             "python": True,
             "pytest": True,
             "ruff": True,
@@ -56,8 +55,8 @@ class PolicyPreflight(EnvironmentCapabilityPreflight):
     def _repository_write_allowed(self) -> bool:
         return True
 
-    def _project_write_allowed(self) -> bool:
-        return True
+    def _project_access(self) -> tuple[bool, bool]:
+        return True, True
 
     def _mission_goal_matches(self) -> bool:
         return True


### PR DESCRIPTION
Issue #48 を実装します。

## Design → Code

先に `docs/architecture/v2/github_project_rate_limit_contract.md` でfailure classification / Project probe budget / External Wait / backoffを正本化しました。

## 変更

- PreflightのProject capability probeを複数の`gh project`取得から単一の小さなGraphQL queryへ縮約
- User / Organization Project ownerを同じ1 requestで解決
- stderrを外部へ露出せず内部分類に利用
- explicit GitHub API rate limitを`GITHUB_PROJECT_RATE_LIMITED`としてtyped診断
- durable / non-durable両Host経路でProject rate limitを`YIELD_EXTERNAL detail=GITHUB_PROJECT_RATE_LIMIT`へ変換
- durable経路ではPreflight external waitをOperational Storeへrun / transition / external waitとして記録
- continuous CLIは5分→最大15分のbounded backoffでfresh readから自動再開
- CodexへProject full item-listを同一遷移で重複取得しない指示を追加
- CLIの構造ラベルを `Start / Config / Target Workspace / Transition / Continue / CI Wait / External Wait` 等へ整理
- rate limit / Project request budget / DB evidence / non-durable host / CLI retryの回帰試験を追加

## Safety

- rate limit中にGitHub mutation/Codex dispatch/Product Workspace変更を行わない
- auth/permission/Project identity等の恒常failureは従来どおりfail-closed
- PostgreSQLや過去snapshotをGitHub current-state Authorityの代替にしない
- Operational Store required環境でwait evidenceを書けない場合はfail-closed

## Current exact-head verification

- HEAD: `2e2324afccb18cb6951a6c7f0d52e10af2bacc49`
- Loop Engineering Deterministic CI: `33299526560` SUCCESS
- exact head identity / Ruff / strict Mypy / full pytest / compileall / diff-check: PASS

current-head review blocking finding: 0