### PR TITLE
#50 merge abort失敗時の安全fallbackを追加する

### DIFF
--- a/docs/architecture/v2/merge_reconciliation_cleanup_contract.md
+++ b/docs/architecture/v2/merge_reconciliation_cleanup_contract.md
@@ -9,13 +9,13 @@ Related observability: #52
 
 Product Workの既存PRを最新trunkへ通常mergeして競合解消するreconciliationで、Codexまたはtrusted host finalizeが完了しなかった場合に、Product Workspaceへ未解決merge状態を残さない。
 
-Loop Engineering自身の不具合修正を理由にProduct Repositoryの履歴を破壊・rewriteしない。
+Loop Engineering自身の不具合修正を理由にProduct Repositoryの共有履歴を破壊・rewriteしない。
 
 ## 2. 前提
 
 reconciliation開始前は`TrustedWorktree.prepare()`のclean gateが成立していることを必須とする。
 
-`PreparedWorktree.start_head`はreconciliation開始直前の信頼済みHEADであり、cleanup時の照合基準として使用する。
+`PreparedWorktree.start_head`はreconciliation開始直前の信頼済みHEAD、`PreparedWorktree.branch`は開始branchであり、cleanup時の照合基準として使用する。
 
 pre-existing user changeがあるworktreeではreconciliationを開始しない。
 
@@ -30,17 +30,49 @@ pre-existing user changeがあるworktreeではreconciliationを開始しない�
 - staged diff判定
 - merge commit作成
 
-`MERGE_HEAD`が存在する場合はtrusted hostが`git merge --abort`を実行する。
+`MERGE_HEAD`が存在する場合は、最初にtrusted hostが`git merge --abort`を実行する。
 
 cleanup成功条件:
 
 - `HEAD == PreparedWorktree.start_head`
+- current branch == `PreparedWorktree.branch`
 - `MERGE_HEAD`が存在しない
 - `git status --porcelain`が空
 
 上記をreadbackできた場合だけ通常の`MERGE_RECONCILIATION_FAILED`として安全に終了できる。
 
-## 4. Effect-bearing / uncertain failure
+## 4. `merge --abort` failure fallback
+
+実運転では、Codexがmerge競合解消中にtracked fileへ追加編集を残した場合、`git merge --abort`が次のように失敗することがある。
+
+```text
+fatal: Could not reset index file to revision 'HEAD'.
+```
+
+この場合でも、merge commit作成前であり、reconciliation開始前のclean状態へ戻せることをfresh evidenceで証明できる場合だけ、trusted hostは限定fallbackとして`git reset --hard <start_head>`を使用できる。
+
+fallback許可条件はすべて必須とする。
+
+1. `PreparedWorktree.reconciliation_started == true`
+2. `PreparedWorktree.pr_number`が存在する
+3. current branch == `PreparedWorktree.branch`
+4. current HEAD == `PreparedWorktree.start_head`
+5. `MERGE_HEAD`が現在も存在する
+6. GitHub PRをfresh readし、live head branch == `PreparedWorktree.branch`
+7. GitHub PRのlive head SHA == `PreparedWorktree.start_head`
+8. `git merge --abort`が実際に失敗した直後である
+
+上記を満たした場合だけ次を実行する。
+
+```text
+git reset --hard <PreparedWorktree.start_head>
+```
+
+fallback後は通常cleanupと同じく、開始branch・開始HEAD・`MERGE_HEAD`不在・clean statusをreadbackする。
+
+`git reset --hard`ではuntracked fileを削除しない。fallback後にuntracked fileが残ってstatusがcleanでなければcleanup failureとしてfail-closedする。`git clean`は使用しない。
+
+## 5. Effect-bearing / uncertain failure
 
 merge commit作成後は`MERGE_HEAD`が消える。以後の失敗には次が含まれる。
 
@@ -50,42 +82,55 @@ merge commit作成後は`MERGE_HEAD`が消える。以後の失敗には次が�
 
 この段階ではremoteへeffectが発生した可能性を否定できないため、`reset --hard`、rebase、force push等で自動的に開始HEADへ戻さない。
 
-cleanup readbackで開始HEADへ戻っていることを証明できない場合はcleanup failureとして保持し、現行Controllerは`MERGE_RECONCILIATION_FAILED`でfail-closedする。
+また、`merge --abort` failure fallbackの許可条件を1つでも証明できない場合も`reset --hard`を使用しない。
+
+cleanup readbackで開始状態へ戻っていることを証明できない場合はcleanup failureとして保持し、現行Controllerは`MERGE_RECONCILIATION_FAILED`でfail-closedする。
 
 cleanup failureを専用detail `MERGE_RECONCILIATION_CLEANUP_FAILED`として上位へ公開する観測性改善は#52で扱う。
 
 既に発生した可能性のあるcommit/pushを「なかったこと」にしない。
 
-## 5. Host contract
+## 6. Host contract
 
 `TrustedWorktree`はreconciliation開始後、成功finalize以外の失敗経路でcleanupを試みる。
 
 - Codex failure → `abort_merge_if_needed()`
 - Codex success + finalize failure → `finalize()`内部でcleanup
+- `merge --abort` success → readback
+- `merge --abort` failure + fallback条件成立 →限定`reset --hard <start_head>` → readback
+- `merge --abort` failure + fallback条件不成立 → cleanup failure
 - finalize success → cleanupしない
 
-cleanup成功時は開始HEAD・`MERGE_HEAD`不在・clean statusをreadbackする。
+cleanup成功時は開始branch・開始HEAD・`MERGE_HEAD`不在・clean statusをreadbackする。
 
 cleanup結果が不明または失敗の場合でも、Controllerは一般的な`MERGE_RECONCILIATION_FAILED`として停止し、再dispatchしない。専用detailへの分類は#52の責務とする。
 
-## 6. Safety
+## 7. Safety
 
-- cleanupは`PreparedWorktree.start_head`を照合して実施する
+- cleanupは`PreparedWorktree.start_head`と`PreparedWorktree.branch`を照合する
+- fallback前にGitHub PR headをfresh readする
 - pre-existing dirty worktreeを自動clean/resetしない
 - `git clean`を使用しない
 - shared historyへforce pushしない
+- rebaseを使用しない
 - merge commit作成後の自動hard resetをしない
+- live PR headが開始時から動いている場合はhard resetしない
+- current branchまたはHEADが開始時から動いている場合はhard resetしない
 - Product側へLoop修正用commitを作らない
 
-## 7. Verification
+## 8. Verification
 
 - Codex failure + active MERGE_HEAD → abort + clean start HEAD
 - Codex success + unresolved conflict → abort + clean start HEAD
 - diff-check/stage/commit failure → abort + clean start HEAD
 - successful finalize → abortなし
-- abort command failure → cleanup failureとして保持
-- abort後HEAD mismatch → cleanup failureとして保持
-- MERGE_HEADなし + HEAD changed → cleanup failureとして保持
-- cleanup failure時も履歴を自動resetせずfail-closed
+- abort failure + branch/HEAD/live PR head一致 → hard reset fallback + clean
+- abort failure + current HEAD mismatch → hard resetなし
+- abort failure + current branch mismatch → hard resetなし
+- abort failure + live PR head mismatch → hard resetなし
+- abort failure + GitHub fresh read失敗 → hard resetなし
+- hard reset failure → cleanup failure
+- fallback後untracked残存 → cleanup failure、`git clean`なし
+- merge commit作成後push failure → hard resetなし
 - pytest / Ruff / strict Mypy / compileall / diff-check PASS
 - actual-host再試行で成功またはcleanなfailureとなり、未解決merge状態を残さない

--- a/src/loop_engineering/trusted_worktree.py
+++ b/src/loop_engineering/trusted_worktree.py
@@ -147,7 +147,7 @@ class TrustedWorktree:
         return FinalizedWorktree(prepared.branch, head_sha, pr_number)
 
     def abort_merge_if_needed(self, prepared: PreparedWorktree | None) -> bool:
-        """reconciliation途中ならabortし、開始前のclean状態へ戻ったことまで確認する。"""
+        """reconciliation途中なら開始前のclean状態へ戻ったことまで確認する。"""
 
         if prepared is None or not prepared.reconciliation_started:
             self._last_reconciliation_cleanup_failed = False
@@ -155,24 +155,62 @@ class TrustedWorktree:
 
         merge_head = self._git(("rev-parse", "-q", "--verify", "MERGE_HEAD"))
         if merge_head.succeeded:
-            if not self._git(("merge", "--abort")).succeeded:
-                self._last_reconciliation_cleanup_failed = True
-                return False
+            abort = self._git(("merge", "--abort"))
+            if not abort.succeeded:
+                cleaned = self._hard_reset_after_abort_failure(prepared)
+                self._last_reconciliation_cleanup_failed = not cleaned
+                return cleaned
         elif merge_head.returncode != 1:
             self._last_reconciliation_cleanup_failed = True
             return False
 
+        cleaned = self._cleanup_readback(prepared)
+        self._last_reconciliation_cleanup_failed = not cleaned
+        return cleaned
+
+    def _hard_reset_after_abort_failure(self, prepared: PreparedWorktree) -> bool:
+        """abort失敗時、安全条件をfresh確認できる場合だけ開始HEADへ戻す。"""
+
+        if prepared.pr_number is None:
+            return False
+
+        current_branch = self._git_output(("branch", "--show-current"))
         current_head = self._git_output(("rev-parse", "HEAD"))
-        merge_head_after = self._git(("rev-parse", "-q", "--verify", "MERGE_HEAD"))
+        merge_head = self._git(("rev-parse", "-q", "--verify", "MERGE_HEAD"))
+        if (
+            current_branch != prepared.branch
+            or current_head != prepared.start_head
+            or not merge_head.succeeded
+        ):
+            return False
+
+        pull = self._api_json(f"repos/{self._config.repository}/pulls/{prepared.pr_number}")
+        if pull is None:
+            return False
+        head_value = pull.get("head")
+        if not isinstance(head_value, dict):
+            return False
+        live_branch = head_value.get("ref")
+        live_head = head_value.get("sha")
+        if live_branch != prepared.branch or live_head != prepared.start_head:
+            return False
+
+        if not self._git(("reset", "--hard", prepared.start_head), timeout_seconds=180).succeeded:
+            return False
+        return self._cleanup_readback(prepared)
+
+    def _cleanup_readback(self, prepared: PreparedWorktree) -> bool:
+        current_branch = self._git_output(("branch", "--show-current"))
+        current_head = self._git_output(("rev-parse", "HEAD"))
+        merge_head = self._git(("rev-parse", "-q", "--verify", "MERGE_HEAD"))
         status = self._git_output(("status", "--porcelain"))
-        cleaned = (
-            current_head == prepared.start_head
-            and merge_head_after.returncode == 1
+        return (
+            current_branch == prepared.branch
+            and current_head == prepared.start_head
+            and merge_head.returncode == 1
             and status is not None
             and not status.strip()
         )
-        self._last_reconciliation_cleanup_failed = not cleaned
-        return cleaned
 
     def _finalize_failed(
         self,

--- a/tests/loop_engineering/test_reconciliation_cleanup.py
+++ b/tests/loop_engineering/test_reconciliation_cleanup.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
@@ -7,6 +8,7 @@ from loop_engineering.trusted_worktree import PreparedWorktree, TrustedWorktree
 from .conftest import config
 
 ResponseScript = LocalCommandResult | tuple[LocalCommandResult, ...]
+_BRANCH = "management/v2-repository-hygiene-guard"
 
 
 class ScriptedRunner:
@@ -42,11 +44,13 @@ def _target(head: str) -> HostTarget:
 
 
 def _prepared(head: str) -> PreparedWorktree:
-    return PreparedWorktree(
-        "management/v2-repository-hygiene-guard",
-        head,
-        441,
-        True,
+    return PreparedWorktree(_BRANCH, head, 441, True)
+
+
+def _live_pull(head: str, branch: str = _BRANCH) -> LocalCommandResult:
+    return LocalCommandResult(
+        0,
+        json.dumps({"head": {"ref": branch, "sha": head}}),
     )
 
 
@@ -63,6 +67,7 @@ def test_finalize_unresolved_conflict_aborts_and_restores_clean_start_head() -> 
                 LocalCommandResult(1, ""),
             ),
             ("git", "merge", "--abort"): LocalCommandResult(0, ""),
+            ("git", "branch", "--show-current"): LocalCommandResult(0, _BRANCH + "\n"),
             ("git", "rev-parse", "HEAD"): LocalCommandResult(0, start + "\n"),
             ("git", "status", "--porcelain"): LocalCommandResult(0, ""),
         }
@@ -74,20 +79,62 @@ def test_finalize_unresolved_conflict_aborts_and_restores_clean_start_head() -> 
     assert result is None
     assert not worktree.reconciliation_cleanup_failed
     assert ("git", "merge", "--abort") in runner.commands
-    assert runner.commands.count(merge_head_probe) == 2
+    assert not any(command[:2] == ("git", "reset") for command in runner.commands)
 
 
-def test_abort_failure_is_exposed_as_cleanup_failure() -> None:
+def test_abort_failure_uses_hard_reset_only_after_fresh_safety_checks() -> None:
     start = "a" * 40
+    merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
     runner = ScriptedRunner(
         {
             ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
                 0, "AGENTS.md\n"
             ),
-            ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD"): LocalCommandResult(
-                0, "b" * 40 + "\n"
+            merge_head_probe: (
+                LocalCommandResult(0, "b" * 40 + "\n"),
+                LocalCommandResult(0, "b" * 40 + "\n"),
+                LocalCommandResult(1, ""),
             ),
-            ("git", "merge", "--abort"): LocalCommandResult(1, ""),
+            ("git", "merge", "--abort"): LocalCommandResult(128, ""),
+            ("git", "branch", "--show-current"): (
+                LocalCommandResult(0, _BRANCH + "\n"),
+                LocalCommandResult(0, _BRANCH + "\n"),
+            ),
+            ("git", "rev-parse", "HEAD"): (
+                LocalCommandResult(0, start + "\n"),
+                LocalCommandResult(0, start + "\n"),
+            ),
+            ("gh", "api", "repos/ktan514/ai-liver-yura/pulls/441"): _live_pull(start),
+            ("git", "reset", "--hard", start): LocalCommandResult(0, ""),
+            ("git", "status", "--porcelain"): LocalCommandResult(0, ""),
+        }
+    )
+    worktree = TrustedWorktree(config(), runner, Path("/repo"), {"PATH": "/usr/bin"})
+
+    result = worktree.finalize(_target(start), _prepared(start), repair=True)
+
+    assert result is None
+    assert not worktree.reconciliation_cleanup_failed
+    assert ("git", "merge", "--abort") in runner.commands
+    assert ("git", "reset", "--hard", start) in runner.commands
+
+
+def test_abort_failure_does_not_reset_when_current_head_moved() -> None:
+    start = "a" * 40
+    moved = "c" * 40
+    merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
+    runner = ScriptedRunner(
+        {
+            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
+                0, "AGENTS.md\n"
+            ),
+            merge_head_probe: (
+                LocalCommandResult(0, "b" * 40 + "\n"),
+                LocalCommandResult(0, "b" * 40 + "\n"),
+            ),
+            ("git", "merge", "--abort"): LocalCommandResult(128, ""),
+            ("git", "branch", "--show-current"): LocalCommandResult(0, _BRANCH + "\n"),
+            ("git", "rev-parse", "HEAD"): LocalCommandResult(0, moved + "\n"),
         }
     )
     worktree = TrustedWorktree(config(), runner, Path("/repo"), {"PATH": "/usr/bin"})
@@ -96,6 +143,126 @@ def test_abort_failure_is_exposed_as_cleanup_failure() -> None:
 
     assert result is None
     assert worktree.reconciliation_cleanup_failed
+    assert not any(command[:2] == ("git", "reset") for command in runner.commands)
+    assert not any(command[:2] == ("gh", "api") for command in runner.commands)
+
+
+def test_abort_failure_does_not_reset_when_live_pr_head_moved() -> None:
+    start = "a" * 40
+    moved = "c" * 40
+    merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
+    runner = ScriptedRunner(
+        {
+            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
+                0, "AGENTS.md\n"
+            ),
+            merge_head_probe: (
+                LocalCommandResult(0, "b" * 40 + "\n"),
+                LocalCommandResult(0, "b" * 40 + "\n"),
+            ),
+            ("git", "merge", "--abort"): LocalCommandResult(128, ""),
+            ("git", "branch", "--show-current"): LocalCommandResult(0, _BRANCH + "\n"),
+            ("git", "rev-parse", "HEAD"): LocalCommandResult(0, start + "\n"),
+            ("gh", "api", "repos/ktan514/ai-liver-yura/pulls/441"): _live_pull(moved),
+        }
+    )
+    worktree = TrustedWorktree(config(), runner, Path("/repo"), {"PATH": "/usr/bin"})
+
+    result = worktree.finalize(_target(start), _prepared(start), repair=True)
+
+    assert result is None
+    assert worktree.reconciliation_cleanup_failed
+    assert not any(command[:2] == ("git", "reset") for command in runner.commands)
+
+
+def test_abort_failure_does_not_reset_when_github_fresh_read_fails() -> None:
+    start = "a" * 40
+    merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
+    runner = ScriptedRunner(
+        {
+            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
+                0, "AGENTS.md\n"
+            ),
+            merge_head_probe: (
+                LocalCommandResult(0, "b" * 40 + "\n"),
+                LocalCommandResult(0, "b" * 40 + "\n"),
+            ),
+            ("git", "merge", "--abort"): LocalCommandResult(128, ""),
+            ("git", "branch", "--show-current"): LocalCommandResult(0, _BRANCH + "\n"),
+            ("git", "rev-parse", "HEAD"): LocalCommandResult(0, start + "\n"),
+            ("gh", "api", "repos/ktan514/ai-liver-yura/pulls/441"): LocalCommandResult(1, ""),
+        }
+    )
+    worktree = TrustedWorktree(config(), runner, Path("/repo"), {"PATH": "/usr/bin"})
+
+    result = worktree.finalize(_target(start), _prepared(start), repair=True)
+
+    assert result is None
+    assert worktree.reconciliation_cleanup_failed
+    assert not any(command[:2] == ("git", "reset") for command in runner.commands)
+
+
+def test_hard_reset_failure_remains_cleanup_failure() -> None:
+    start = "a" * 40
+    merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
+    runner = ScriptedRunner(
+        {
+            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
+                0, "AGENTS.md\n"
+            ),
+            merge_head_probe: (
+                LocalCommandResult(0, "b" * 40 + "\n"),
+                LocalCommandResult(0, "b" * 40 + "\n"),
+            ),
+            ("git", "merge", "--abort"): LocalCommandResult(128, ""),
+            ("git", "branch", "--show-current"): LocalCommandResult(0, _BRANCH + "\n"),
+            ("git", "rev-parse", "HEAD"): LocalCommandResult(0, start + "\n"),
+            ("gh", "api", "repos/ktan514/ai-liver-yura/pulls/441"): _live_pull(start),
+            ("git", "reset", "--hard", start): LocalCommandResult(128, ""),
+        }
+    )
+    worktree = TrustedWorktree(config(), runner, Path("/repo"), {"PATH": "/usr/bin"})
+
+    result = worktree.finalize(_target(start), _prepared(start), repair=True)
+
+    assert result is None
+    assert worktree.reconciliation_cleanup_failed
+
+
+def test_fallback_does_not_git_clean_untracked_residue() -> None:
+    start = "a" * 40
+    merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
+    runner = ScriptedRunner(
+        {
+            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
+                0, "AGENTS.md\n"
+            ),
+            merge_head_probe: (
+                LocalCommandResult(0, "b" * 40 + "\n"),
+                LocalCommandResult(0, "b" * 40 + "\n"),
+                LocalCommandResult(1, ""),
+            ),
+            ("git", "merge", "--abort"): LocalCommandResult(128, ""),
+            ("git", "branch", "--show-current"): (
+                LocalCommandResult(0, _BRANCH + "\n"),
+                LocalCommandResult(0, _BRANCH + "\n"),
+            ),
+            ("git", "rev-parse", "HEAD"): (
+                LocalCommandResult(0, start + "\n"),
+                LocalCommandResult(0, start + "\n"),
+            ),
+            ("gh", "api", "repos/ktan514/ai-liver-yura/pulls/441"): _live_pull(start),
+            ("git", "reset", "--hard", start): LocalCommandResult(0, ""),
+            ("git", "status", "--porcelain"): LocalCommandResult(0, "?? extra.txt\n"),
+        }
+    )
+    worktree = TrustedWorktree(config(), runner, Path("/repo"), {"PATH": "/usr/bin"})
+
+    result = worktree.finalize(_target(start), _prepared(start), repair=True)
+
+    assert result is None
+    assert worktree.reconciliation_cleanup_failed
+    assert not any(command[:2] == ("git", "clean") for command in runner.commands)
 
 
 def test_push_failure_after_merge_commit_never_resets_history() -> None:
@@ -125,6 +292,7 @@ def test_push_failure_after_merge_commit_never_resets_history() -> None:
                 LocalCommandResult(1, ""),
                 LocalCommandResult(1, ""),
             ),
+            ("git", "branch", "--show-current"): LocalCommandResult(0, _BRANCH + "\n"),
             ("git", "status", "--porcelain"): LocalCommandResult(0, ""),
         }
     )


### PR DESCRIPTION
Issue #50 のactual-host再試行で、Codexが競合解消中にtracked fileへ追加編集を残したため `git merge --abort` が `fatal: Could not reset index file to revision 'HEAD'.` で失敗し、Product Workspaceへmerge途中状態が残ることを確認した。

## Design → Code

`docs/architecture/v2/merge_reconciliation_cleanup_contract.md` を更新し、abort失敗時の限定hard-reset fallback契約を先に定義した。

## 変更

- `merge --abort`失敗時だけfallback判定へ入る
- current branch / current HEAD / `MERGE_HEAD` を開始時情報と照合
- GitHub PRをfresh readし、live head branch / SHAも開始時と一致することを必須化
- 全条件成立時だけ `git reset --hard <start_head>` を実行
- reset後にbranch / HEAD / MERGE_HEAD不在 / clean statusをreadback
- GitHub fresh read失敗、HEAD/branch/PR head移動時はresetせずfail-closed
- merge commit作成後は従来どおりreset禁止
- untracked残存時は`git clean`せずcleanup failure

## Verification

- 実運転と同じabort exit 128 + safe fallback
- current HEAD moved
- live PR head moved
- GitHub fresh read failure
- hard reset failure
- fallback後untracked residue
- merge commit後push failureではresetしない

## Current exact-head verification

- HEAD: `8c3c707cfccd93888c5df2cbba2980011954da87`
- Loop Engineering Deterministic CI: `33305198624` SUCCESS
- exact head identity / Ruff / strict Mypy / full pytest / compileall / diff-check: PASS
- current-head review blocking finding: 0

actual-host再試行はmerge後に行い、#50はその証拠までopen維持する。