### PR TITLE
Loop運転: Draft統合境界と日本語merge messageを修正する (#57 #58)

### DIFF
--- a/docs/architecture/v2/loop_canonical_review_pipeline.md
+++ b/docs/architecture/v2/loop_canonical_review_pipeline.md
@@ -24,6 +24,18 @@
 
 非機能的な強化、追加監査性、より厳格な管理情報検証、仮説的な競合防御など、必須挙動を妨げない指摘は記録して後回しにしてよい。提供元失敗を含む`NOT_RUN`は、機械検査と必須機能証拠が通っているWorkを停止しない。よりきれいなレビュー判定を得ることだけを目的にレビューワー基盤を強化しない。
 
+## DraftとReadyの境界
+
+Draft PRは「まだ統合可能状態へ昇格していない」というGitHub上の明示状態として扱う。
+
+- actual-hostはDraft PRを同一遷移内で自動Ready化してそのままmergeしない。
+- exact-head CIがSUCCESSでもDraftなら`REVIEW_PENDING`として外部待ちへ譲る。
+- Ready化はレビュー・修正・運用判断によって別の状態遷移として発生したことをfresh readしてから扱う。
+- Draft待機はMission全体のHuman Interventionではなく、別のdependency-ready WorkがあればMissionは継続できる。
+- Ready化後も期待HEAD、CI、既知の機能停止要因、Write Gateをfresh確認する。
+
+この境界により、review `PASS`を必須化せず、同時に「CI成功だけでDraftをReady化・mergeする」競合した副作用を禁止する。
+
 ## 統合判定
 
 Ready化または統合の前に、実行機はPR/HEAD/基点、必須の厳密HEAD機械検査、機能完了証拠、書込み判定（Write Gate）の事前条件を再解決する。統合は期待HEADへ結び付けた通常GitHub経路で実施し、その後に基幹と統合効果を再取得する。

--- a/src/loop_engineering/__main__.py
+++ b/src/loop_engineering/__main__.py
@@ -208,10 +208,11 @@ def main() -> int:
 
             if (
                 transition_result.status is HostTransitionStatus.YIELD_EXTERNAL
-                and transition_result.detail == "CI_PENDING"
+                and transition_result.detail in {"CI_PENDING", "REVIEW_PENDING"}
             ):
+                wait_kind = "CI" if transition_result.detail == "CI_PENDING" else "Review"
                 console.event(
-                    f"CI Wait: {int(ci_wait_seconds)}秒後に自動再開します"
+                    f"{wait_kind} Wait: {int(ci_wait_seconds)}秒後に自動再開します"
                 )
                 time.sleep(ci_wait_seconds)
                 ci_wait_seconds = min(

--- a/src/loop_engineering/actual_host_merge_safety.py
+++ b/src/loop_engineering/actual_host_merge_safety.py
@@ -1,0 +1,215 @@
+"""実ホストのReady・review・merge境界を安全に制御する。"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from .ci_gate import CIGateStatus
+from .config import LoopEngineConfig
+from .host_entrypoint import (
+    PilotAwareMissionPort,
+    PilotPlanningImplementer,
+    ReconciliationAwareHostLoopController,
+    StrictGhMissionPort,
+)
+from .host_runtime import (
+    HostTarget,
+    HostTransitionResult,
+    HostTransitionStatus,
+    LocalRunner,
+)
+
+
+class SafeActualHostMissionPort(StrictGhMissionPort):
+    """Draftを同一遷移で統合せず、日本語の通常mergeだけを実行する。"""
+
+    def __init__(
+        self,
+        config: LoopEngineConfig,
+        runner: LocalRunner,
+        environment: Mapping[str, str],
+    ) -> None:
+        super().__init__(config, runner, environment)
+
+    def make_ready_for_review(self, target: HostTarget) -> bool:
+        """expected HEADを維持したままReady化だけを行う。"""
+        if target.pr_number is None or target.head_sha is None:
+            return False
+        fresh = self.current_target()
+        if (
+            fresh is None
+            or fresh.pr_number != target.pr_number
+            or fresh.head_sha != target.head_sha
+            or fresh.stale_checkpoint
+            or fresh.merged
+        ):
+            return False
+        if not fresh.draft:
+            return True
+        ready = self._run_gh(
+            ("pr", "ready", str(target.pr_number), "--repo", self.config.repository)
+        )
+        if not ready.succeeded:
+            return False
+        readback = self.current_target()
+        return bool(
+            readback is not None
+            and readback.pr_number == target.pr_number
+            and readback.head_sha == target.head_sha
+            and not readback.stale_checkpoint
+            and not readback.draft
+            and not readback.merged
+        )
+
+    def has_current_head_review(self, target: HostTarget) -> bool:
+        """current exact HEADへ提出済みのreview evidenceがあるか確認する。"""
+        if target.pr_number is None or target.head_sha is None:
+            return False
+        raw = self._api_value(
+            f"repos/{self.config.repository}/pulls/{target.pr_number}/reviews?per_page=100"
+        )
+        if not isinstance(raw, list):
+            raise RuntimeError("GitHubレビュー応答が一覧ではありません")
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            if item.get("commit_id") != target.head_sha:
+                continue
+            state = item.get("state")
+            if state in {"DISMISSED", "PENDING"}:
+                continue
+            return True
+        return False
+
+    def merge_current(self, target: HostTarget) -> bool:
+        """Ready済みexpected HEADだけを日本語messageで通常mergeする。"""
+        self._merge_conflict_target = None
+        if target.pr_number is None or target.head_sha is None:
+            return False
+        if self._pull_requires_reconciliation(target):
+            self._remember_merge_conflict(target)
+            return False
+
+        fresh = self.current_target()
+        if (
+            fresh is None
+            or fresh.pr_number != target.pr_number
+            or fresh.head_sha != target.head_sha
+            or fresh.stale_checkpoint
+        ):
+            return False
+        if fresh.merged:
+            return True
+        if fresh.draft:
+            return False
+
+        pull = self._api_json(f"repos/{self.config.repository}/pulls/{target.pr_number}")
+        if pull.get("state") != "open":
+            return False
+        head = pull.get("head")
+        base = pull.get("base")
+        if not isinstance(head, dict) or head.get("sha") != target.head_sha:
+            return False
+        if not isinstance(base, dict) or not isinstance(base.get("ref"), str):
+            return False
+        base_ref = base["ref"]
+
+        merged = self._run_gh(
+            (
+                "pr",
+                "merge",
+                str(target.pr_number),
+                "--repo",
+                self.config.repository,
+                "--merge",
+                "--match-head-commit",
+                target.head_sha,
+                "--subject",
+                f"PR #{target.pr_number} を {base_ref} へ統合する",
+                "--body",
+                f"Work #{target.work_issue} の変更を通常マージで統合する。",
+            ),
+            timeout_seconds=180,
+        )
+        if not merged.succeeded:
+            if self._pull_requires_reconciliation(target):
+                self._remember_merge_conflict(target)
+            return False
+        readback = self._api_json(f"repos/{self.config.repository}/pulls/{target.pr_number}")
+        return bool(readback.get("merged"))
+
+
+class ReviewAwareHostLoopController(ReconciliationAwareHostLoopController):
+    """Ready化とcurrent-head review到着をmergeとは別遷移にする。"""
+
+    def __init__(
+        self,
+        config: LoopEngineConfig,
+        mission: PilotAwareMissionPort,
+        implementer: PilotPlanningImplementer,
+        review_port: SafeActualHostMissionPort,
+    ) -> None:
+        super().__init__(config, mission, implementer)
+        self._review_port = review_port
+
+    def run_once(self) -> HostTransitionResult:
+        try:
+            target = self._reconciliation_mission.current_target()
+        except RuntimeError:
+            return super().run_once()
+
+        if (
+            target is not None
+            and target.issue_open
+            and not target.merged
+            and not target.stale_checkpoint
+            and target.pr_number is not None
+            and target.head_sha is not None
+        ):
+            try:
+                ci = self._reconciliation_mission.ci_status(target)
+            except RuntimeError:
+                return HostTransitionResult(
+                    HostTransitionStatus.INTERVENTION_REQUIRED,
+                    "CI_OBSERVE_FAILED",
+                    target.work_issue,
+                    target.pr_number,
+                    target.head_sha,
+                )
+            if ci is CIGateStatus.PASS:
+                if target.draft:
+                    if not self._review_port.make_ready_for_review(target):
+                        return HostTransitionResult(
+                            HostTransitionStatus.INTERVENTION_REQUIRED,
+                            "READY_TRANSITION_FAILED",
+                            target.work_issue,
+                            target.pr_number,
+                            target.head_sha,
+                        )
+                    return HostTransitionResult(
+                        HostTransitionStatus.YIELD_EXTERNAL,
+                        "REVIEW_PENDING",
+                        target.work_issue,
+                        target.pr_number,
+                        target.head_sha,
+                    )
+                try:
+                    reviewed = self._review_port.has_current_head_review(target)
+                except RuntimeError:
+                    return HostTransitionResult(
+                        HostTransitionStatus.YIELD_EXTERNAL,
+                        "REVIEW_PENDING",
+                        target.work_issue,
+                        target.pr_number,
+                        target.head_sha,
+                    )
+                if not reviewed:
+                    return HostTransitionResult(
+                        HostTransitionStatus.YIELD_EXTERNAL,
+                        "REVIEW_PENDING",
+                        target.work_issue,
+                        target.pr_number,
+                        target.head_sha,
+                    )
+
+        return super().run_once()

--- a/src/loop_engineering/durable_host_entrypoint.py
+++ b/src/loop_engineering/durable_host_entrypoint.py
@@ -9,13 +9,12 @@ from pathlib import Path
 from typing import Protocol
 
 from . import host_entrypoint
-from .config import LoopEngineConfig
-from .host_entrypoint import (
-    PilotAwareMissionPort,
-    PilotPlanningImplementer,
-    ReconciliationAwareHostLoopController,
-    StrictGhMissionPort,
+from .actual_host_merge_safety import (
+    ReviewAwareHostLoopController,
+    SafeActualHostMissionPort,
 )
+from .config import LoopEngineConfig
+from .host_entrypoint import PilotAwareMissionPort, PilotPlanningImplementer
 from .host_runtime import (
     HostTransitionResult,
     HostTransitionStatus,
@@ -140,7 +139,7 @@ def run_durable_actual_host_transition(
             "CODEX_COMMAND_INVALID",
         )
 
-    strict = StrictGhMissionPort(resolved_config, runner, values)
+    strict = SafeActualHostMissionPort(resolved_config, runner, values)
     mission = PilotAwareMissionPort(resolved_config, strict)
     implementer = PilotPlanningImplementer(
         resolved_config,
@@ -149,10 +148,11 @@ def run_durable_actual_host_transition(
         values,
         argv_prefix,
     )
-    controller = ReconciliationAwareHostLoopController(
+    controller = ReviewAwareHostLoopController(
         resolved_config,
         mission,
         implementer,
+        strict,
     )
     return DurableHostTransitionCoordinator(
         project_key=resolved_project_key,

--- a/tests/loop_engineering/test_actual_host_merge_safety.py
+++ b/tests/loop_engineering/test_actual_host_merge_safety.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from loop_engineering.actual_host_merge_safety import (
+    ReviewAwareHostLoopController,
+    SafeActualHostMissionPort,
+)
+from loop_engineering.ci_gate import CIGateStatus
+from loop_engineering.host_entrypoint import PilotAwareMissionPort, PilotPlanningImplementer
+from loop_engineering.host_runtime import (
+    HostTarget,
+    HostTransitionStatus,
+    LocalCommandResult,
+)
+
+from .conftest import config
+
+
+class NoopRunner:
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        environment: Mapping[str, str] | None = None,
+        timeout_seconds: int = 120,
+        capture_output: bool = True,
+    ) -> LocalCommandResult:
+        del command, cwd, environment, timeout_seconds, capture_output
+        return LocalCommandResult(0, "")
+
+
+class FakePilotMission(PilotAwareMissionPort):
+    def __init__(self, target: HostTarget) -> None:
+        self.target = target
+        self.merge_calls = 0
+        self.checkpoints: list[str] = []
+
+    def current_target(self) -> HostTarget | None:
+        return self.target
+
+    def ci_status(self, target: HostTarget) -> CIGateStatus:
+        del target
+        return CIGateStatus.PASS
+
+    def merge_current(self, target: HostTarget) -> bool:
+        del target
+        self.merge_calls += 1
+        return True
+
+    def merge_requires_reconciliation(self, target: HostTarget) -> bool:
+        del target
+        return False
+
+    def complete_work(self, target: HostTarget) -> bool:
+        del target
+        return True
+
+    def publish_checkpoint(self, body: str) -> bool:
+        self.checkpoints.append(body)
+        return True
+
+
+class NoopPilotImplementer(PilotPlanningImplementer):
+    def __init__(self) -> None:
+        self.plan_calls: list[int | None] = []
+
+    def continue_work(self, target: HostTarget, *, repair: bool) -> bool:
+        del target, repair
+        return False
+
+    def plan_next_work(self, completed_work: int | None) -> bool:
+        self.plan_calls.append(completed_work)
+        return True
+
+
+class FakeReviewPort(SafeActualHostMissionPort):
+    def __init__(self, *, ready_result: bool = True, reviewed: bool = False) -> None:
+        self.ready_result = ready_result
+        self.reviewed = reviewed
+        self.ready_calls = 0
+        self.review_calls = 0
+
+    def make_ready_for_review(self, target: HostTarget) -> bool:
+        del target
+        self.ready_calls += 1
+        return self.ready_result
+
+    def has_current_head_review(self, target: HostTarget) -> bool:
+        del target
+        self.review_calls += 1
+        return self.reviewed
+
+
+class RecordingSafePort(SafeActualHostMissionPort):
+    def __init__(self, target: HostTarget) -> None:
+        super().__init__(config(), NoopRunner(), {"PATH": "/usr/bin"})
+        self.target = target
+        self.commands: list[tuple[str, ...]] = []
+        self.pull_reads = 0
+
+    def current_target(self) -> HostTarget | None:
+        return self.target
+
+    def _pull_requires_reconciliation(self, target: HostTarget) -> bool:
+        del target
+        return False
+
+    def _api_json(self, endpoint: str) -> dict[str, object]:
+        del endpoint
+        self.pull_reads += 1
+        if self.pull_reads == 1:
+            return {
+                "state": "open",
+                "head": {"sha": self.target.head_sha},
+                "base": {"ref": "rebuild/v2-foundation"},
+            }
+        return {"merged": True}
+
+    def _run_gh(
+        self,
+        arguments: Sequence[str],
+        *,
+        timeout_seconds: int = 60,
+    ) -> LocalCommandResult:
+        del timeout_seconds
+        self.commands.append(tuple(arguments))
+        return LocalCommandResult(0, "")
+
+
+def test_draft_ci_success_only_moves_to_review_pending() -> None:
+    target = HostTarget(384, True, 441, "a" * 40, True, False, 1, "a" * 40)
+    mission = FakePilotMission(target)
+    implementer = NoopPilotImplementer()
+    review = FakeReviewPort(ready_result=True)
+
+    result = ReviewAwareHostLoopController(
+        config(), mission, implementer, review
+    ).run_once()
+
+    assert result.status is HostTransitionStatus.YIELD_EXTERNAL
+    assert result.detail == "REVIEW_PENDING"
+    assert review.ready_calls == 1
+    assert review.review_calls == 0
+    assert mission.merge_calls == 0
+
+
+def test_ready_pr_without_current_head_review_stays_pending() -> None:
+    target = HostTarget(384, True, 441, "b" * 40, False, False, 1, "b" * 40)
+    mission = FakePilotMission(target)
+    implementer = NoopPilotImplementer()
+    review = FakeReviewPort(reviewed=False)
+
+    result = ReviewAwareHostLoopController(
+        config(), mission, implementer, review
+    ).run_once()
+
+    assert result.status is HostTransitionStatus.YIELD_EXTERNAL
+    assert result.detail == "REVIEW_PENDING"
+    assert review.ready_calls == 0
+    assert review.review_calls == 1
+    assert mission.merge_calls == 0
+
+
+def test_draft_merge_is_refused_without_ready_side_effect() -> None:
+    target = HostTarget(384, True, 441, "c" * 40, True, False, 1, "c" * 40)
+    port = RecordingSafePort(target)
+
+    assert not port.merge_current(target)
+    assert port.commands == []
+
+
+def test_ready_merge_uses_japanese_subject_and_body() -> None:
+    target = HostTarget(384, True, 441, "d" * 40, False, False, 1, "d" * 40)
+    port = RecordingSafePort(target)
+
+    assert port.merge_current(target)
+    assert len(port.commands) == 1
+    command = port.commands[0]
+    assert "--match-head-commit" in command
+    assert "--subject" in command
+    assert "PR #441 を rebuild/v2-foundation へ統合する" in command
+    assert "--body" in command
+    assert "Work #384 の変更を通常マージで統合する。" in command


### PR DESCRIPTION
## 対象

- #57 PR通常マージのmerge commitメッセージが英語既定値になる
- #58 Draft PRを同一遷移でReady化してmergeし得る

## 方針

- Draft PRは同一遷移でReady化→mergeしない
- CI SUCCESSでもDraftなら `REVIEW_PENDING` として外部待ちへ譲る
- review PASSそのものは正本どおり必須化しない
- Ready後の通常mergeでは expected HEAD固定を維持する
- merge commitのsubject/bodyを日本語で明示する
- 既存の通常merge方式・readback・CI gateを維持する

## 完了条件

- 設計→実装→tests
- pytest / Ruff / strict Mypy / compileall / diff-check PASS
- exact-head CI PASS
- Yura actual-hostでDraft PRを誤mergeしない
- merge commitタイトル/本文が日本語になる
