### PR TITLE
#53 Project owner判定をrepositoryOwnerへ修正する

### DIFF
--- a/docs/architecture/v2/github_project_owner_resolution_contract.md
+++ b/docs/architecture/v2/github_project_owner_resolution_contract.md
@@ -1,0 +1,66 @@
+# GitHub Project Owner Resolution Contract
+
+Owner Issue: #53
+Parent: #9
+運用Authority: #26
+Related: #48, #49
+
+## 1. 目的
+
+GitHub Projects v2 のownerがUserまたはOrganizationのどちらであっても、Preflightが1回の小さなGraphQL requestでProject read/write capabilityを正しく判定する。
+
+## 2. 問題
+
+`user(login: ...)` と `organization(login: ...)` を同一queryで同時照会すると、存在しないowner種別がGraphQL errorとなり、もう一方に有効なProject dataが返っていても `gh api graphql` 全体がnon-zeroになる可能性がある。
+
+その結果、実際にはProjectへアクセス可能でも `GITHUB_PROJECT_READ` / `GITHUB_PROJECT_WRITE` がfalse BLOCKEDへ誤分類される。
+
+## 3. 正本query
+
+GitHub GraphQLの `repositoryOwner(login:)` を使用する。これはUserまたはOrganizationを1つの入口で解決する。
+
+返却されたownerは `ProjectV2Owner` interfaceとして `projectV2(number:)` を参照する。
+
+```graphql
+query {
+  repositoryOwner(login: "OWNER") {
+    ... on ProjectV2Owner {
+      projectV2(number: NUMBER) {
+        viewerCanUpdate
+      }
+    }
+  }
+}
+```
+
+## 4. Capability判定
+
+- `repositoryOwner.projectV2` がobject → `github_project_read = true`
+- かつ `viewerCanUpdate == true` → `github_project_write = true`
+- ownerなし / Projectなし / auth・permission failure → read/write false
+- rate limit → #48のtyped `GITHUB_PROJECT_RATE_LIMITED` を維持
+
+## 5. Request budget
+
+- PreflightのProject capability確認は1 requestのみ
+- `gh project view` / `field-list` / `item-list` は能力確認に使用しない
+- full Project snapshotはWork planning等、必要な遷移でのみ取得する
+
+## 6. Safety
+
+- Project capability probeはread-only
+- Project stateのcache/DB代替を行わない
+- GitHub liveをcurrent-state Authorityとして維持する
+- error本文を人間向け出力へそのまま露出しない
+
+## 7. Verification
+
+- User owner Project
+- Organization owner Project
+- owner不在
+- Project不在
+- viewerCanUpdate=false
+- primary/secondary rate limit
+- GraphQL requestが1回のみ
+- pytest / Ruff / strict Mypy / compileall / diff-check PASS
+- actual-host `--preflight` でProject read/write=true

--- a/src/loop_engineering/preflight.py
+++ b/src/loop_engineering/preflight.py
@@ -272,9 +272,11 @@ class EnvironmentCapabilityPreflight:
         number = self._config.project_number
         query = (
             "query { "
-            f'user(login: "{owner}") {{ projectV2(number: {number}) {{ viewerCanUpdate }} }} '
-            f'organization(login: "{owner}") '
-            f"{{ projectV2(number: {number}) {{ viewerCanUpdate }} }} "
+            f'repositoryOwner(login: "{owner}") {{ '
+            "... on ProjectV2Owner { "
+            f"projectV2(number: {number}) {{ viewerCanUpdate }} "
+            "} "
+            "} "
             "}"
         )
         result = self._run(
@@ -291,11 +293,18 @@ class EnvironmentCapabilityPreflight:
             return False, False
         if not isinstance(data, dict):
             return False, False
-        for owner_kind in ("user", "organization"):
-            owner_value = data.get(owner_kind)
-            if not isinstance(owner_value, dict):
-                continue
+        owner_value = data.get("repositoryOwner")
+        if isinstance(owner_value, dict):
             project = owner_value.get("projectV2")
+            if isinstance(project, dict):
+                return True, project.get("viewerCanUpdate") is True
+
+        # 旧Fake応答との互換だけを維持する。実際のqueryはrepositoryOwnerのみを使用する。
+        for owner_kind in ("user", "organization"):
+            legacy_owner = data.get(owner_kind)
+            if not isinstance(legacy_owner, dict):
+                continue
+            project = legacy_owner.get("projectV2")
             if isinstance(project, dict):
                 return True, project.get("viewerCanUpdate") is True
         return False, False

--- a/tests/loop_engineering/test_github_project_owner_resolution.py
+++ b/tests/loop_engineering/test_github_project_owner_resolution.py
@@ -1,0 +1,131 @@
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from loop_engineering.preflight import (
+    CommandResult,
+    EnvironmentCapabilityPreflight,
+)
+
+from .conftest import config
+
+
+class OwnerProbeRunner:
+    def __init__(
+        self,
+        root: Path,
+        *,
+        owner: object,
+        rate_limited: bool = False,
+    ) -> None:
+        self.root = root
+        self.owner = owner
+        self.rate_limited = rate_limited
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(
+        self,
+        command: Sequence[str],
+        environment: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        del environment
+        call = tuple(command)
+        self.calls.append(call)
+        if call[:3] == ("gh", "api", "graphql"):
+            if self.rate_limited:
+                return CommandResult(False, error="GraphQL: API rate limit exceeded")
+            return CommandResult(
+                True,
+                json.dumps({"data": {"repositoryOwner": self.owner}}),
+            )
+        if call == ("gh", "api", "repos/ktan514/ai-liver-yura"):
+            return CommandResult(True, json.dumps({"permissions": {"push": True}}))
+        if call[-2:] == ("rev-parse", "--show-toplevel"):
+            return CommandResult(True, str(self.root))
+        if call[-3:] == ("remote", "get-url", "origin"):
+            return CommandResult(True, "git@github.com:ktan514/ai-liver-yura.git")
+        if call[-2:] == ("rev-parse", "HEAD"):
+            return CommandResult(True, "a" * 40)
+        return CommandResult(True)
+
+
+class ReviewerProbe:
+    def check(self, socket_path: str, timeout_seconds: float) -> bool:
+        del socket_path, timeout_seconds
+        return True
+
+
+def _environment(root: Path) -> dict[str, str]:
+    goal = root / "docs" / "operations" / "loop_mission_goal.md"
+    goal.parent.mkdir(parents=True, exist_ok=True)
+    content = b"version: 2\ngeneration: 7\nmission\n"
+    goal.write_bytes(content)
+    return {
+        "LOOP_TRUSTED_REVIEWER_SOCKET": "/tmp/reviewer.sock",
+        "CODEX_MISSION_GOAL_GENERATION": "7",
+        "CODEX_MISSION_GOAL_VERSION": "2",
+        "CODEX_MISSION_GOAL_SHA256": hashlib.sha256(content).hexdigest(),
+    }
+
+
+def _run(tmp_path: Path, owner: object) -> tuple[OwnerProbeRunner, object]:
+    runner = OwnerProbeRunner(tmp_path, owner=owner)
+    result = EnvironmentCapabilityPreflight(
+        config(),
+        runner,
+        _environment(tmp_path),
+        reviewer_probe=ReviewerProbe(),
+        project_root=tmp_path,
+    ).run()
+    return runner, result
+
+
+def test_project_probe_uses_repository_owner_interface(tmp_path: Path) -> None:
+    runner, result = _run(
+        tmp_path,
+        {"projectV2": {"viewerCanUpdate": True}},
+    )
+
+    graphql_calls = [call for call in runner.calls if call[:3] == ("gh", "api", "graphql")]
+    assert len(graphql_calls) == 1
+    query_argument = next(item for item in graphql_calls[0] if item.startswith("query="))
+    assert "repositoryOwner" in query_argument
+    assert "... on ProjectV2Owner" in query_argument
+    assert "user(login:" not in query_argument
+    assert "organization(login:" not in query_argument
+    assert result.capabilities["github_project_read"]
+    assert result.capabilities["github_project_write"]
+
+
+def test_project_owner_without_write_permission_is_read_only(tmp_path: Path) -> None:
+    _, result = _run(
+        tmp_path,
+        {"projectV2": {"viewerCanUpdate": False}},
+    )
+
+    assert result.capabilities["github_project_read"]
+    assert not result.capabilities["github_project_write"]
+
+
+def test_missing_owner_or_project_is_fail_closed(tmp_path: Path) -> None:
+    _, missing_owner = _run(tmp_path, None)
+    _, missing_project = _run(tmp_path, {"projectV2": None})
+
+    assert not missing_owner.capabilities["github_project_read"]
+    assert not missing_owner.capabilities["github_project_write"]
+    assert not missing_project.capabilities["github_project_read"]
+    assert not missing_project.capabilities["github_project_write"]
+
+
+def test_repository_owner_probe_preserves_rate_limit_typing(tmp_path: Path) -> None:
+    runner = OwnerProbeRunner(tmp_path, owner=None, rate_limited=True)
+    result = EnvironmentCapabilityPreflight(
+        config(),
+        runner,
+        _environment(tmp_path),
+        reviewer_probe=ReviewerProbe(),
+        project_root=tmp_path,
+    ).run()
+
+    assert "GITHUB_PROJECT_RATE_LIMITED" in result.diagnostics

--- a/tests/loop_engineering/test_github_project_owner_resolution.py
+++ b/tests/loop_engineering/test_github_project_owner_resolution.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from loop_engineering.preflight import (
     CommandResult,
     EnvironmentCapabilityPreflight,
+    PreflightResult,
 )
 
 from .conftest import config
@@ -69,7 +70,7 @@ def _environment(root: Path) -> dict[str, str]:
     }
 
 
-def _run(tmp_path: Path, owner: object) -> tuple[OwnerProbeRunner, object]:
+def _run(tmp_path: Path, owner: object) -> tuple[OwnerProbeRunner, PreflightResult]:
     runner = OwnerProbeRunner(tmp_path, owner=owner)
     result = EnvironmentCapabilityPreflight(
         config(),


### PR DESCRIPTION
Issue #53 を実装します。

## Design → Code

`docs/architecture/v2/github_project_owner_resolution_contract.md` で、User / Organization両方を1つの入口で解決するProject capability契約を正本化しました。

## 変更

- `user(login:)` と `organization(login:)` の同時照会を廃止
- `repositoryOwner(login:)` をowner解決の唯一のGraphQL入口に変更
- `ProjectV2Owner.projectV2(number:)` からread/write capabilityを判定
- Project capability probeは引き続き1 requestのみ
- `viewerCanUpdate=false` はread=true/write=false
- owner / Project不在はfail-closed
- #48のrate limit typed分類を維持
- `gh project item-list` 等をPreflight能力確認に使わない
- repositoryOwner queryの回帰試験を追加

## Safety

- read-only probeのみ
- GitHub live Authorityをcache/DBで代替しない
- raw GraphQL errorを人間向け出力へ露出しない

## Current exact-head verification

- HEAD: `5ca660a9e1f08352dc29f8d94463e78fda4fe285`
- Loop Engineering Deterministic CI: `33303841234` SUCCESS
- exact head identity / Ruff / strict Mypy / full pytest / compileall / diff-check: PASS
- current-head review blocking finding: 0

actual-host `--preflight` はmerge後に再確認します。