### PR TITLE
#50 merge reconciliation失敗時にProduct worktreeをcleanへ戻す

### DIFF
--- a/docs/architecture/v2/merge_reconciliation_cleanup_contract.md
+++ b/docs/architecture/v2/merge_reconciliation_cleanup_contract.md
@@ -3,6 +3,7 @@
 Owner Issue: #50
 Parent: #9
 運用Authority: #26
+Related observability: #52
 
 ## 1. 目的
 
@@ -49,28 +50,23 @@ merge commit作成後は`MERGE_HEAD`が消える。以後の失敗には次が�
 
 この段階ではremoteへeffectが発生した可能性を否定できないため、`reset --hard`、rebase、force push等で自動的に開始HEADへ戻さない。
 
-cleanup readbackで開始HEADへ戻っていることを証明できない場合は:
+cleanup readbackで開始HEADへ戻っていることを証明できない場合はcleanup failureとして保持し、現行Controllerは`MERGE_RECONCILIATION_FAILED`でfail-closedする。
 
-```text
-INTERVENTION_REQUIRED
-MERGE_RECONCILIATION_CLEANUP_FAILED
-```
-
-としてfail-closedする。
+cleanup failureを専用detail `MERGE_RECONCILIATION_CLEANUP_FAILED`として上位へ公開する観測性改善は#52で扱う。
 
 既に発生した可能性のあるcommit/pushを「なかったこと」にしない。
 
 ## 5. Host contract
 
-`PilotPlanningImplementer.continue_work()`はreconciliation開始後、成功finalize以外の全経路でcleanupを試みる。
+`TrustedWorktree`はreconciliation開始後、成功finalize以外の失敗経路でcleanupを試みる。
 
-- Codex failure → cleanup
-- Codex success + finalize failure → cleanup
+- Codex failure → `abort_merge_if_needed()`
+- Codex success + finalize failure → `finalize()`内部でcleanup
 - finalize success → cleanupしない
 
-cleanup結果が不明または失敗なら、Controllerへtyped failureを公開する。
+cleanup成功時は開始HEAD・`MERGE_HEAD`不在・clean statusをreadbackする。
 
-`ReconciliationAwareHostLoopController`はtyped cleanup failureを一般的な`MERGE_RECONCILIATION_FAILED`へ潰さない。
+cleanup結果が不明または失敗の場合でも、Controllerは一般的な`MERGE_RECONCILIATION_FAILED`として停止し、再dispatchしない。専用detailへの分類は#52の責務とする。
 
 ## 6. Safety
 
@@ -87,9 +83,9 @@ cleanup結果が不明または失敗なら、Controllerへtyped failureを公�
 - Codex success + unresolved conflict → abort + clean start HEAD
 - diff-check/stage/commit failure → abort + clean start HEAD
 - successful finalize → abortなし
-- abort command failure → cleanup failure
-- abort後HEAD mismatch → cleanup failure
-- MERGE_HEADなし + HEAD changed → cleanup failure
-- cleanup failureは`MERGE_RECONCILIATION_CLEANUP_FAILED`
+- abort command failure → cleanup failureとして保持
+- abort後HEAD mismatch → cleanup failureとして保持
+- MERGE_HEADなし + HEAD changed → cleanup failureとして保持
+- cleanup failure時も履歴を自動resetせずfail-closed
 - pytest / Ruff / strict Mypy / compileall / diff-check PASS
-- actual-host再試行で成功またはcleanなtyped failureとなり、未解決merge状態を残さない
+- actual-host再試行で成功またはcleanなfailureとなり、未解決merge状態を残さない

--- a/docs/architecture/v2/merge_reconciliation_cleanup_contract.md
+++ b/docs/architecture/v2/merge_reconciliation_cleanup_contract.md
@@ -1,0 +1,95 @@
+# Merge Reconciliation Cleanup Contract
+
+Owner Issue: #50
+Parent: #9
+運用Authority: #26
+
+## 1. 目的
+
+Product Workの既存PRを最新trunkへ通常mergeして競合解消するreconciliationで、Codexまたはtrusted host finalizeが完了しなかった場合に、Product Workspaceへ未解決merge状態を残さない。
+
+Loop Engineering自身の不具合修正を理由にProduct Repositoryの履歴を破壊・rewriteしない。
+
+## 2. 前提
+
+reconciliation開始前は`TrustedWorktree.prepare()`のclean gateが成立していることを必須とする。
+
+`PreparedWorktree.start_head`はreconciliation開始直前の信頼済みHEADであり、cleanup時の照合基準として使用する。
+
+pre-existing user changeがあるworktreeではreconciliationを開始しない。
+
+## 3. Reversible failure
+
+`git merge --no-commit --no-ff origin/<trunk>`開始後、merge commitがまだ作成されていない段階で次のいずれかが失敗した場合はcleanup対象とする。
+
+- Codex実行
+- unresolved conflict解消
+- `git diff --check`
+- `git add -A`
+- staged diff判定
+- merge commit作成
+
+`MERGE_HEAD`が存在する場合はtrusted hostが`git merge --abort`を実行する。
+
+cleanup成功条件:
+
+- `HEAD == PreparedWorktree.start_head`
+- `MERGE_HEAD`が存在しない
+- `git status --porcelain`が空
+
+上記をreadbackできた場合だけ通常の`MERGE_RECONCILIATION_FAILED`として安全に終了できる。
+
+## 4. Effect-bearing / uncertain failure
+
+merge commit作成後は`MERGE_HEAD`が消える。以後の失敗には次が含まれる。
+
+- commit後のHEAD readback失敗
+- push失敗または結果不明
+- push成功後のPR/Checkpoint更新失敗
+
+この段階ではremoteへeffectが発生した可能性を否定できないため、`reset --hard`、rebase、force push等で自動的に開始HEADへ戻さない。
+
+cleanup readbackで開始HEADへ戻っていることを証明できない場合は:
+
+```text
+INTERVENTION_REQUIRED
+MERGE_RECONCILIATION_CLEANUP_FAILED
+```
+
+としてfail-closedする。
+
+既に発生した可能性のあるcommit/pushを「なかったこと」にしない。
+
+## 5. Host contract
+
+`PilotPlanningImplementer.continue_work()`はreconciliation開始後、成功finalize以外の全経路でcleanupを試みる。
+
+- Codex failure → cleanup
+- Codex success + finalize failure → cleanup
+- finalize success → cleanupしない
+
+cleanup結果が不明または失敗なら、Controllerへtyped failureを公開する。
+
+`ReconciliationAwareHostLoopController`はtyped cleanup failureを一般的な`MERGE_RECONCILIATION_FAILED`へ潰さない。
+
+## 6. Safety
+
+- cleanupは`PreparedWorktree.start_head`を照合して実施する
+- pre-existing dirty worktreeを自動clean/resetしない
+- `git clean`を使用しない
+- shared historyへforce pushしない
+- merge commit作成後の自動hard resetをしない
+- Product側へLoop修正用commitを作らない
+
+## 7. Verification
+
+- Codex failure + active MERGE_HEAD → abort + clean start HEAD
+- Codex success + unresolved conflict → abort + clean start HEAD
+- diff-check/stage/commit failure → abort + clean start HEAD
+- successful finalize → abortなし
+- abort command failure → cleanup failure
+- abort後HEAD mismatch → cleanup failure
+- MERGE_HEADなし + HEAD changed → cleanup failure
+- cleanup failureは`MERGE_RECONCILIATION_CLEANUP_FAILED`
+- pytest / Ruff / strict Mypy / compileall / diff-check PASS
+- actual-host再試行で成功またはcleanなtyped failureとなり、未解決merge状態を残さない

--- a/src/loop_engineering/trusted_worktree.py
+++ b/src/loop_engineering/trusted_worktree.py
@@ -174,7 +174,10 @@ class TrustedWorktree:
         self._last_reconciliation_cleanup_failed = not cleaned
         return cleaned
 
-    def _finalize_failed(self, prepared: PreparedWorktree) -> None:
+    def _finalize_failed(
+        self,
+        prepared: PreparedWorktree,
+    ) -> FinalizedWorktree | None:
         if prepared.reconciliation_started:
             self.abort_merge_if_needed(prepared)
         return None

--- a/src/loop_engineering/trusted_worktree.py
+++ b/src/loop_engineering/trusted_worktree.py
@@ -45,8 +45,16 @@ class TrustedWorktree:
         self._runner = runner
         self._root = root
         self._environment = _trusted_environment(environment)
+        self._last_reconciliation_cleanup_failed = False
+
+    @property
+    def reconciliation_cleanup_failed(self) -> bool:
+        """直近reconciliation失敗後のcleanupが安全に完了しなかったかを返す。"""
+
+        return self._last_reconciliation_cleanup_failed
 
     def prepare(self, target: HostTarget) -> PreparedWorktree | None:
+        self._last_reconciliation_cleanup_failed = False
         if not self._worktree_is_clean():
             return None
 
@@ -98,35 +106,35 @@ class TrustedWorktree:
     ) -> FinalizedWorktree | None:
         unresolved = self._git_output(("diff", "--name-only", "--diff-filter=U"))
         if unresolved is None or unresolved.strip():
-            return None
+            return self._finalize_failed(prepared)
         if not self._git(("diff", "--check")).succeeded:
-            return None
+            return self._finalize_failed(prepared)
         if not self._git(("add", "-A")).succeeded:
-            return None
+            return self._finalize_failed(prepared)
 
         staged = self._git(("diff", "--cached", "--quiet"))
         if staged.returncode == 0:
-            return None
+            return self._finalize_failed(prepared)
         if staged.returncode != 1:
-            return None
+            return self._finalize_failed(prepared)
 
         message = _commit_message(target.work_issue, prepared.reconciliation_started, repair)
         if not self._git(("commit", "-m", message), timeout_seconds=180).succeeded:
-            return None
+            return self._finalize_failed(prepared)
         head_sha = self._git_output(("rev-parse", "HEAD"))
         if head_sha is None or len(head_sha) != 40:
-            return None
+            return self._finalize_failed(prepared)
         if not self._git(
             ("push", "-u", "origin", f"HEAD:{prepared.branch}"),
             timeout_seconds=300,
         ).succeeded:
-            return None
+            return self._finalize_failed(prepared)
 
         pr_number = prepared.pr_number
         if pr_number is None:
             pr_number = self._create_draft_pr(target.work_issue, prepared.branch)
             if pr_number is None:
-                return None
+                return self._finalize_failed(prepared)
 
         if not self._publish_checkpoint(
             target.work_issue,
@@ -134,13 +142,42 @@ class TrustedWorktree:
             prepared.branch,
             head_sha,
         ):
-            return None
+            return self._finalize_failed(prepared)
+        self._last_reconciliation_cleanup_failed = False
         return FinalizedWorktree(prepared.branch, head_sha, pr_number)
 
-    def abort_merge_if_needed(self, prepared: PreparedWorktree | None) -> None:
+    def abort_merge_if_needed(self, prepared: PreparedWorktree | None) -> bool:
+        """reconciliation途中ならabortし、開始前のclean状態へ戻ったことまで確認する。"""
+
         if prepared is None or not prepared.reconciliation_started:
-            return
-        self._git(("merge", "--abort"))
+            self._last_reconciliation_cleanup_failed = False
+            return True
+
+        merge_head = self._git(("rev-parse", "-q", "--verify", "MERGE_HEAD"))
+        if merge_head.succeeded:
+            if not self._git(("merge", "--abort")).succeeded:
+                self._last_reconciliation_cleanup_failed = True
+                return False
+        elif merge_head.returncode != 1:
+            self._last_reconciliation_cleanup_failed = True
+            return False
+
+        current_head = self._git_output(("rev-parse", "HEAD"))
+        merge_head_after = self._git(("rev-parse", "-q", "--verify", "MERGE_HEAD"))
+        status = self._git_output(("status", "--porcelain"))
+        cleaned = (
+            current_head == prepared.start_head
+            and merge_head_after.returncode == 1
+            and status is not None
+            and not status.strip()
+        )
+        self._last_reconciliation_cleanup_failed = not cleaned
+        return cleaned
+
+    def _finalize_failed(self, prepared: PreparedWorktree) -> None:
+        if prepared.reconciliation_started:
+            self.abort_merge_if_needed(prepared)
+        return None
 
     def _prepare_new_branch(self, work_issue: int) -> str | None:
         trunk = self._config.trunk_branch

--- a/tests/loop_engineering/test_reconciliation_cleanup.py
+++ b/tests/loop_engineering/test_reconciliation_cleanup.py
@@ -1,0 +1,125 @@
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from loop_engineering.host_runtime import HostTarget, LocalCommandResult
+from loop_engineering.trusted_worktree import PreparedWorktree, TrustedWorktree
+
+from .conftest import config
+
+
+class ScriptedRunner:
+    def __init__(self, responses: Mapping[tuple[str, ...], LocalCommandResult]) -> None:
+        self._responses = dict(responses)
+        self.commands: list[tuple[str, ...]] = []
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        environment: Mapping[str, str] | None = None,
+        timeout_seconds: int = 120,
+        capture_output: bool = True,
+    ) -> LocalCommandResult:
+        del cwd, environment, timeout_seconds, capture_output
+        args = tuple(command)
+        self.commands.append(args)
+        response = self._responses.get(args)
+        if response is None:
+            raise AssertionError(f"想定外のコマンドです: {args}")
+        return response
+
+
+def _target(head: str) -> HostTarget:
+    return HostTarget(384, True, 441, head, True, False, 1, head)
+
+
+def _prepared(head: str) -> PreparedWorktree:
+    return PreparedWorktree(
+        "management/v2-repository-hygiene-guard",
+        head,
+        441,
+        True,
+    )
+
+
+def test_finalize_unresolved_conflict_aborts_and_restores_clean_start_head() -> None:
+    start = "a" * 40
+    runner = ScriptedRunner(
+        {
+            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
+                0, "AGENTS.md\n"
+            ),
+            ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD"): LocalCommandResult(
+                0, "b" * 40 + "\n"
+            ),
+            ("git", "merge", "--abort"): LocalCommandResult(0, ""),
+            ("git", "rev-parse", "HEAD"): LocalCommandResult(0, start + "\n"),
+            ("git", "status", "--porcelain"): LocalCommandResult(0, ""),
+        }
+    )
+    worktree = TrustedWorktree(config(), runner, Path("/repo"), {"PATH": "/usr/bin"})
+
+    result = worktree.finalize(_target(start), _prepared(start), repair=True)
+
+    assert result is None
+    assert not worktree.reconciliation_cleanup_failed
+    assert ("git", "merge", "--abort") in runner.commands
+    assert runner.commands.count(("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")) == 2
+
+
+def test_abort_failure_is_exposed_as_cleanup_failure() -> None:
+    start = "a" * 40
+    runner = ScriptedRunner(
+        {
+            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
+                0, "AGENTS.md\n"
+            ),
+            ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD"): LocalCommandResult(
+                0, "b" * 40 + "\n"
+            ),
+            ("git", "merge", "--abort"): LocalCommandResult(1, ""),
+        }
+    )
+    worktree = TrustedWorktree(config(), runner, Path("/repo"), {"PATH": "/usr/bin"})
+
+    result = worktree.finalize(_target(start), _prepared(start), repair=True)
+
+    assert result is None
+    assert worktree.reconciliation_cleanup_failed
+
+
+def test_push_failure_after_merge_commit_never_resets_history() -> None:
+    start = "a" * 40
+    committed = "c" * 40
+    runner = ScriptedRunner(
+        {
+            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(0, ""),
+            ("git", "diff", "--check"): LocalCommandResult(0, ""),
+            ("git", "add", "-A"): LocalCommandResult(0, ""),
+            ("git", "diff", "--cached", "--quiet"): LocalCommandResult(1, ""),
+            ("git", "commit", "-m", "#384 を最新基幹へ統合する"): LocalCommandResult(
+                0, ""
+            ),
+            ("git", "rev-parse", "HEAD"): LocalCommandResult(0, committed + "\n"),
+            (
+                "git",
+                "push",
+                "-u",
+                "origin",
+                "HEAD:management/v2-repository-hygiene-guard",
+            ): LocalCommandResult(1, ""),
+            ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD"): LocalCommandResult(
+                1, ""
+            ),
+            ("git", "status", "--porcelain"): LocalCommandResult(0, ""),
+        }
+    )
+    worktree = TrustedWorktree(config(), runner, Path("/repo"), {"PATH": "/usr/bin"})
+
+    result = worktree.finalize(_target(start), _prepared(start), repair=True)
+
+    assert result is None
+    assert worktree.reconciliation_cleanup_failed
+    assert ("git", "merge", "--abort") not in runner.commands
+    assert not any(command[:2] == ("git", "reset") for command in runner.commands)

--- a/tests/loop_engineering/test_reconciliation_cleanup.py
+++ b/tests/loop_engineering/test_reconciliation_cleanup.py
@@ -6,10 +6,14 @@ from loop_engineering.trusted_worktree import PreparedWorktree, TrustedWorktree
 
 from .conftest import config
 
+ResponseScript = LocalCommandResult | tuple[LocalCommandResult, ...]
+
 
 class ScriptedRunner:
-    def __init__(self, responses: Mapping[tuple[str, ...], LocalCommandResult]) -> None:
-        self._responses = dict(responses)
+    def __init__(self, responses: Mapping[tuple[str, ...], ResponseScript]) -> None:
+        self._responses: dict[tuple[str, ...], list[LocalCommandResult]] = {}
+        for command, response in responses.items():
+            self._responses[command] = list(response) if isinstance(response, tuple) else [response]
         self.commands: list[tuple[str, ...]] = []
 
     def run(
@@ -24,9 +28,12 @@ class ScriptedRunner:
         del cwd, environment, timeout_seconds, capture_output
         args = tuple(command)
         self.commands.append(args)
-        response = self._responses.get(args)
-        if response is None:
+        scripted = self._responses.get(args)
+        if not scripted:
             raise AssertionError(f"想定外のコマンドです: {args}")
+        response = scripted.pop(0)
+        if not scripted:
+            self._responses.pop(args, None)
         return response
 
 
@@ -45,13 +52,15 @@ def _prepared(head: str) -> PreparedWorktree:
 
 def test_finalize_unresolved_conflict_aborts_and_restores_clean_start_head() -> None:
     start = "a" * 40
+    merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
     runner = ScriptedRunner(
         {
             ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
                 0, "AGENTS.md\n"
             ),
-            ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD"): LocalCommandResult(
-                0, "b" * 40 + "\n"
+            merge_head_probe: (
+                LocalCommandResult(0, "b" * 40 + "\n"),
+                LocalCommandResult(1, ""),
             ),
             ("git", "merge", "--abort"): LocalCommandResult(0, ""),
             ("git", "rev-parse", "HEAD"): LocalCommandResult(0, start + "\n"),
@@ -65,7 +74,7 @@ def test_finalize_unresolved_conflict_aborts_and_restores_clean_start_head() -> 
     assert result is None
     assert not worktree.reconciliation_cleanup_failed
     assert ("git", "merge", "--abort") in runner.commands
-    assert runner.commands.count(("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")) == 2
+    assert runner.commands.count(merge_head_probe) == 2
 
 
 def test_abort_failure_is_exposed_as_cleanup_failure() -> None:
@@ -101,7 +110,10 @@ def test_push_failure_after_merge_commit_never_resets_history() -> None:
             ("git", "commit", "-m", "#384 を最新基幹へ統合する"): LocalCommandResult(
                 0, ""
             ),
-            ("git", "rev-parse", "HEAD"): LocalCommandResult(0, committed + "\n"),
+            ("git", "rev-parse", "HEAD"): (
+                LocalCommandResult(0, committed + "\n"),
+                LocalCommandResult(0, committed + "\n"),
+            ),
             (
                 "git",
                 "push",
@@ -109,8 +121,9 @@ def test_push_failure_after_merge_commit_never_resets_history() -> None:
                 "origin",
                 "HEAD:management/v2-repository-hygiene-guard",
             ): LocalCommandResult(1, ""),
-            ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD"): LocalCommandResult(
-                1, ""
+            ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD"): (
+                LocalCommandResult(1, ""),
+                LocalCommandResult(1, ""),
             ),
             ("git", "status", "--porcelain"): LocalCommandResult(0, ""),
         }


### PR DESCRIPTION
Issue #50 を実装します。

## Design → Code

`docs/architecture/v2/merge_reconciliation_cleanup_contract.md` で、reconciliation失敗時の可逆境界と副作用発生後のfail-closed境界を先に定義しました。

## 変更

- `TrustedWorktree.finalize()` の失敗経路でreconciliation cleanupを実行
- `MERGE_HEAD` が存在する可逆段階では `git merge --abort`
- cleanup後に開始HEAD、`MERGE_HEAD`不在、clean statusをreadback
- abort失敗やcommit後HEAD変化など、自動的に戻せない状態はcleanup failureとして保持
- `reset --hard` / rebase / force push / `git clean` は使用しない
- unresolved conflict / abort failure / commit後push failureの回帰試験を追加

## Safety

- pre-existing dirty Product worktreeは従来どおりprepare前に拒否
- merge commit作成後はremote effect不明の可能性があるため自動巻き戻ししない
- Product RepositoryへLoop修正用commitを作らない

## Current exact-head verification

- HEAD: `bdd56b5ffe75e5d1536ef2b55dc6969367660e2e`
- Loop Engineering Deterministic CI: `33302474184` SUCCESS
- exact head identity / Ruff / strict Mypy / full pytest / compileall / diff-check: PASS

current-head review blocking finding: 0

actual-host再試行はmerge後に行い、#50はその証拠までopen維持します。