### PR TITLE
#50 競合解消をtrusted hostで正常確定できるようにする

### DIFF
--- a/docs/architecture/v2/merge_reconciliation_cleanup_contract.md
+++ b/docs/architecture/v2/merge_reconciliation_cleanup_contract.md
@@ -9,6 +9,8 @@ Related observability: #52
 
 Product Workの既存PRを最新trunkへ通常mergeして競合解消するreconciliationで、Codexまたはtrusted host finalizeが完了しなかった場合に、Product Workspaceへ未解決merge状態を残さない。
 
+同時に、Codexが競合ファイル内容を正しく解消した場合は、その解消結果をtrusted hostがindexへ登録し、merge commitとして正常に確定できることを必須とする。
+
 Loop Engineering自身の不具合修正を理由にProduct Repositoryの共有履歴を破壊・rewriteしない。
 
 ## 2. 前提
@@ -19,14 +21,35 @@ reconciliation開始前は`TrustedWorktree.prepare()`のclean gateが成立し�
 
 pre-existing user changeがあるworktreeではreconciliationを開始しない。
 
-## 3. Reversible failure
+## 3. 競合解消の正常finalize順序
+
+CodexにはGit管理情報の変更を許可せず、競合ファイルの内容編集と必要な検証だけを担当させる。したがってCodexが内容上の競合を解消しても、trusted hostがstageするまではGit index上のunmerged entryが残ることは正常である。
+
+そのため、`diff-filter=U`や`git ls-files -u`を`git add`より前に最終失敗判定へ使用してはならない。
+
+trusted hostはCodex成功後、次の順序でfinalizeする。
+
+1. `git add -A`でCodexが作業領域へ残した解消結果と付随変更をstageする
+2. `git ls-files -u`でunmerged index entryが0件であることを確認する
+3. `git diff --cached --check`でstaged差分のconflict marker / whitespace errorを検査する
+4. staged差分が存在することを確認する
+5. merge commitを作成する
+6. exact HEADを取得する
+7. 通常pushする
+8. PR / Mission Checkpointを更新する
+
+`git add -A`後も`git ls-files -u`が残る、または`git diff --cached --check`が失敗する場合は競合解消失敗としてcleanupへ進む。
+
+Codexが競合解消に付随してtestや契約文書を更新した場合、それらも同じtrusted host finalize対象とする。merge開始前はclean gateが成立しているため、pre-existing user changeとの混同はしない。
+
+## 4. Reversible failure
 
 `git merge --no-commit --no-ff origin/<trunk>`開始後、merge commitがまだ作成されていない段階で次のいずれかが失敗した場合はcleanup対象とする。
 
 - Codex実行
-- unresolved conflict解消
-- `git diff --check`
 - `git add -A`
+- `git ls-files -u` readback / unmerged残存
+- `git diff --cached --check`
 - staged diff判定
 - merge commit作成
 
@@ -41,7 +64,7 @@ cleanup成功条件:
 
 上記をreadbackできた場合だけ通常の`MERGE_RECONCILIATION_FAILED`として安全に終了できる。
 
-## 4. `merge --abort` failure fallback
+## 5. `merge --abort` failure fallback
 
 実運転では、Codexがmerge競合解消中にtracked fileへ追加編集を残した場合、`git merge --abort`が次のように失敗することがある。
 
@@ -72,7 +95,7 @@ fallback後は通常cleanupと同じく、開始branch・開始HEAD・`MERGE_HEA
 
 `git reset --hard`ではuntracked fileを削除しない。fallback後にuntracked fileが残ってstatusがcleanでなければcleanup failureとしてfail-closedする。`git clean`は使用しない。
 
-## 5. Effect-bearing / uncertain failure
+## 6. Effect-bearing / uncertain failure
 
 merge commit作成後は`MERGE_HEAD`が消える。以後の失敗には次が含まれる。
 
@@ -90,10 +113,11 @@ cleanup failureを専用detail `MERGE_RECONCILIATION_CLEANUP_FAILED`として上
 
 既に発生した可能性のあるcommit/pushを「なかったこと」にしない。
 
-## 6. Host contract
+## 7. Host contract
 
 `TrustedWorktree`はreconciliation開始後、成功finalize以外の失敗経路でcleanupを試みる。
 
+- Codex success + content resolution → trusted host stage → unmerged gate → cached diff-check → commit/push
 - Codex failure → `abort_merge_if_needed()`
 - Codex success + finalize failure → `finalize()`内部でcleanup
 - `merge --abort` success → readback
@@ -105,8 +129,11 @@ cleanup成功時は開始branch・開始HEAD・`MERGE_HEAD`不在・clean status
 
 cleanup結果が不明または失敗の場合でも、Controllerは一般的な`MERGE_RECONCILIATION_FAILED`として停止し、再dispatchしない。専用detailへの分類は#52の責務とする。
 
-## 7. Safety
+## 8. Safety
 
+- Codexには`git add` / commit / pushを許可しない
+- stageとunmerged解消確認はtrusted hostだけが実施する
+- staged差分はcommit前に`git diff --cached --check`を通す
 - cleanupは`PreparedWorktree.start_head`と`PreparedWorktree.branch`を照合する
 - fallback前にGitHub PR headをfresh readする
 - pre-existing dirty worktreeを自動clean/resetしない
@@ -118,11 +145,12 @@ cleanup結果が不明または失敗の場合でも、Controllerは一般的な
 - current branchまたはHEADが開始時から動いている場合はhard resetしない
 - Product側へLoop修正用commitを作らない
 
-## 8. Verification
+## 9. Verification
 
+- Codexが競合内容を解消しindexがUのまま → trusted host stage後にunmerged 0 → merge commit成功
+- stage後もunmerged残存 → cleanup
+- staged差分にconflict marker / whitespace error → cleanup
 - Codex failure + active MERGE_HEAD → abort + clean start HEAD
-- Codex success + unresolved conflict → abort + clean start HEAD
-- diff-check/stage/commit failure → abort + clean start HEAD
 - successful finalize → abortなし
 - abort failure + branch/HEAD/live PR head一致 → hard reset fallback + clean
 - abort failure + current HEAD mismatch → hard resetなし
@@ -133,4 +161,4 @@ cleanup結果が不明または失敗の場合でも、Controllerは一般的な
 - fallback後untracked残存 → cleanup failure、`git clean`なし
 - merge commit作成後push failure → hard resetなし
 - pytest / Ruff / strict Mypy / compileall / diff-check PASS
-- actual-host再試行で成功またはcleanなfailureとなり、未解決merge状態を残さない
+- actual-host再試行で#384 / PR #441の競合解消がcommit/pushされる、またはcleanなfailureとなる

--- a/src/loop_engineering/trusted_worktree.py
+++ b/src/loop_engineering/trusted_worktree.py
@@ -104,12 +104,14 @@ class TrustedWorktree:
         *,
         repair: bool,
     ) -> FinalizedWorktree | None:
-        unresolved = self._git_output(("diff", "--name-only", "--diff-filter=U"))
-        if unresolved is None or unresolved.strip():
-            return self._finalize_failed(prepared)
-        if not self._git(("diff", "--check")).succeeded:
-            return self._finalize_failed(prepared)
         if not self._git(("add", "-A")).succeeded:
+            return self._finalize_failed(prepared)
+
+        unmerged = self._git_output(("ls-files", "-u"))
+        if unmerged is None or unmerged.strip():
+            return self._finalize_failed(prepared)
+
+        if not self._git(("diff", "--cached", "--check")).succeeded:
             return self._finalize_failed(prepared)
 
         staged = self._git(("diff", "--cached", "--quiet"))

--- a/tests/loop_engineering/test_reconciliation_cleanup.py
+++ b/tests/loop_engineering/test_reconciliation_cleanup.py
@@ -39,6 +39,47 @@ class ScriptedRunner:
         return response
 
 
+class SuccessfulFinalizeRunner:
+    def __init__(self, committed: str) -> None:
+        self.committed = committed
+        self.commands: list[tuple[str, ...]] = []
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        environment: Mapping[str, str] | None = None,
+        timeout_seconds: int = 120,
+        capture_output: bool = True,
+    ) -> LocalCommandResult:
+        del cwd, environment, timeout_seconds, capture_output
+        args = tuple(command)
+        self.commands.append(args)
+        if args == ("git", "add", "-A"):
+            return LocalCommandResult(0, "")
+        if args == ("git", "ls-files", "-u"):
+            return LocalCommandResult(0, "")
+        if args == ("git", "diff", "--cached", "--check"):
+            return LocalCommandResult(0, "")
+        if args == ("git", "diff", "--cached", "--quiet"):
+            return LocalCommandResult(1, "")
+        if args == ("git", "commit", "-m", "#384 を最新基幹へ統合する"):
+            return LocalCommandResult(0, "")
+        if args == ("git", "rev-parse", "HEAD"):
+            return LocalCommandResult(0, self.committed + "\n")
+        if args == ("git", "push", "-u", "origin", f"HEAD:{_BRANCH}"):
+            return LocalCommandResult(0, "")
+        if (
+            len(args) == 5
+            and args[:3] == ("gh", "api", "repos/ktan514/ai-liver-yura/issues/450/comments")
+            and args[3] == "-f"
+            and args[4].startswith("body=## Mission Checkpoint")
+        ):
+            return LocalCommandResult(0, "")
+        raise AssertionError(f"想定外のコマンドです: {args}")
+
+
 def _target(head: str) -> HostTarget:
     return HostTarget(384, True, 441, head, True, False, 1, head)
 
@@ -54,24 +95,47 @@ def _live_pull(head: str, branch: str = _BRANCH) -> LocalCommandResult:
     )
 
 
-def test_finalize_unresolved_conflict_aborts_and_restores_clean_start_head() -> None:
+def _cleanup_after_abort_success(start: str) -> dict[tuple[str, ...], ResponseScript]:
+    return {
+        ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD"): (
+            LocalCommandResult(0, "b" * 40 + "\n"),
+            LocalCommandResult(1, ""),
+        ),
+        ("git", "merge", "--abort"): LocalCommandResult(0, ""),
+        ("git", "branch", "--show-current"): LocalCommandResult(0, _BRANCH + "\n"),
+        ("git", "rev-parse", "HEAD"): LocalCommandResult(0, start + "\n"),
+        ("git", "status", "--porcelain"): LocalCommandResult(0, ""),
+    }
+
+
+def test_finalize_stages_resolution_before_unmerged_gate_and_commits() -> None:
     start = "a" * 40
-    merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
-    runner = ScriptedRunner(
-        {
-            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
-                0, "AGENTS.md\n"
-            ),
-            merge_head_probe: (
-                LocalCommandResult(0, "b" * 40 + "\n"),
-                LocalCommandResult(1, ""),
-            ),
-            ("git", "merge", "--abort"): LocalCommandResult(0, ""),
-            ("git", "branch", "--show-current"): LocalCommandResult(0, _BRANCH + "\n"),
-            ("git", "rev-parse", "HEAD"): LocalCommandResult(0, start + "\n"),
-            ("git", "status", "--porcelain"): LocalCommandResult(0, ""),
-        }
+    committed = "c" * 40
+    runner = SuccessfulFinalizeRunner(committed)
+    worktree = TrustedWorktree(config(), runner, Path("/repo"), {"PATH": "/usr/bin"})
+
+    result = worktree.finalize(_target(start), _prepared(start), repair=True)
+
+    assert result is not None
+    assert result.head_sha == committed
+    assert result.pr_number == 441
+    assert runner.commands.index(("git", "add", "-A")) < runner.commands.index(
+        ("git", "ls-files", "-u")
     )
+    assert ("git", "diff", "--cached", "--check") in runner.commands
+    assert ("git", "merge", "--abort") not in runner.commands
+
+
+def test_stage_after_codex_still_unmerged_aborts_and_restores_clean_start_head() -> None:
+    start = "a" * 40
+    responses: dict[tuple[str, ...], ResponseScript] = {
+        ("git", "add", "-A"): LocalCommandResult(0, ""),
+        ("git", "ls-files", "-u"): LocalCommandResult(
+            0, "100644 deadbeef 1\tAGENTS.md\n"
+        ),
+        **_cleanup_after_abort_success(start),
+    }
+    runner = ScriptedRunner(responses)
     worktree = TrustedWorktree(config(), runner, Path("/repo"), {"PATH": "/usr/bin"})
 
     result = worktree.finalize(_target(start), _prepared(start), repair=True)
@@ -82,13 +146,32 @@ def test_finalize_unresolved_conflict_aborts_and_restores_clean_start_head() -> 
     assert not any(command[:2] == ("git", "reset") for command in runner.commands)
 
 
+def test_cached_diff_check_failure_aborts_and_restores_clean_start_head() -> None:
+    start = "a" * 40
+    responses: dict[tuple[str, ...], ResponseScript] = {
+        ("git", "add", "-A"): LocalCommandResult(0, ""),
+        ("git", "ls-files", "-u"): LocalCommandResult(0, ""),
+        ("git", "diff", "--cached", "--check"): LocalCommandResult(1, ""),
+        **_cleanup_after_abort_success(start),
+    }
+    runner = ScriptedRunner(responses)
+    worktree = TrustedWorktree(config(), runner, Path("/repo"), {"PATH": "/usr/bin"})
+
+    result = worktree.finalize(_target(start), _prepared(start), repair=True)
+
+    assert result is None
+    assert not worktree.reconciliation_cleanup_failed
+    assert ("git", "merge", "--abort") in runner.commands
+
+
 def test_abort_failure_uses_hard_reset_only_after_fresh_safety_checks() -> None:
     start = "a" * 40
     merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
     runner = ScriptedRunner(
         {
-            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
-                0, "AGENTS.md\n"
+            ("git", "add", "-A"): LocalCommandResult(0, ""),
+            ("git", "ls-files", "-u"): LocalCommandResult(
+                0, "100644 deadbeef 1\tAGENTS.md\n"
             ),
             merge_head_probe: (
                 LocalCommandResult(0, "b" * 40 + "\n"),
@@ -115,7 +198,6 @@ def test_abort_failure_uses_hard_reset_only_after_fresh_safety_checks() -> None:
 
     assert result is None
     assert not worktree.reconciliation_cleanup_failed
-    assert ("git", "merge", "--abort") in runner.commands
     assert ("git", "reset", "--hard", start) in runner.commands
 
 
@@ -125,8 +207,9 @@ def test_abort_failure_does_not_reset_when_current_head_moved() -> None:
     merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
     runner = ScriptedRunner(
         {
-            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
-                0, "AGENTS.md\n"
+            ("git", "add", "-A"): LocalCommandResult(0, ""),
+            ("git", "ls-files", "-u"): LocalCommandResult(
+                0, "100644 deadbeef 1\tAGENTS.md\n"
             ),
             merge_head_probe: (
                 LocalCommandResult(0, "b" * 40 + "\n"),
@@ -153,8 +236,9 @@ def test_abort_failure_does_not_reset_when_live_pr_head_moved() -> None:
     merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
     runner = ScriptedRunner(
         {
-            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
-                0, "AGENTS.md\n"
+            ("git", "add", "-A"): LocalCommandResult(0, ""),
+            ("git", "ls-files", "-u"): LocalCommandResult(
+                0, "100644 deadbeef 1\tAGENTS.md\n"
             ),
             merge_head_probe: (
                 LocalCommandResult(0, "b" * 40 + "\n"),
@@ -180,8 +264,9 @@ def test_abort_failure_does_not_reset_when_github_fresh_read_fails() -> None:
     merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
     runner = ScriptedRunner(
         {
-            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
-                0, "AGENTS.md\n"
+            ("git", "add", "-A"): LocalCommandResult(0, ""),
+            ("git", "ls-files", "-u"): LocalCommandResult(
+                0, "100644 deadbeef 1\tAGENTS.md\n"
             ),
             merge_head_probe: (
                 LocalCommandResult(0, "b" * 40 + "\n"),
@@ -207,8 +292,9 @@ def test_hard_reset_failure_remains_cleanup_failure() -> None:
     merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
     runner = ScriptedRunner(
         {
-            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
-                0, "AGENTS.md\n"
+            ("git", "add", "-A"): LocalCommandResult(0, ""),
+            ("git", "ls-files", "-u"): LocalCommandResult(
+                0, "100644 deadbeef 1\tAGENTS.md\n"
             ),
             merge_head_probe: (
                 LocalCommandResult(0, "b" * 40 + "\n"),
@@ -234,8 +320,9 @@ def test_fallback_does_not_git_clean_untracked_residue() -> None:
     merge_head_probe = ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD")
     runner = ScriptedRunner(
         {
-            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(
-                0, "AGENTS.md\n"
+            ("git", "add", "-A"): LocalCommandResult(0, ""),
+            ("git", "ls-files", "-u"): LocalCommandResult(
+                0, "100644 deadbeef 1\tAGENTS.md\n"
             ),
             merge_head_probe: (
                 LocalCommandResult(0, "b" * 40 + "\n"),
@@ -270,9 +357,9 @@ def test_push_failure_after_merge_commit_never_resets_history() -> None:
     committed = "c" * 40
     runner = ScriptedRunner(
         {
-            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(0, ""),
-            ("git", "diff", "--check"): LocalCommandResult(0, ""),
             ("git", "add", "-A"): LocalCommandResult(0, ""),
+            ("git", "ls-files", "-u"): LocalCommandResult(0, ""),
+            ("git", "diff", "--cached", "--check"): LocalCommandResult(0, ""),
             ("git", "diff", "--cached", "--quiet"): LocalCommandResult(1, ""),
             ("git", "commit", "-m", "#384 を最新基幹へ統合する"): LocalCommandResult(
                 0, ""
@@ -281,13 +368,7 @@ def test_push_failure_after_merge_commit_never_resets_history() -> None:
                 LocalCommandResult(0, committed + "\n"),
                 LocalCommandResult(0, committed + "\n"),
             ),
-            (
-                "git",
-                "push",
-                "-u",
-                "origin",
-                "HEAD:management/v2-repository-hygiene-guard",
-            ): LocalCommandResult(1, ""),
+            ("git", "push", "-u", "origin", f"HEAD:{_BRANCH}"): LocalCommandResult(1, ""),
             ("git", "rev-parse", "-q", "--verify", "MERGE_HEAD"): (
                 LocalCommandResult(1, ""),
                 LocalCommandResult(1, ""),

--- a/tests/loop_engineering/test_trusted_worktree.py
+++ b/tests/loop_engineering/test_trusted_worktree.py
@@ -149,9 +149,9 @@ def test_finalize_commits_pushes_and_publishes_checkpoint_in_japanese() -> None:
     new_head = "d" * 40
     runner = ScriptedRunner(
         {
-            ("git", "diff", "--name-only", "--diff-filter=U"): LocalCommandResult(0, ""),
-            ("git", "diff", "--check"): LocalCommandResult(0, ""),
             ("git", "add", "-A"): LocalCommandResult(0, ""),
+            ("git", "ls-files", "-u"): LocalCommandResult(0, ""),
+            ("git", "diff", "--cached", "--check"): LocalCommandResult(0, ""),
             ("git", "diff", "--cached", "--quiet"): LocalCommandResult(1, ""),
             ("git", "commit", "-m", "#340 の実装を進める"): LocalCommandResult(0, ""),
             ("git", "rev-parse", "HEAD"): LocalCommandResult(0, new_head + "\n"),


### PR DESCRIPTION
Issue #50 のactual-host検証で、Codexが競合ファイル内容を解消しても、trusted hostが `git add -A` する前に `diff-filter=U` を失敗判定していたため、正常なmerge reconciliationが必ずcleanupへ落ちる順序バグを確認した。

## Design → Code

`docs/architecture/v2/merge_reconciliation_cleanup_contract.md` に正常finalize順序を追加した。

## 変更

- Codexは従来どおりGit管理操作をしない
- trusted hostが最初に `git add -A` で競合解消結果をindexへ登録
- `git ls-files -u` でunmerged entryが0件であることを確認
- `git diff --cached --check` でconflict marker / whitespace errorを検査
- staged差分確認後にmerge commit / push / Checkpointへ進む
- stage後もunmergedが残る場合は従来のcleanupへ進む
- #55で追加したabort failure hard-reset fallbackは維持

## Verification

- indexがUのままでもCodex解消後はhost stageで正常commitへ進める
- stage後unmerged残存はcleanup
- cached diff-check失敗はcleanup
- abort fallback safety境界を維持
- merge commit後push失敗でresetしない

Draftのままexact-head CIとcurrent-head reviewを確認する。