### PR TITLE
feat: V2の作業状態DBとIssue責務を分離する

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ area = Runtime / Infrastructure
 issue_level = Work
 ```
 
-Project / Mission / Parent / Integration Workを同じIssue番号へ便宜的に潰しません。GitHub liveとMission #33を現在状態の正本として扱います。
+Project / Mission / Parent / Integration Workを同じIssue番号へ便宜的に潰しません。IssueとProjectは課題・作業の統括を、PostgreSQLは停止後に復元する実行作業状態を所有します。詳細は`docs/architecture/v2/work_state_and_issue_boundary.md`を参照してください。
 
 ## 起動
 

--- a/config/goals/ktan514__ai-liver-yura.md
+++ b/config/goals/ktan514__ai-liver-yura.md
@@ -5,7 +5,7 @@ generation: 1
 
 ## Mission
 
-Root #317をMission #450の管理下で完成まで進める。現在状態の正本はGitHub liveのIssue、PR、branch、厳密HEAD、CI、Project #7とする。固定PR番号や固定HEADをGoal本文へ埋め込まず、最新Mission Checkpointとfresh readbackから現在対象を解決する。
+Root #317をMission #450の管理下で完成まで進める。IssueとProject #7は課題・作業の統括を、PostgreSQLは停止後に復元する実行作業状態を所有する。PR、branch、厳密HEAD、CIは対象外部効果の正本とし、DB復元後に必要な対象だけを再照合する。固定PR番号や固定HEADをGoal本文へ埋め込まない。
 
 ## Authorityと安全境界
 
@@ -19,7 +19,7 @@ Root #317をMission #450の管理下で完成まで進める。現在状態の�
 
 ## 再開判定
 
-branch作成、実装、push、merge、新規PR作成の前にGitHub live、最新Mission/Work Checkpoint、現在trunk、canonical design、active lineage、CI/review状態をfresh確認する。
+branch作成、実装、push、merge、新規PR作成の前にDBの安全Checkpointと作業パケットを復元し、Issue / Projectの作業定義、現在trunk、正本設計、作業系列、対象CI/review状態を必要な範囲で再照合する。Issue commentを再開入力にしない。
 
 競合lineage、不明なSHA更新、Authority不一致がある場合は再調整してから進む。会話記憶だけで現在対象を確定しない。
 
@@ -39,7 +39,7 @@ branch作成、実装、push、merge、新規PR作成の前にGitHub live、最�
 
 ## Operational State
 
-PostgreSQLはLoop EngineeringのRun、transition、checkpoint、blocker、lease、重複実行防止等のOperational Stateに使用する。GitHub current-state AuthorityやMission GoalをDBの過去状態で上書きしない。
+PostgreSQLはLoop EngineeringのRun、transition、作業パケット、Checkpoint、blocker、lease、重複実行防止等の実行作業状態に使用する。停止後の再開はDBを起点にする。Issueの目的、受入条件、依存関係、完了判断をDBの状態で上書きしない。
 
 ## Mission状態
 

--- a/docs/architecture/authority_and_state.md
+++ b/docs/architecture/authority_and_state.md
@@ -9,7 +9,19 @@ Loop Engineeringが扱う「現在状態」「設計Authority」「実行記憶�
 
 ## 2. Authority classes
 
-### 2.1 Current-state Authority
+### 2.1 課題・作業の統括
+
+「何を解決するか」「いつ完了とみなすか」を決めるIssueと計画システムの現在値。
+
+例:
+
+- Issueの目的、受入条件、依存関係、open/closed
+- Projectの優先度、計画上の状態
+- Issue commentによる人間向け進捗・判断記録
+
+Issue commentは実行再開の機械入力ではない。
+
+### 2.2 外部現在状態
 
 「今どうなっているか」を決める外部/live source。
 
@@ -23,15 +35,15 @@ Loop Engineeringが扱う「現在状態」「設計Authority」「実行記憶�
 
 Coreは特定providerを前提にせず、Adapterからnormalized snapshotを受け取る。
 
-### 2.2 Design Authority
+### 2.3 設計正本
 
 「どうあるべきか」を決めるtrusted canonical design / ADR / policy。
 
 必ずexact revision identityを持つ。
 
-### 2.3 Operational State
+### 2.4 実行作業状態
 
-再起動・重複抑止・監査のためのruntime memory。
+再起動・重複抑止・監査のためのDB上の実行記憶。選択済み作業、作業パケット、再開Checkpoint、未確定の外部効果を含む。
 
 例:
 
@@ -42,9 +54,9 @@ Coreは特定providerを前提にせず、Adapterからnormalized snapshotを受
 - event log
 - local checkpoint
 
-Operational Stateをexternal current-state Authorityへ昇格しない。
+Issueの目的・受入条件・完了判断をDBへ移さない。一方で、再開対象をIssue Checkpointから復元しない。
 
-### 2.4 Conversational Context
+### 2.5 会話文脈
 
 chat transcript / summary / memory等。
 
@@ -54,17 +66,16 @@ chat transcript / summary / memory等。
 
 Generic default:
 
-### Current facts
+### 課題・実行状態
 
-1. fresh live provider state
-2. provider-bound latest durable checkpoint
-3. normalized planning state
-4. trusted local operational evidence
-5. conversational context
+1. Issue / Projectの現在定義
+2. DBの選択済み作業と安全Checkpoint
+3. 対象外部効果の現在値
+4. 会話文脈
 
 ただし「順番で上書きする」だけではなく、不一致はtyped conflictとして残す。
 
-### Design intent
+### 設計意図
 
 1. target Workが参照するtrusted canonical design revision
 2. parent/root architecture / mandatory platform policy
@@ -264,7 +275,7 @@ PRが長期化してtrusted canonical branchが進んだ場合、Review/Resume�
 
 ## 12. Checkpoint model
 
-Checkpointは再開補助でありcurrent truthではない。
+CheckpointはDB内の再開正本である。ただし、外部効果の成否はCheckpointだけで確定せず、必要な対象を再照合する。
 
 ```text
 Checkpoint
@@ -284,13 +295,14 @@ Checkpoint
 restart時:
 
 ```text
-Checkpoint
-+ fresh live state
-→ reconcile
-→ Resume Gate
+DB Checkpoint
++ Issue / Project定義同期
++ 対象外部効果の再照合
+→ 再調整
+→ 再開判定
 ```
 
-Checkpointだけから作業を再開しない。
+Issue commentだけから作業を再開しない。DB Checkpointが指す未確定effectは再送せず、先に対象を照合する。
 
 ## 13. State ownership matrix
 
@@ -301,7 +313,7 @@ Checkpointだけから作業を再開しない。
 | canonical design | trusted source ref | yes | yes when generation-sensitive |
 | CI result | CI provider | yes | yes before merge |
 | review verdict | Reviewer provider/broker | yes | yes before merge |
-| runtime blocker | RuntimeStore + resolution evidence | n/a | yes |
+| 実行上のblocker | RuntimeStore + 解消証拠 | n/a | yes |
 | execution lease | ExecutionLeasePort | n/a | yes |
 | chat memory | none/current state non-authoritative | yes | never sufficient |
 

--- a/docs/architecture/v2/loop_autonomous_runner.md
+++ b/docs/architecture/v2/loop_autonomous_runner.md
@@ -54,7 +54,7 @@ Repository、Project、Mission、Parent、Integration Work、trunk、CI workflow
 - Integration Work: #27
 - Root: 未設定
 
-現在対象は毎回GitHub liveから再取得する。Checkpointや会話記憶だけからPR / branch / HEADを推測しない。
+現在対象はDBの作業記録と安全Checkpointから復元する。PR / branch / HEADなど外部効果に関わる対象は、DBが記録したidentityを用いて必要な遷移の直前にGitHubから再取得する。Issue commentや会話記憶だけから対象を推測しない。
 
 ## 接続口と実行境界
 
@@ -62,7 +62,7 @@ Repository、Project、Mission、Parent、Integration Work、trunk、CI workflow
 
 standalone実装正本は`src/loop_engineering/**`であり、製品実行系を別packageへ複製しない。現在の配置契約は`standalone_package_layout.md`を正本とする。
 
-最新Mission Checkpointを探索候補として使用するが、古い解析可能なCheckpointへ遡って現在対象を補完しない。現在対象の識別情報が必要な遷移で欠落または不正なら安全側停止にする。
+Issueの状況報告は候補探索にも再開入力にも使用しない。DBの安全Checkpointに現在対象の識別情報が欠落または不正な場合は安全側停止にする。
 
 ただし、Work統合後から次Work選択前までの正常な中間状態と、破損したCheckpointは区別する必要がある。#27はこの実運転境界を検証する。
 

--- a/docs/architecture/v2/loop_design_completion_matrix.md
+++ b/docs/architecture/v2/loop_design_completion_matrix.md
@@ -4,6 +4,8 @@
 
 この表は#462配下のLoop Engineering実装で参照する設計上の正本である。開発制御系の`tools/loop_engine/`と、AI Liver製品実行系の`app/`を意図的に分離する。
 
+Issue #62のV2作業状態DB移行では、`work_state_and_issue_boundary.md`、`work_recovery_algorithm.md`、`v2_adapters_cutover_and_acceptance.md`を優先する。旧actual-host方式と自然文Checkpoint解析を前提にした記述はV2へ適用しない。
+
 | 領域 | 正本文書 | 所有Work | 完了契約 |
 | --- | --- | --- | --- |
 | A: 環境 | `docs/operations/loop_environment_preflight.md` | #463 / #469 | 利用能力確認とホスト起動は製品に依存しない |

--- a/docs/architecture/v2/loop_integration_recovery.md
+++ b/docs/architecture/v2/loop_integration_recovery.md
@@ -9,8 +9,8 @@
 | CI | 厳密HEADに対するGitHub Actions証拠 |
 | ProjectのStatus / Priority / Area / Issue level / Start / Target | Project #7の現在値 |
 | 正本設計 | Repository正本文書のblob identity |
-| Work Checkpoint | 遷移、`TaskPacket`、健全性、永続的な経緯 |
-| Mission Checkpoint | 現在Workの経緯と次作業 |
+| DB作業Checkpoint | 遷移、作業パケット、健全性、永続的な経緯と再開地点 |
+| Issueの状況報告 | 現在Workの経緯と次作業を人間へ展開する出力 |
 
 Checkpointの値でProject #7が所有する項目を上書きしない。現在の正本と矛盾した場合は現在状態から修復するか、安全側停止（fail-closed）する。
 
@@ -22,13 +22,13 @@ Checkpointの値でProject #7が所有する項目を上書きしない。現在
 
 ## 実ホストでの対象解決
 
-通常のLoop CLIは、#450の**最新**`Mission Checkpoint`コメントだけを探索記録として使用し、古い解析可能なCheckpointへ遡らない。変更可能なCheckpointは最低でも`current Work`を明示し、PRが存在する場合は`current PR`と観測した厳密HEADも記録する。
+通常のLoop CLIは、DBの最新安全Checkpointと作業パケットを復元する。Issue commentを探索して`current Work`、PR、HEAD、次遷移を組み立てない。
 
-Checkpointの対象情報自体は実行上の正本ではない。解析後、CI判定、Codex起動、Ready化、統合、Issue終了、Checkpoint投稿の前に、Work IssueとPR/branch HEADをGitHubから再取得する。CheckpointのHEADと現在PRのHEADが異なる場合は古い情報として扱い、再調整が完了するまで変更しない。
+DBのCheckpointは実行再開の正本だが、外部効果の成否を単独で決めない。CI判定、Codex起動、Ready化、統合、Issue終了の前に、DBが記録したWork IssueとPR/branch HEADをGitHubから必要最小限で再取得する。記録したHEADと現在PRのHEADが異なる場合は古い情報として扱い、再調整が完了するまで変更しない。
 
-最新Mission Checkpointに明示的な現在対象がない、対象識別情報が不正、またはGitHubの現在状態と再調整できない場合、ホストは型付きの安全側停止結果を返す。過去の完了済みWorkを再実行する危険があるため、古いMission Checkpointへ暗黙に戻ってはならない。
+DBに安全Checkpointがない、対象識別情報が不正、または未確定effectを再調整できない場合、ホストは型付きの安全側停止結果を返す。過去のIssue報告へ暗黙に戻ってはならない。
 
-次Workを選択する計画専用Codexは、次回ホスト実行が必要とする`current Work`、PR、HEADの識別情報を明示した新しいMission Checkpointを必ず作成する。
+次Workを選択する計画処理は、次回ホスト実行に必要な`current Work`、PR、HEAD、次遷移をDBの作業パケットと安全Checkpointへ確定する。Issueには確定後の状況報告だけを投稿する。
 
 ## 統合競合の再調整
 

--- a/docs/architecture/v2/loop_operational_store.md
+++ b/docs/architecture/v2/loop_operational_store.md
@@ -1,24 +1,25 @@
 # Loop運用記憶 / PostgreSQL管理基盤
 
-管理Issue: #44
+管理Issue: #62
+旧管理Issue: #44
 関連: #27 / #3 / #31 / source `ktan514/ai-liver-yura#470`
 状態: canonical architecture
 
 ## 1. 目的
 
-PostgreSQLをLoop Engineeringの運用状態（Operational State）の永続正本として使用する。
+PostgreSQLをLoop Engineeringの実行中作業状態の永続正本として使用する。再開時の作業選択済み状態、作業パケット、Checkpoint、未確定effect、lease、重複抑止はDBから復元する。
 
-GitHub liveのIssue、PR、Project、branch、厳密HEAD、CI、reviewは引き続き現在状態の正本であり、PostgreSQLへ複製した過去値で上書きしない。Mission GoalとProject Registrationのbootstrap trust anchorもDBだけへ依存させない。
+GitHub Issueは課題・受入条件・優先度・依存関係・完了判断と人間向け状況報告を所有する。PR、branch、厳密HEAD、CI、reviewは各外部提供元が実効果の正本であり、DB復元後に必要な対象だけを再照合する。詳細な責務境界は`work_state_and_issue_boundary.md`を正本とする。
 
 ```text
-GitHub live
-→ Productの現在状態
+GitHub Issue / Project
+→ 課題と作業の統括
 
 Host Mission Goal / Project Registration
 → 実行対象と安全境界
 
 PostgreSQL Operational Store
-→ Run / transition / checkpoint / blocker / lease / idempotency等の運用状態
+→ 実行作業 / 作業パケット / Checkpoint / effect / lease / 重複抑止
 ```
 
 ## 2. ローカル実運転の接続方式
@@ -117,23 +118,24 @@ Migrationは通常の観測とは分離した明示操作で行い、事前確�
 | `loop_dispatches` | Codex/review等のdispatch重複抑止 |
 | `loop_external_waits` | review/CI/Human等の待機identity |
 
-ProductのIssue/PR本文やcanonical design本文をDBへ丸ごとmirrorしない。必要な場合はstable identity、revision、digest、状態値、secret-safe metadataだけを保存する。
+ProductのIssue/PR本文やcanonical design本文をDBへ丸ごとmirrorしない。必要な場合はstable identity、revision、digest、状態値、secret-safe metadataだけを保存する。作業状態、作業パケット、再開Checkpoint、effect試行、Issue報告outboxはDBへ追加する。
 
 ## 7. restart / reconcile
 
-再起動時にDBだけからcurrent Workを決めない。
+再起動時はDBの作業記録と安全Checkpointからcurrent Workを復元する。Issue commentを探索して再開対象を決めない。
 
 ```text
 Operational State readback
-+ fresh GitHub live state
++ Issue / Projectの作業定義同期
++ 対象外部効果の限定再照合
 + Host Mission Goal / Project Registration
 → RECONCILE
 → Resume Gate
 ```
 
-DBは「前回どこまでeffectを要求・確認したか」「重複送信してよいか」「blocker/leaseが残っているか」を提供する。
+DBは「どの作業を選択し、前回どこまでeffectを要求・確認したか」「重複送信してよいか」「blocker/leaseが残っているか」を提供する。
 
-GitHub liveとDBが不一致なら、現在状態はGitHubを優先し、不一致自体をtyped conflict/evidenceとして記録する。
+Issueの定義変更とDBの未完了作業が不一致なら、同期競合として記録して再調整する。外部効果の不一致は対象提供元の読戻しを優先する。
 
 ## 8. idempotency / transaction
 
@@ -178,8 +180,9 @@ Yura Product Workspaceを対象に次を確認する。
 
 ## 11. Hard invariants
 
-- PostgreSQL Operational State != GitHub current-state Authority
-- Mission Goalの正本をDBだけへ移さない
+- PostgreSQLは再開する実行作業状態の正本である
+- Issueは課題・受入条件・完了判断の正本である
+- Issue commentを再開の機械入力にしない
 - Product Workspaceへ管理DB credentialを保存しない
 - passwordをcommand argvへ埋め込まない
 - Preflightはmigrationを自動適用しない

--- a/docs/architecture/v2/runtime_state_reconciliation.md
+++ b/docs/architecture/v2/runtime_state_reconciliation.md
@@ -1,6 +1,7 @@
 # Runtime Operational State / Restart Reconciliation
 
-管理Issue: #44
+管理Issue: #62
+旧管理Issue: #44
 関連: #27 / #46
 状態: canonical architecture
 
@@ -8,7 +9,7 @@
 
 PostgreSQL Operational Storeを、Loop EngineeringのHost run、遷移履歴、実行排他、再起動復旧、重複副作用防止のために使用する。
 
-この文書はGitHub current-state Authorityを変更しない。Issue、PR、Project、branch、exact HEAD、CI、review、Mission Checkpointの現在状態はfresh GitHub readを正とする。PostgreSQLは過去の運用効果と未確定状態を保持するだけで、DBだけからcurrent Workやmerge可否を決定しない。
+この文書は`work_state_and_issue_boundary.md`に従う。DBは再開対象の作業、作業パケット、Checkpoint、未確定effectを復元する正本である。Issueは課題と作業の統括を所有し、Issue commentは人間向け報告であって再開入力ではない。PR、branch、exact HEAD、CI、reviewの実効果は、DBが記録した対象identityを用いて必要時だけ再照合する。
 
 ## 2. 1 Host遷移の永続境界
 
@@ -16,11 +17,11 @@ PostgreSQL Operational Storeを、Loop EngineeringのHost run、遷移履歴、�
 
 開始順序:
 
-1. 前回の未完了runをPostgreSQLからreadbackする。
-2. GitHubからcurrent targetをfresh readする。
-3. 前回未完了runがある場合は、そのrunが記録した観測Checkpointとfresh targetを比較してreconcileする。
+1. 前回の未完了runと作業の安全CheckpointをPostgreSQLからreadbackする。
+2. Issue / Projectから作業定義の変更だけを同期する。
+3. 前回未完了runがある場合は、DBのeffect状態に対応する外部対象だけを再照合してreconcileする。
 4. 現在runの`run_id`を生成し`loop_runs`へ`RUNNING`として記録する。
-5. current targetの最小snapshotを`loop_checkpoints`へ記録する。
+5. 復元した作業パケットと外部対象identityを`loop_checkpoints`へ記録する。
 6. project単位execution leaseを取得する。
 7. Host controllerを1遷移だけ実行する。
 8. 結果を`loop_transitions`へ記録し、必要に応じてblocker / external waitを更新する。
@@ -32,24 +33,23 @@ PostgreSQL Operational Storeを、Loop EngineeringのHost run、遷移履歴、�
 
 前回runが`RUNNING`のまま残っている場合、Loop Engineeringは副作用が発生しなかったと推定しない。
 
-前回runに記録されたCheckpoint snapshotとfresh GitHub targetを比較する。
+前回runに記録された作業Checkpointと、そのCheckpointが指す外部effectだけを比較する。
 
 ### 3.1 GitHub側が前進している場合
 
 次のいずれかが変化していれば、DB上の前回状態はstale operational stateとしてreconcileできる。
 
-- Mission Checkpoint comment identity
 - current Work
 - current PR
 - exact HEAD
 
-fresh GitHub stateを採用し、前回runを`RECONCILED`として閉じ、古いleaseを解放して現在runを継続する。
+確認済みの外部効果をDBへ確定し、前回runを`RECONCILED`として閉じ、古いleaseを解放して現在runを継続する。
 
 ### 3.2 同一Checkpointのままの場合
 
-前回runが`RUNNING`で、fresh GitHub targetが前回snapshotと同一である場合、副作用の成否は確定できない。
+前回runが`RUNNING`で、DB上の`EFFECT_PENDING`に対応する外部効果を確認できない場合、副作用の成否は確定できない。
 
-この場合はCodex実行、GitHub write、merge等を再送しない。`OPERATIONAL_STATE_UNCERTAIN`として型付きInterventionへ遷移し、blockerを永続化する。
+この場合はCodex実行、GitHub write、merge等を再送しない。`OPERATIONAL_STATE_UNCERTAIN`として型付き待機またはblockerへ遷移し、DBへ永続化する。
 
 前回runに観測Checkpoint自体が無い場合も同様に未確定として扱う。
 

--- a/docs/architecture/v2/v2_adapters_cutover_and_acceptance.md
+++ b/docs/architecture/v2/v2_adapters_cutover_and_acceptance.md
@@ -1,0 +1,117 @@
+# V2接続層・切替・受入設計
+
+管理Issue: #62
+
+状態: 再設計正本
+
+## 1. 適用範囲
+
+本書は`work_recovery_algorithm.md`で未確定だった接続層、Host合成、旧状態からの切替、受入試験を定義する。V2は旧actual-host入口を呼び出さず、旧自然文Checkpointの解析器も使用しない。
+
+## 2. 接続口
+
+| 接続口 | 読取り | 書込み | 入出力 | 禁止事項 |
+| --- | --- | --- | --- | --- |
+| `WorkDefinitionPort` | Issue / Project | なし | Issue identity、revision、open/closed、受入条件digest、依存関係、優先度 | 本文・commentから現在WorkやPRを推測しない |
+| `EffectReadbackPort` | PR / branch / CI / review / Issue | なし | DBのeffect keyとtarget identity | target外の探索、結果の推測 |
+| `EffectExecutorPort` | 必要最小限 | あり | `EffectIntent` | lease、DB意図、Write Gateなしの変更 |
+| `IssueReportPublisherPort` | Issue | comment投稿 | outbox identityと安全な報告本文 | DB未確定状態の報告、本文への秘密情報混入 |
+| `WorkStatePort` | PostgreSQL | PostgreSQL | WorkRecord、packet、Checkpoint、effect、outbox | Issue定義の上書き |
+
+各接続口は`repository`と対象identityを引数に必須で受け取る。JSON本文、Issue自然文、PR説明文は型付き入力へ変換しない。接続層からの通信失敗は、対象と段階を含む型付き結果に正規化する。
+
+## 3. Issue / Project定義同期
+
+同期器は1回の読取り区間で、対象Issueと必要なProject itemだけを取得する。保存する値は次である。
+
+```text
+issue identity / issue revision / issue state
+acceptance criteria digest
+dependency issue identities
+priority / Project status / 計画日
+```
+
+IssueがclosedでDBのWorkが`COMPLETED`以外なら`WORK_CLOSED_BEFORE_COMPLETION`、dependencyが未完了なら`WAITING(DEPENDENCY_PENDING)`、同一Issue identityへの異なる受入条件digestは`BLOCKED(WORK_DEFINITION_CONFLICT)`とする。
+
+同期は作業パケットの対象、PR、HEADを作らない。これらはDBに既存のpacketがある場合にだけ、effect読戻しの対象として扱う。
+
+## 4. 外部effectの読戻しと実行
+
+`EffectIntent`は次を必須とする。
+
+```text
+idempotency key
+work identity / packet generation
+kind
+target identity
+expected preconditions
+expected effect
+```
+
+| kind | target identity | 読戻しで確認する値 |
+| --- | --- | --- |
+| `PUSH` | branch、期待HEAD | branch HEAD |
+| `MERGE` | PR、base、期待HEAD | PR状態、merge commit、base、head |
+| `READY` | PR、期待HEAD | draft状態、head |
+| `ISSUE_UPDATE` | Issue、期待revision | Issue revisionと変更値 |
+| `REPORT` | Issue、outbox identity | 投稿済みreport identity |
+
+実行順序は常に`lease → DB意図確定 → Write Gate再確認 → effect実行 → readback → DB結果確定`である。Write Gate不成立、readback不能、期待外のidentityは`UNCERTAIN`または`BLOCKED`であり、同じkeyを再送しない。
+
+## 5. outbox
+
+outboxは`work identity + checkpoint identity + report kind`を一意キーとする。報告本文は定型化した状態、確認済みeffect、待機理由、次の人間への連絡事項だけを含み、DB内部ID、秘密値、認証情報、無加工診断、作業パケット全体を除外する。
+
+投稿前に同一outbox identityをIssue timelineから検索する。存在すれば`PUBLISHED`に確定し、存在しなければ投稿して読戻す。通信失敗は`PENDING`のままにし、作業effectを再実行しない。
+
+## 6. V2 Host合成
+
+V2 Host入口は明示的な`--v2-once`だけで起動する。旧入口の別名、通常入口、continuous実行から暗黙に到達してはならない。
+
+```text
+Preflight
+→ DB migration / capability確認
+→ Work identityを明示指定
+→ V2ResumeCoordinator
+→ READY packetだけを1回実行
+→ DB Checkpoint
+→ outbox投稿
+→ 終了
+```
+
+`--v2-once`はWork identityを必須とする。DBに復元対象が無い場合、またはpacket generationが一致しない場合は変更せず終了する。複数Workの自動選択、sleep、polling、別Workへの暗黙移動は行わない。
+
+leaseは`repository + work identity`単位で原子的に取得し、holder、取得時刻、期限、packet generationを保存する。期限切れleaseは、前holderの未確定effectを先に読戻した場合だけ引き継げる。
+
+## 7. 移行と切替
+
+1. versioned SQLでV2表を追加する。既存表と旧記録は削除・更新しない。
+2. 明示`--migrate-v2-work-state <issue>`だけが、対象Issueの最新状態を一度読み、V2 WorkRecord候補を作る。
+3. PR、HEAD、次遷移、effect意図を旧自然文から復元しない。これらが必要ならmigration結果を`BLOCKED(MIGRATION_TARGET_INCOMPLETE)`にする。
+4. migration結果を人間がIssue上で確認し、V2 packetを明示発行するまで`--v2-once`は実行不可とする。
+5. 切替後も旧Host入口はV2 Workを受け付けない。旧表は監査専用として保持する。
+
+切替失敗時はV2 Workを`BLOCKED`にする。schemaを巻き戻さず、旧actual-host方式へfallbackしない。
+
+## 8. 受入試験
+
+製造前に次を決定論的な試験で満たす。
+
+1. Issue commentに任意のWork、PR、HEADを書いても再開対象は変化しない。
+2. DB安全Checkpointだけから同じpacketを復元できる。
+3. `INTENT_RECORDED`と`UNCERTAIN`の全effect kindで再送0回を証明する。
+4. effectの読戻しが別HEAD、別base、別revisionなら変更0回を証明する。
+5. outbox投稿失敗後、effectなしで同じ報告だけを再送できる。
+6. lease競合、期限切れ、DB障害、migration不一致で変更0回を証明する。
+7. 旧入口がV2 Workを実行できない。
+8. `--v2-once`が1 packet・1遷移だけ実行する。
+9. 実機では専用DBと明示指定の非破壊Workで、DB復元とoutboxのreadbackを確認する。
+
+## 9. 製造開始条件
+
+次がすべて満たされるまで実装へ進まない。
+
+- 本書、`work_state_and_issue_boundary.md`、`work_recovery_algorithm.md`間の矛盾がない。
+- schema、接続口、状態遷移、切替、受入試験が一意に定義されている。
+- 旧actual-host方式へ到達しないことが明示されている。
+- Issue #62で設計レビュー可能な受入条件が合意されている。

--- a/docs/architecture/v2/v2_manufacturing_plan.md
+++ b/docs/architecture/v2/v2_manufacturing_plan.md
@@ -1,0 +1,34 @@
+# V2製造作業計画書
+
+管理Issue: #62
+
+状態: 製造順序の正本
+
+## 1. 前提
+
+本書はV2製造作業の順序、開始日、終了日、依存関係の正本である。製造者は本書にない順序で外部effectを伴う実装を開始しない。開始日・終了日はGitHub Project #9の同名fieldへ転記する。
+
+## 2. 作業順序
+
+| 順序 | 作業 | 開始日 | 終了日 | 依存 | 完了条件 |
+| --- | --- | --- | --- | --- | --- |
+| 1 | DB transaction・lease・packet generation | 2026-08-31 | 2026-09-01 | #62 | intent、Checkpoint、leaseを同一transactionで確定し、競合leaseと停止を試験する |
+| 2 | Issue / Project定義同期adapter | 2026-09-02 | 2026-09-03 | 1 | 指定IssueとProject fieldだけをrevision付きで同期し、自然文を解析しない |
+| 3 | effect読戻し・outbox投稿adapter | 2026-09-04 | 2026-09-05 | 1, 2 | target限定readback、`UNCERTAIN`再送禁止、報告重複抑止を試験する |
+| 4 | `--v2-once` Host合成・移行・受入 | 2026-09-06 | 2026-09-06 | 1, 2, 3 | 明示Workの1 packet・1遷移、旧入口拒否、停止復元の結合試験を通す |
+
+## 3. 詳細設計への対応
+
+| 作業 | 詳細設計の節 |
+| --- | --- |
+| 1 | `work_recovery_algorithm.md` 3、4、5 / `v2_adapters_cutover_and_acceptance.md` 4、6 |
+| 2 | `v2_adapters_cutover_and_acceptance.md` 2、3 |
+| 3 | `v2_adapters_cutover_and_acceptance.md` 4、5 |
+| 4 | `v2_adapters_cutover_and_acceptance.md` 6、7、8 |
+
+## 4. 共通完了条件
+
+- `v2`ラベルを持つIssueとPRだけで作業する。
+- 各WorkはProject #9へ追加し、本書の開始日・終了日を設定する。
+- 新しい外部変更はDB intent、lease、Write Gate、readbackを通過する。
+- 全Work完了後にだけ、#62の受入試験を実機で行う。

--- a/docs/architecture/v2/work_recovery_algorithm.md
+++ b/docs/architecture/v2/work_recovery_algorithm.md
@@ -67,6 +67,8 @@ INTENT_RECORDED
 
 DBにWorkRecordまたは安全Checkpointが無い場合、過去Issue commentへ戻らない。`BLOCKED(WORK_RECOVERY_MISSING)`として、Issueから新規Workを明示選択する処理だけを許可する。
 
+`READY`を返すには、`WorkRecord.latest_task_packet_identity`が指す作業パケットと`WorkRecord.latest_checkpoint_identity`が指す安全Checkpointの両方が存在し、同じWorkを参照し、Checkpointの`task_packet_identity`がその作業パケットを指していなければならない。時刻上もっとも新しい別Checkpointをpointerの代わりに採用してはならない。pointer欠落、参照先欠落、Work不一致、作業パケット不一致のいずれかがある場合は`BLOCKED(WORK_RECOVERY_MISSING)`とし、新しい外部変更を開始しない。
+
 Checkpointが旧schemaの場合、対応migrationを適用した明示移行処理へ渡す。任意の列欠落を空値で補うことは禁止する。
 
 ### 4.2 定義同期

--- a/docs/architecture/v2/work_recovery_algorithm.md
+++ b/docs/architecture/v2/work_recovery_algorithm.md
@@ -10,6 +10,8 @@ V2は、Issue comment、会話、古い外部観測から現在作業を推測�
 
 この文書は`work_state_and_issue_boundary.md`の責務境界を、実行可能な決定アルゴリズムへ具体化する。
 
+接続層、Host合成、切替、受入試験は`v2_adapters_cutover_and_acceptance.md`を正本とする。
+
 ## 2. 入力と出力
 
 1回の再開判定の入力は次だけである。

--- a/docs/architecture/v2/work_recovery_algorithm.md
+++ b/docs/architecture/v2/work_recovery_algorithm.md
@@ -1,0 +1,119 @@
+# V2作業復元アルゴリズム
+
+管理Issue: #62
+
+状態: 再設計正本
+
+## 1. 目的
+
+V2は、Issue comment、会話、古い外部観測から現在作業を推測しない。停止後の再開はDBの安全Checkpointを唯一の起点とし、Issueは課題定義、外部提供元は効果の確認だけを担う。
+
+この文書は`work_state_and_issue_boundary.md`の責務境界を、実行可能な決定アルゴリズムへ具体化する。
+
+## 2. 入力と出力
+
+1回の再開判定の入力は次だけである。
+
+| 入力 | 用途 |
+| --- | --- |
+| DB作業記録 | 選択済みWork、作業パケット、最後の安全Checkpoint、lease、effect試行、報告outbox |
+| Issue / Project定義 | 目的、受入条件、依存関係、優先度、完了判断の同期 |
+| effect対象の外部読戻し | DBに`INTENT_RECORDED`または`UNCERTAIN`として残る対象だけの確認 |
+
+出力は`ResumeDecision`である。
+
+```text
+READY(packet)
+RECONCILE_REQUIRED(effect identities)
+WAITING(reason)
+BLOCKED(reason)
+```
+
+`READY`以外は新しい外部変更を開始しない。
+
+## 3. データモデル
+
+`WorkRecord`はIssue identityと最後に同期したIssue revision、作業ライフサイクル、現在の作業パケット、最後の安全Checkpointを持つ。`TaskPacket`はgeneration、遷移、設計identity、外部対象identity、事前条件を持つ。`WorkCheckpoint`は作業パケットに対応する安全な再開地点だけを持つ。
+
+effectは次の状態機械を必須とする。
+
+```text
+INTENT_RECORDED
+  ├─ 外部効果の読戻し成功 → CONFIRMED
+  ├─ 外部効果なしの読戻し成功 → NO_EFFECT
+  └─ 読戻し不能または曖昧 → UNCERTAIN
+```
+
+`UNCERTAIN`から`INTENT_RECORDED`へ戻す遷移は禁止する。新しいeffectは、異なるidempotency keyを持つ新しい作業パケットだけが要求できる。
+
+## 4. 再開アルゴリズム
+
+```text
+1. DBからWorkRecordと最新安全Checkpointを復元する
+2. DB migration世代とCheckpoint generationを検証する
+3. Work単位leaseを原子的に取得する
+4. Issue / Projectの作業定義を同期する
+5. 定義identity、revision、依存関係、完了判断を照合する
+6. 未確定effectだけを外部提供元から読戻す
+7. ResumeDecisionを確定する
+8. READYの場合だけ作業パケットを1回実行する
+9. DBへ新しい安全Checkpointを確定する
+10. 確定済みCheckpointからIssue報告outboxを生成する
+```
+
+### 4.1 DB復元
+
+DBにWorkRecordまたは安全Checkpointが無い場合、過去Issue commentへ戻らない。`BLOCKED(WORK_RECOVERY_MISSING)`として、Issueから新規Workを明示選択する処理だけを許可する。
+
+Checkpointが旧schemaの場合、対応migrationを適用した明示移行処理へ渡す。任意の列欠落を空値で補うことは禁止する。
+
+### 4.2 定義同期
+
+Issue / Projectから同期するのは、Issue identity、open/closed、受入条件revision、依存関係、優先度、Project計画値だけである。本文・commentの自然文から`current Work`、PR、HEAD、次遷移を抽出しない。
+
+DBの未完了WorkとIssueの定義が競合する場合は、DBまたはIssueのどちらかを暗黙上書きしない。`BLOCKED(WORK_DEFINITION_CONFLICT)`として、明示的な再調整決定を要求する。
+
+### 4.3 effect読戻し
+
+読戻し対象はDBのeffect試行に記録された`kind`と`target_identity`に限定する。例としてmergeはPR番号・base・期待HEAD、pushはbranch・期待HEAD、Issue更新はIssue番号・期待revisionを読む。
+
+対象外のPR、branch、Issue本文、過去作業系列を探索して現在対象を推測してはならない。
+
+### 4.4 作業パケット実行
+
+`READY`の作業パケットは1回だけ実行する。外部変更前に必ず次をDBへ同一transactionで確定する。
+
+```text
+packet status = STARTED
+effect status = INTENT_RECORDED
+effect idempotency key
+期待する外部対象identity
+```
+
+外部効果後はreadbackが`CONFIRMED`になるまで、後続の依存effectや完了遷移へ進まない。プロセス停止時は`INTENT_RECORDED`または`UNCERTAIN`が残り、次回は第6段階から再開する。
+
+## 5. crash matrix
+
+| 停止地点 | DB状態 | 次回の扱い |
+| --- | --- | --- |
+| effect前 | 安全Checkpoint | 同じpacketを実行可能 |
+| effect意図の確定後、effect前 | `INTENT_RECORDED` | 対象を読戻し、再送しない |
+| effect後、読戻し前 | `INTENT_RECORDED` | 対象を読戻し、確認不能なら`UNCERTAIN` |
+| 読戻し成功後、Checkpoint前 | `CONFIRMED` | DBから次のCheckpointを再構成 |
+| Checkpoint後、Issue報告前 | outbox `PENDING` | effectを再実行せず報告だけを再送 |
+
+## 6. Issue報告
+
+Issue報告はDBの確定済みCheckpointからだけ生成する。outbox identityは`work identity + checkpoint identity + report kind`とし、同じ報告を重複投稿しない。
+
+報告の失敗は`PENDING`のまま保持する。DBのWork、effect、Checkpointを巻き戻さず、次回は報告だけを再試行できる。
+
+## 7. 不変条件
+
+- Issue commentは機械的な再開入力ではない。
+- DBに記録されないeffectを実行しない。
+- `UNCERTAIN` effectを再送しない。
+- DBの作業状態をIssue自然文で上書きしない。
+- Issueの目的・受入条件・完了判断をDBの過去値で上書きしない。
+- leaseを持たない実行者はeffectを開始しない。
+- 1作業パケットは1つの安全Checkpoint generationへだけ進む。

--- a/docs/architecture/v2/work_state_and_issue_boundary.md
+++ b/docs/architecture/v2/work_state_and_issue_boundary.md
@@ -1,0 +1,125 @@
+# 作業状態DBとIssueの責務境界
+
+管理Issue: #62
+
+状態: 再設計正本
+
+## 1. 結論
+
+Loop Engineeringは、GitHub IssueとPostgreSQLに同じ作業状態を正本として持たせない。
+
+- Issueは課題と作業の元締めである。何を解決するか、受入条件、優先度、依存関係、設計判断、利用者へ知らせる状況報告を所有する。
+- PostgreSQLは実行中の作業状態の永続正本である。作業環境が停止した後に、どの作業をどこまで実行し、何を確認してから再開するかを復元する。
+- GitHubのPR、branch、CI、reviewなどの外部効果は、それぞれの提供元が正本である。DBはそれらを再実行するための対象identityと確認結果を保存するが、外部効果の値を推測してはならない。
+
+従来の「最新Issue Checkpointを再開の入力にする」方式は廃止する。Issueの報告文は人間向けの出力であり、機械が再開対象を解決する入力ではない。
+
+## 2. 所有権
+
+| 情報 | 所有者 | 用途 |
+| --- | --- | --- |
+| 課題の目的、背景、受入条件、優先度、依存関係、完了判断 | Issue / Project | 作業の起票・選択・統括 |
+| 設計判断と変更理由 | IssueとRepository正本文書 | 人間への情報展開と設計意図 |
+| 進捗、停止理由、次の連絡事項 | Issue comment | 人間への状況報告 |
+| 作業の選択結果、作業パケット、実行段階、再開地点 | PostgreSQL | 停止後の復元 |
+| run、遷移、lease、dispatch、idempotency、blocker、外部待機 | PostgreSQL | 重複防止と安全な継続 |
+| PR、branch、HEAD、CI、reviewの実効果 | 各外部提供元 | 変更前後の対象確認 |
+
+Issueのopen/closed、Projectの優先度・依存関係はDBが上書きしない。反対に、DBの実行段階、lease、未確定副作用、作業パケットをIssue commentから復元・上書きしない。
+
+## 3. DBの復元モデル
+
+DBにはIssueごとの実行可能な作業記録を保持する。少なくとも次をversioned migrationで導入する。
+
+```text
+work_records
+- work_key                         # repository identity + Issue identity
+- issue_identity / issue_revision  # 起票元への参照と最後に確認した版
+- lifecycle                        # PLANNED / SELECTED / RUNNING / WAITING / BLOCKED / COMPLETED
+- selected_transition
+- active_lineage_identity?
+- latest_task_packet_identity?
+- last_safe_checkpoint_identity?
+- revision
+
+task_packets
+- identity / work_key / generation
+- transition / preconditions / expected_effects
+- canonical_design_identities
+- external_target_identities
+- status                            # ISSUED / STARTED / COMPLETED / SUPERSEDED / UNCERTAIN
+
+work_checkpoints
+- identity / work_key / run_identity
+- checkpoint_kind                   # SAFE_POINT / EFFECT_PENDING / EFFECT_CONFIRMED / WAITING
+- resumable_state
+- next_action
+- task_packet_identity
+- external_target_identities
+- evidence_identities
+
+effect_attempts
+- idempotency_key / work_key / kind
+- target_identity / status          # INTENT_RECORDED / CONFIRMED / NO_EFFECT / UNCERTAIN
+- request_identity? / confirmed_at?
+```
+
+本文、秘密情報、無加工のプロンプト、Issue/PR本文、差分、認証情報は保存しない。必要なのは参照identity、版、列挙値、上限付きの安全な説明コードだけである。
+
+`work_records.revision`と各Checkpointのgenerationにより、同じ作業パケットを停止後に二重実行しない。DB更新と外部効果の間に異常終了した場合は、`UNCERTAIN`として残し、再送ではなく対象外部効果の照合へ進む。
+
+## 4. 起動・再開手順
+
+```text
+Issue / Projectを観測
+  → DBへ作業記録を作成または同期
+  → DBから未完了の作業記録と最後の安全Checkpointを復元
+  → 対象外部効果だけを再照合
+  → 再調整
+  → lease取得
+  → 1遷移を実行
+  → DBへCheckpointを確定
+  → Issueへ人間向け報告を投影
+```
+
+再起動の最初の入力はDBである。Issue commentを探索して作業、PR、HEAD、次遷移を組み立ててはならない。
+
+ただし、DBだけで外部変更を開始してはならない。次の場合だけ、DBが記録した対象identityを使って必要最小限の外部再照合を行う。
+
+- PR操作・push・mergeの前: branch、base、HEAD、PR状態
+- CI/reviewに依存する遷移の前: 記録した厳密HEADへの証拠
+- Issue/Project変更の前: 対象Issueと変更予定field
+- `EFFECT_PENDING`または`UNCERTAIN`: 当該effect identityの有無
+
+外部照合が不能なら、DBの安全Checkpointを保持したまま`WAITING`または`BLOCKED`にし、同じ副作用を再送しない。
+
+## 5. Issueとの同期
+
+同期は一方向の役割を持つ。
+
+1. IssueからDBへ、作業の定義と計画上の変更を取り込む。
+2. DBからIssueへ、理解可能な進捗報告を投稿する。
+
+報告には作業状態、実行済み段階、確認済み外部効果、待機理由、次の人間への連絡事項を含める。作業パケット全体、lease、DB内部ID、再実行鍵、機密性のある診断は投稿しない。
+
+DBへの保存に失敗した遷移は、外部変更を開始しない。外部変更後にDB確定へ失敗した場合は`UNCERTAIN`を優先して安全側に停止し、復旧後に対象だけを照合する。Issueへの報告失敗はDBの実行状態を巻き戻さない。報告は再送可能なoutboxとしてDBに保持し、同一報告を重複投稿しない。
+
+## 6. 移行
+
+1. `loop_runs`、`loop_transitions`、`loop_checkpoints`を削除せず、既存記録を履歴として保持する。
+2. 新しい作業記録、作業パケット、Checkpoint、effect試行、Issue報告outboxを追加する。
+3. 現行の最新Issue Checkpointを一度だけ読取り、対応するDB作業記録の初期化候補として扱う。曖昧な対象は自動移行せず`BLOCKED`にする。
+4. Host入口をDB復元→限定再照合へ切り替える。
+5. Issue Checkpointを再開入力から外し、DB確定後の人間向け報告へ置き換える。
+6. 停止後の復元、effect未確定、Issue投稿失敗、GitHub読取不能、DB障害、二重起動を結合試験で証明する。
+
+## 7. 不変条件
+
+- 作業環境の再開対象はDBの安全Checkpointから復元する。
+- 課題の目的・受入条件・完了判断はIssueが所有する。
+- Issue commentは再開の機械入力ではない。
+- 外部効果はDBの記録だけで成功と判定しない。
+- `UNCERTAIN`のeffectを自動再送しない。
+- DB確定前に外部変更を開始しない。
+- DBとIssueの不一致は片方で静かに上書きせず、同期競合として記録する。
+- Issueへの状況報告はDB確定済み状態だけから作成する。

--- a/docs/architecture/v2/work_state_and_issue_boundary.md
+++ b/docs/architecture/v2/work_state_and_issue_boundary.md
@@ -68,6 +68,8 @@ effect_attempts
 
 `work_records.revision`と各Checkpointのgenerationにより、同じ作業パケットを停止後に二重実行しない。DB更新と外部効果の間に異常終了した場合は、`UNCERTAIN`として残し、再送ではなく対象外部効果の照合へ進む。
 
+再開・effect・報告の厳密な状態機械は`work_recovery_algorithm.md`を正本とする。
+
 ## 4. 起動・再開手順
 
 ```text

--- a/docs/operations/loop_engineering_operation_hub.md
+++ b/docs/operations/loop_engineering_operation_hub.md
@@ -4,11 +4,14 @@
 
 ## Authority
 
-- 現在状態: GitHub live Issue / PR / branch / commit SHA / Actions
-- 作業再開: 対象Issueの最新Resume Checkpoint
+- 課題と作業の統括: GitHub Issue / Project
+- 作業再開: PostgreSQLの作業記録と最後の安全Checkpoint
+- 外部効果の確認: GitHubのPR / branch / commit SHA / Actions
 - 計画: GitHub Project `loop-engineering` のlive field
 - 設計: Repository正本文書
 - 会話記憶・summary: 候補発見のみ
+
+Issue commentは人間向けの状況報告であり、再開対象の機械入力に使わない。詳細は`docs/architecture/v2/work_state_and_issue_boundary.md`を参照する。
 
 ## 必須原則
 

--- a/docs/operations/loop_mission_goal.md
+++ b/docs/operations/loop_mission_goal.md
@@ -5,7 +5,7 @@ generation: 1
 
 ## Mission
 
-Mission #33とParent #9を通じて、`ktan514/loop-engineering`をstandalone Loop Engineering Platformとして完成させる。GitHub上の現在Issue、PR、branch、厳密HEAD、CI、Project #9状態を現在状態の正本とする。このGoalへ固定PR番号や固定HEADを書き込まず、最新Mission/Work CheckpointとGitHub liveの再取得から現在対象を解決する。
+Mission #33とParent #9を通じて、`ktan514/loop-engineering`をstandalone Loop Engineering Platformとして完成させる。IssueとProject #9は課題・作業の統括を所有し、PostgreSQLは再開する実行作業状態を所有する。PR、branch、厳密HEAD、CIは対象外部効果の正本であり、DB復元後に必要な対象だけを再取得する。このGoalへ固定PR番号や固定HEADを書き込まない。
 
 ## 正本と安全境界
 
@@ -60,7 +60,7 @@ OpenAI API keyの標準環境変数名は`OPENAI_API_KEY`とする。`OPENAI_API
 
 ## 再開判定と作業パケット
 
-branch作成、実装、push、merge、新規PR作成の前に、GitHub現在状態、最新Mission/Work Checkpoint、正本設計、現在の作業系列を読み、Issue、設計、branch、基点/HEAD SHA、検証、次作業、競合を含む再開証明（Resume Certificate）を生成する。会話記憶から現在状態を推測しない。競合、未知の作業系列、説明できないSHA変更がある場合は、実装前に再調整する。
+branch作成、実装、push、merge、新規PR作成の前に、DBの作業記録と最後の安全Checkpointを復元し、Issue / Projectの作業定義、正本設計、対象のbranch・基点・HEAD SHA・検証状態を必要な範囲で照合する。Issue、設計、branch、基点/HEAD SHA、検証、次作業、競合を含む再開証明（Resume Certificate）を生成する。会話記憶またはIssue commentから現在状態を推測しない。競合、未知の作業系列、説明できないSHA変更がある場合は、実装前に再調整する。
 
 選択した作業パケット（Task Packet）は、正本、対象範囲・非対象、厳密対象、依存関係、受け入れ確認、危険境界、唯一の能動作業系列を明示する。
 
@@ -82,7 +82,7 @@ branch作成、実装、push、merge、新規PR作成の前に、GitHub現在状
 
 有用な独立作業が存在する間、Missionは`ACTIVE`である。外部結果だけが未確定の場合、`YIELD_EXTERNAL`は安全な実行結果であり、人間介入ではない。`PAUSED_FOR_INTERVENTION`は、安全に推測できない実際の利用者判断または正本判断が必要な場合だけ使用する。
 
-重要な遷移ごとにMission/Work、branch/PR、厳密HEAD、完了作業、検証、停止要因、最初の再開作業をGitHubへ記録する。個別Work完了だけでMission #33を完了にしない。
+重要な遷移ごとに、DBへMission/Work、branch/PR、厳密HEAD、完了作業、検証、停止要因、最初の再開作業を確定する。Issueにはその確定済み状態から人間向け状況報告を投稿する。個別Work完了だけでMission #33を完了にしない。
 
 Mission #33を完了できるのは、少なくとも次が現在証拠で満了した場合だけである。
 

--- a/src/loop_engineering/migrations/0004_v2_work_state.sql
+++ b/src/loop_engineering/migrations/0004_v2_work_state.sql
@@ -1,0 +1,71 @@
+CREATE TABLE IF NOT EXISTS loop_work_records (
+    identity TEXT PRIMARY KEY,
+    repository TEXT NOT NULL,
+    issue_number BIGINT NOT NULL,
+    issue_revision TEXT NOT NULL,
+    lifecycle TEXT NOT NULL,
+    selected_transition TEXT,
+    active_lineage_identity TEXT,
+    latest_task_packet_identity TEXT,
+    latest_checkpoint_identity TEXT,
+    revision BIGINT NOT NULL DEFAULT 1,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (repository, issue_number)
+);
+
+CREATE TABLE IF NOT EXISTS loop_task_packets (
+    identity TEXT PRIMARY KEY,
+    work_identity TEXT NOT NULL REFERENCES loop_work_records(identity),
+    generation BIGINT NOT NULL,
+    transition TEXT NOT NULL,
+    status TEXT NOT NULL,
+    canonical_design_identities JSONB NOT NULL DEFAULT '[]'::jsonb,
+    external_target_identities JSONB NOT NULL DEFAULT '[]'::jsonb,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (work_identity, generation)
+);
+
+CREATE TABLE IF NOT EXISTS loop_work_checkpoints (
+    identity TEXT PRIMARY KEY,
+    work_identity TEXT NOT NULL REFERENCES loop_work_records(identity),
+    run_identity TEXT NOT NULL,
+    task_packet_identity TEXT REFERENCES loop_task_packets(identity),
+    checkpoint_kind TEXT NOT NULL,
+    resumable_state TEXT NOT NULL,
+    next_action TEXT NOT NULL,
+    external_target_identities JSONB NOT NULL DEFAULT '[]'::jsonb,
+    evidence_identities JSONB NOT NULL DEFAULT '[]'::jsonb,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS loop_effect_attempts (
+    idempotency_key TEXT PRIMARY KEY,
+    work_identity TEXT NOT NULL REFERENCES loop_work_records(identity),
+    kind TEXT NOT NULL,
+    target_identity TEXT NOT NULL,
+    status TEXT NOT NULL,
+    request_identity TEXT,
+    confirmed_at TIMESTAMPTZ,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS loop_issue_report_outbox (
+    identity TEXT PRIMARY KEY,
+    work_identity TEXT NOT NULL REFERENCES loop_work_records(identity),
+    status TEXT NOT NULL,
+    report_kind TEXT NOT NULL,
+    checkpoint_identity TEXT REFERENCES loop_work_checkpoints(identity),
+    body TEXT NOT NULL,
+    published_at TIMESTAMPTZ,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS loop_work_records_repository_issue_index
+    ON loop_work_records (repository, issue_number, updated_at DESC);
+CREATE INDEX IF NOT EXISTS loop_work_checkpoints_work_index
+    ON loop_work_checkpoints (work_identity, recorded_at DESC);
+CREATE INDEX IF NOT EXISTS loop_effect_attempts_work_status_index
+    ON loop_effect_attempts (work_identity, status, recorded_at DESC);
+CREATE INDEX IF NOT EXISTS loop_issue_report_outbox_pending_index
+    ON loop_issue_report_outbox (status, recorded_at ASC);

--- a/src/loop_engineering/v2_resume.py
+++ b/src/loop_engineering/v2_resume.py
@@ -1,0 +1,106 @@
+"""V2のDB起点再開判定を提供する。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+from .work_state import EffectAttempt, RecoveredWork, WorkRecord
+
+
+class V2ResumeStatus(str, Enum):
+    READY = "READY"
+    RECONCILE_REQUIRED = "RECONCILE_REQUIRED"
+    BLOCKED = "BLOCKED"
+
+
+class EffectReadbackStatus(str, Enum):
+    CONFIRMED = "CONFIRMED"
+    NO_EFFECT = "NO_EFFECT"
+    UNKNOWN = "UNKNOWN"
+
+
+@dataclass(frozen=True, slots=True)
+class V2ResumeResult:
+    status: V2ResumeStatus
+    detail: str
+    recovered: RecoveredWork | None = None
+
+
+class WorkRecoveryPort(Protocol):
+    def recover(self, work_identity: str) -> RecoveredWork | None: ...
+
+    def upsert_work(self, record: WorkRecord) -> None: ...
+
+    def record_effect_outcome(self, idempotency_key: str, status: str) -> None: ...
+
+
+class WorkDefinitionPort(Protocol):
+    """IssueとProjectから作業定義だけを同期する。"""
+
+    def synchronize(self, record: WorkRecord) -> WorkRecord | None: ...
+
+
+class EffectReadbackPort(Protocol):
+    """DBに記録済みの外部effectだけを照合する。"""
+
+    def readback(self, attempt: EffectAttempt) -> EffectReadbackStatus: ...
+
+
+class V2ResumeCoordinator:
+    """DBを起点に、安全な実行開始可否だけを判定する。"""
+
+    def __init__(
+        self,
+        recovery: WorkRecoveryPort,
+        definitions: WorkDefinitionPort,
+        effects: EffectReadbackPort,
+    ) -> None:
+        self._recovery = recovery
+        self._definitions = definitions
+        self._effects = effects
+
+    def resume(self, work_identity: str) -> V2ResumeResult:
+        recovered = self._recovery.recover(work_identity)
+        if recovered is None:
+            return V2ResumeResult(V2ResumeStatus.BLOCKED, "WORK_RECOVERY_MISSING")
+
+        synchronized = self._definitions.synchronize(recovered.record)
+        if synchronized is None:
+            return V2ResumeResult(
+                V2ResumeStatus.BLOCKED,
+                "WORK_DEFINITION_UNAVAILABLE",
+                recovered,
+            )
+        if not _same_work(recovered.record, synchronized):
+            return V2ResumeResult(
+                V2ResumeStatus.BLOCKED,
+                "WORK_DEFINITION_CONFLICT",
+                recovered,
+            )
+        self._recovery.upsert_work(synchronized)
+
+        for attempt in recovered.pending_effects:
+            readback = self._effects.readback(attempt)
+            if readback is EffectReadbackStatus.CONFIRMED:
+                self._recovery.record_effect_outcome(attempt.idempotency_key, "CONFIRMED")
+                continue
+            if readback is EffectReadbackStatus.NO_EFFECT:
+                self._recovery.record_effect_outcome(attempt.idempotency_key, "NO_EFFECT")
+                continue
+            return V2ResumeResult(
+                V2ResumeStatus.RECONCILE_REQUIRED,
+                "EFFECT_READBACK_UNKNOWN",
+                recovered,
+            )
+
+        return V2ResumeResult(V2ResumeStatus.READY, "RESUME_READY", recovered)
+
+
+def _same_work(before: WorkRecord, after: WorkRecord) -> bool:
+    return (
+        before.identity == after.identity
+        and before.repository == after.repository
+        and before.issue_number == after.issue_number
+    )

--- a/src/loop_engineering/v2_resume.py
+++ b/src/loop_engineering/v2_resume.py
@@ -63,8 +63,8 @@ class V2ResumeCoordinator:
 
     def resume(self, work_identity: str) -> V2ResumeResult:
         recovered = self._recovery.recover(work_identity)
-        if recovered is None:
-            return V2ResumeResult(V2ResumeStatus.BLOCKED, "WORK_RECOVERY_MISSING")
+        if recovered is None or not _complete_recovery(recovered):
+            return V2ResumeResult(V2ResumeStatus.BLOCKED, "WORK_RECOVERY_MISSING", recovered)
 
         synchronized = self._definitions.synchronize(recovered.record)
         if synchronized is None:
@@ -96,6 +96,21 @@ class V2ResumeCoordinator:
             )
 
         return V2ResumeResult(V2ResumeStatus.READY, "RESUME_READY", recovered)
+
+
+def _complete_recovery(recovered: RecoveredWork) -> bool:
+    packet = recovered.task_packet
+    checkpoint = recovered.checkpoint
+    if packet is None or checkpoint is None:
+        return False
+    record = recovered.record
+    return (
+        record.latest_task_packet_identity == packet.identity
+        and record.latest_checkpoint_identity == checkpoint.identity
+        and packet.work_identity == record.identity
+        and checkpoint.work_identity == record.identity
+        and checkpoint.task_packet_identity == packet.identity
+    )
 
 
 def _same_work(before: WorkRecord, after: WorkRecord) -> bool:

--- a/src/loop_engineering/work_state.py
+++ b/src/loop_engineering/work_state.py
@@ -1,0 +1,235 @@
+"""V2の作業状態をDBへ保存し、停止後の再開情報を復元する。"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class WorkStateUnavailable(RuntimeError):
+    """作業状態を安全に読み書きできない。"""
+
+
+class WorkStateDatabase(Protocol):
+    def execute_sql(self, sql: str) -> bool: ...
+
+    def query_json_rows(self, select_sql: str) -> list[dict[str, object]] | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class WorkRecord:
+    identity: str
+    repository: str
+    issue_number: int
+    issue_revision: str
+    lifecycle: str
+    selected_transition: str | None = None
+    active_lineage_identity: str | None = None
+    latest_task_packet_identity: str | None = None
+    latest_checkpoint_identity: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WorkCheckpoint:
+    identity: str
+    work_identity: str
+    run_identity: str
+    checkpoint_kind: str
+    resumable_state: str
+    next_action: str
+    task_packet_identity: str | None = None
+    external_target_identities: tuple[str, ...] = ()
+    evidence_identities: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class EffectAttempt:
+    idempotency_key: str
+    work_identity: str
+    kind: str
+    target_identity: str
+    status: str
+    request_identity: str | None = None
+
+
+class PostgreSQLWorkStateStore:
+    """秘密を含まないV2作業状態だけをPostgreSQLへ保存する。"""
+
+    _LIFECYCLES = frozenset({"PLANNED", "SELECTED", "RUNNING", "WAITING", "BLOCKED", "COMPLETED"})
+    _CHECKPOINT_KINDS = frozenset({"SAFE_POINT", "EFFECT_PENDING", "EFFECT_CONFIRMED", "WAITING"})
+    _EFFECT_STATUSES = frozenset({"INTENT_RECORDED", "CONFIRMED", "NO_EFFECT", "UNCERTAIN"})
+    _OUTBOX_STATUSES = frozenset({"PENDING", "PUBLISHED"})
+
+    def __init__(self, database: WorkStateDatabase) -> None:
+        self._database = database
+
+    def upsert_work(self, record: WorkRecord) -> None:
+        if record.lifecycle not in self._LIFECYCLES or record.issue_number < 1:
+            raise WorkStateUnavailable("WORK_RECORD_INVALID")
+        self._execute(
+            "INSERT INTO loop_work_records "
+            "(identity, repository, issue_number, issue_revision, lifecycle, selected_transition, "
+            "active_lineage_identity, latest_task_packet_identity, "
+            "latest_checkpoint_identity) VALUES ("
+            f"{_literal(record.identity)}, {_literal(record.repository)}, {record.issue_number}, "
+            f"{_literal(record.issue_revision)}, {_literal(record.lifecycle)}, "
+            f"{_nullable_literal(record.selected_transition)}, "
+            f"{_nullable_literal(record.active_lineage_identity)}, "
+            f"{_nullable_literal(record.latest_task_packet_identity)}, "
+            f"{_nullable_literal(record.latest_checkpoint_identity)}) "
+            "ON CONFLICT (identity) DO UPDATE SET "
+            "issue_revision = EXCLUDED.issue_revision, lifecycle = EXCLUDED.lifecycle, "
+            "selected_transition = EXCLUDED.selected_transition, "
+            "active_lineage_identity = EXCLUDED.active_lineage_identity, "
+            "latest_task_packet_identity = EXCLUDED.latest_task_packet_identity, "
+            "latest_checkpoint_identity = EXCLUDED.latest_checkpoint_identity, "
+            "revision = loop_work_records.revision + 1, updated_at = now()"
+        )
+
+    def record_checkpoint(self, checkpoint: WorkCheckpoint) -> None:
+        if checkpoint.checkpoint_kind not in self._CHECKPOINT_KINDS:
+            raise WorkStateUnavailable("WORK_CHECKPOINT_INVALID")
+        self._execute(
+            "INSERT INTO loop_work_checkpoints "
+            "(identity, work_identity, run_identity, task_packet_identity, checkpoint_kind, "
+            "resumable_state, next_action, external_target_identities, "
+            "evidence_identities) VALUES ("
+            f"{_literal(checkpoint.identity)}, {_literal(checkpoint.work_identity)}, "
+            f"{_literal(checkpoint.run_identity)}, "
+            f"{_nullable_literal(checkpoint.task_packet_identity)}, "
+            f"{_literal(checkpoint.checkpoint_kind)}, {_literal(checkpoint.resumable_state)}, "
+            f"{_literal(checkpoint.next_action)}, "
+            f"{_json_literal(checkpoint.external_target_identities)}, "
+            f"{_json_literal(checkpoint.evidence_identities)}) "
+            "ON CONFLICT (identity) DO NOTHING"
+        )
+        self._execute(
+            "UPDATE loop_work_records SET "
+            f"latest_checkpoint_identity = {_literal(checkpoint.identity)}, updated_at = now() "
+            f"WHERE identity = {_literal(checkpoint.work_identity)}"
+        )
+
+    def latest_checkpoint(self, work_identity: str) -> WorkCheckpoint | None:
+        rows = self._query(
+            "SELECT identity, work_identity, run_identity, task_packet_identity, checkpoint_kind, "
+            "resumable_state, next_action, external_target_identities, evidence_identities "
+            "FROM loop_work_checkpoints "
+            f"WHERE work_identity = {_literal(work_identity)} "
+            "ORDER BY recorded_at DESC, identity DESC LIMIT 1"
+        )
+        if not rows:
+            return None
+        row = rows[0]
+        return WorkCheckpoint(
+            identity=_required_string(row, "identity"),
+            work_identity=_required_string(row, "work_identity"),
+            run_identity=_required_string(row, "run_identity"),
+            task_packet_identity=_optional_string(row, "task_packet_identity"),
+            checkpoint_kind=_required_string(row, "checkpoint_kind"),
+            resumable_state=_required_string(row, "resumable_state"),
+            next_action=_required_string(row, "next_action"),
+            external_target_identities=_string_tuple(row, "external_target_identities"),
+            evidence_identities=_string_tuple(row, "evidence_identities"),
+        )
+
+    def record_effect_intent(self, attempt: EffectAttempt) -> bool:
+        if attempt.status != "INTENT_RECORDED":
+            raise WorkStateUnavailable("EFFECT_INTENT_INVALID")
+        self._execute(
+            "INSERT INTO loop_effect_attempts "
+            "(idempotency_key, work_identity, kind, target_identity, status, "
+            "request_identity) VALUES ("
+            f"{_literal(attempt.idempotency_key)}, {_literal(attempt.work_identity)}, "
+            f"{_literal(attempt.kind)}, {_literal(attempt.target_identity)}, "
+            "'INTENT_RECORDED', "
+            f"{_nullable_literal(attempt.request_identity)}) "
+            "ON CONFLICT (idempotency_key) DO NOTHING"
+        )
+        rows = self._query(
+            "SELECT status FROM loop_effect_attempts "
+            f"WHERE idempotency_key = {_literal(attempt.idempotency_key)} LIMIT 1"
+        )
+        return bool(rows) and _optional_string(rows[0], "status") == "INTENT_RECORDED"
+
+    def record_effect_outcome(self, idempotency_key: str, status: str) -> None:
+        if status not in self._EFFECT_STATUSES or status == "INTENT_RECORDED":
+            raise WorkStateUnavailable("EFFECT_OUTCOME_INVALID")
+        self._execute(
+            "UPDATE loop_effect_attempts SET "
+            f"status = {_literal(status)}, "
+            "confirmed_at = CASE WHEN "
+            f"{_literal(status)} = 'CONFIRMED' THEN now() ELSE confirmed_at END "
+            f"WHERE idempotency_key = {_literal(idempotency_key)} "
+            "AND status = 'INTENT_RECORDED'"
+        )
+
+    def enqueue_issue_report(
+        self,
+        *,
+        identity: str,
+        work_identity: str,
+        report_kind: str,
+        checkpoint_identity: str | None,
+        body: str,
+    ) -> None:
+        if not body or len(body) > 4000:
+            raise WorkStateUnavailable("ISSUE_REPORT_INVALID")
+        self._execute(
+            "INSERT INTO loop_issue_report_outbox "
+            "(identity, work_identity, status, report_kind, checkpoint_identity, body) VALUES ("
+            f"{_literal(identity)}, {_literal(work_identity)}, 'PENDING', {_literal(report_kind)}, "
+            f"{_nullable_literal(checkpoint_identity)}, {_literal(body)}) "
+            "ON CONFLICT (identity) DO NOTHING"
+        )
+
+    def mark_issue_report_published(self, identity: str) -> None:
+        self._execute(
+            "UPDATE loop_issue_report_outbox SET status = 'PUBLISHED', published_at = now() "
+            f"WHERE identity = {_literal(identity)} AND status = 'PENDING'"
+        )
+
+    def _execute(self, sql: str) -> None:
+        if not self._database.execute_sql(sql):
+            raise WorkStateUnavailable("WORK_STATE_WRITE_FAILED")
+
+    def _query(self, sql: str) -> list[dict[str, object]]:
+        rows = self._database.query_json_rows(sql)
+        if rows is None:
+            raise WorkStateUnavailable("WORK_STATE_READ_FAILED")
+        return rows
+
+
+def _literal(value: str) -> str:
+    if "\x00" in value or len(value) > 4096:
+        raise WorkStateUnavailable("WORK_STATE_VALUE_INVALID")
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _nullable_literal(value: str | None) -> str:
+    return "NULL" if value is None else _literal(value)
+
+
+def _json_literal(values: tuple[str, ...]) -> str:
+    if any("\x00" in value or len(value) > 1024 for value in values):
+        raise WorkStateUnavailable("WORK_STATE_VALUE_INVALID")
+    return _literal(json.dumps(values, ensure_ascii=False, separators=(",", ":"))) + "::jsonb"
+
+
+def _required_string(row: dict[str, object], name: str) -> str:
+    value = _optional_string(row, name)
+    if value is None:
+        raise WorkStateUnavailable("WORK_STATE_ROW_INVALID")
+    return value
+
+
+def _optional_string(row: dict[str, object], name: str) -> str | None:
+    value = row.get(name)
+    return value if isinstance(value, str) else None
+
+
+def _string_tuple(row: dict[str, object], name: str) -> tuple[str, ...]:
+    value = row.get(name)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise WorkStateUnavailable("WORK_STATE_ROW_INVALID")
+    return tuple(value)

--- a/src/loop_engineering/work_state.py
+++ b/src/loop_engineering/work_state.py
@@ -159,18 +159,7 @@ class PostgreSQLWorkStateStore:
         )
         if not rows:
             return None
-        row = rows[0]
-        return WorkCheckpoint(
-            identity=_required_string(row, "identity"),
-            work_identity=_required_string(row, "work_identity"),
-            run_identity=_required_string(row, "run_identity"),
-            task_packet_identity=_optional_string(row, "task_packet_identity"),
-            checkpoint_kind=_required_string(row, "checkpoint_kind"),
-            resumable_state=_required_string(row, "resumable_state"),
-            next_action=_required_string(row, "next_action"),
-            external_target_identities=_string_tuple(row, "external_target_identities"),
-            evidence_identities=_string_tuple(row, "evidence_identities"),
-        )
+        return _work_checkpoint(rows[0])
 
     def record_effect_intent(self, attempt: EffectAttempt) -> bool:
         if attempt.status != "INTENT_RECORDED":
@@ -214,7 +203,7 @@ class PostgreSQLWorkStateStore:
             return None
         record = _work_record(records[0])
         packet = self._task_packet(record.latest_task_packet_identity)
-        checkpoint = self.latest_checkpoint(work_identity)
+        checkpoint = self._checkpoint(record.latest_checkpoint_identity)
         pending_effects = self._pending_effects(work_identity)
         return RecoveredWork(record, packet, checkpoint, pending_effects)
 
@@ -253,7 +242,7 @@ class PostgreSQLWorkStateStore:
             f"WHERE identity = {_literal(identity)} LIMIT 1"
         )
         if not rows:
-            raise WorkStateUnavailable("TASK_PACKET_MISSING")
+            return None
         row = rows[0]
         generation = row.get("generation")
         if not isinstance(generation, int) or generation < 1:
@@ -267,6 +256,19 @@ class PostgreSQLWorkStateStore:
             canonical_design_identities=_string_tuple(row, "canonical_design_identities"),
             external_target_identities=_string_tuple(row, "external_target_identities"),
         )
+
+    def _checkpoint(self, identity: str | None) -> WorkCheckpoint | None:
+        if identity is None:
+            return None
+        rows = self._query(
+            "SELECT identity, work_identity, run_identity, task_packet_identity, checkpoint_kind, "
+            "resumable_state, next_action, external_target_identities, evidence_identities "
+            "FROM loop_work_checkpoints "
+            f"WHERE identity = {_literal(identity)} LIMIT 1"
+        )
+        if not rows:
+            return None
+        return _work_checkpoint(rows[0])
 
     def _pending_effects(self, work_identity: str) -> tuple[EffectAttempt, ...]:
         rows = self._query(
@@ -348,4 +350,18 @@ def _work_record(row: dict[str, object]) -> WorkRecord:
         active_lineage_identity=_optional_string(row, "active_lineage_identity"),
         latest_task_packet_identity=_optional_string(row, "latest_task_packet_identity"),
         latest_checkpoint_identity=_optional_string(row, "latest_checkpoint_identity"),
+    )
+
+
+def _work_checkpoint(row: dict[str, object]) -> WorkCheckpoint:
+    return WorkCheckpoint(
+        identity=_required_string(row, "identity"),
+        work_identity=_required_string(row, "work_identity"),
+        run_identity=_required_string(row, "run_identity"),
+        task_packet_identity=_optional_string(row, "task_packet_identity"),
+        checkpoint_kind=_required_string(row, "checkpoint_kind"),
+        resumable_state=_required_string(row, "resumable_state"),
+        next_action=_required_string(row, "next_action"),
+        external_target_identities=_string_tuple(row, "external_target_identities"),
+        evidence_identities=_string_tuple(row, "evidence_identities"),
     )

--- a/src/loop_engineering/work_state.py
+++ b/src/loop_engineering/work_state.py
@@ -44,6 +44,17 @@ class WorkCheckpoint:
 
 
 @dataclass(frozen=True, slots=True)
+class WorkTaskPacket:
+    identity: str
+    work_identity: str
+    generation: int
+    transition: str
+    status: str
+    canonical_design_identities: tuple[str, ...] = ()
+    external_target_identities: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class EffectAttempt:
     idempotency_key: str
     work_identity: str
@@ -53,13 +64,21 @@ class EffectAttempt:
     request_identity: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class RecoveredWork:
+    record: WorkRecord
+    task_packet: WorkTaskPacket | None
+    checkpoint: WorkCheckpoint | None
+    pending_effects: tuple[EffectAttempt, ...]
+
+
 class PostgreSQLWorkStateStore:
     """秘密を含まないV2作業状態だけをPostgreSQLへ保存する。"""
 
     _LIFECYCLES = frozenset({"PLANNED", "SELECTED", "RUNNING", "WAITING", "BLOCKED", "COMPLETED"})
     _CHECKPOINT_KINDS = frozenset({"SAFE_POINT", "EFFECT_PENDING", "EFFECT_CONFIRMED", "WAITING"})
     _EFFECT_STATUSES = frozenset({"INTENT_RECORDED", "CONFIRMED", "NO_EFFECT", "UNCERTAIN"})
-    _OUTBOX_STATUSES = frozenset({"PENDING", "PUBLISHED"})
+    _TASK_PACKET_STATUSES = frozenset({"ISSUED", "STARTED", "COMPLETED", "SUPERSEDED", "UNCERTAIN"})
 
     def __init__(self, database: WorkStateDatabase) -> None:
         self._database = database
@@ -108,6 +127,26 @@ class PostgreSQLWorkStateStore:
             "UPDATE loop_work_records SET "
             f"latest_checkpoint_identity = {_literal(checkpoint.identity)}, updated_at = now() "
             f"WHERE identity = {_literal(checkpoint.work_identity)}"
+        )
+
+    def record_task_packet(self, packet: WorkTaskPacket) -> None:
+        if packet.generation < 1 or packet.status not in self._TASK_PACKET_STATUSES:
+            raise WorkStateUnavailable("TASK_PACKET_INVALID")
+        self._execute(
+            "INSERT INTO loop_task_packets "
+            "(identity, work_identity, generation, transition, status, "
+            "canonical_design_identities, "
+            "external_target_identities) VALUES ("
+            f"{_literal(packet.identity)}, {_literal(packet.work_identity)}, {packet.generation}, "
+            f"{_literal(packet.transition)}, {_literal(packet.status)}, "
+            f"{_json_literal(packet.canonical_design_identities)}, "
+            f"{_json_literal(packet.external_target_identities)}) "
+            "ON CONFLICT (identity) DO NOTHING"
+        )
+        self._execute(
+            "UPDATE loop_work_records SET "
+            f"latest_task_packet_identity = {_literal(packet.identity)}, updated_at = now() "
+            f"WHERE identity = {_literal(packet.work_identity)}"
         )
 
     def latest_checkpoint(self, work_identity: str) -> WorkCheckpoint | None:
@@ -164,6 +203,21 @@ class PostgreSQLWorkStateStore:
             "AND status = 'INTENT_RECORDED'"
         )
 
+    def recover(self, work_identity: str) -> RecoveredWork | None:
+        records = self._query(
+            "SELECT identity, repository, issue_number, issue_revision, lifecycle, "
+            "selected_transition, active_lineage_identity, latest_task_packet_identity, "
+            "latest_checkpoint_identity FROM loop_work_records "
+            f"WHERE identity = {_literal(work_identity)} LIMIT 1"
+        )
+        if not records:
+            return None
+        record = _work_record(records[0])
+        packet = self._task_packet(record.latest_task_packet_identity)
+        checkpoint = self.latest_checkpoint(work_identity)
+        pending_effects = self._pending_effects(work_identity)
+        return RecoveredWork(record, packet, checkpoint, pending_effects)
+
     def enqueue_issue_report(
         self,
         *,
@@ -187,6 +241,51 @@ class PostgreSQLWorkStateStore:
         self._execute(
             "UPDATE loop_issue_report_outbox SET status = 'PUBLISHED', published_at = now() "
             f"WHERE identity = {_literal(identity)} AND status = 'PENDING'"
+        )
+
+    def _task_packet(self, identity: str | None) -> WorkTaskPacket | None:
+        if identity is None:
+            return None
+        rows = self._query(
+            "SELECT identity, work_identity, generation, transition, status, "
+            "canonical_design_identities, external_target_identities "
+            "FROM loop_task_packets "
+            f"WHERE identity = {_literal(identity)} LIMIT 1"
+        )
+        if not rows:
+            raise WorkStateUnavailable("TASK_PACKET_MISSING")
+        row = rows[0]
+        generation = row.get("generation")
+        if not isinstance(generation, int) or generation < 1:
+            raise WorkStateUnavailable("WORK_STATE_ROW_INVALID")
+        return WorkTaskPacket(
+            identity=_required_string(row, "identity"),
+            work_identity=_required_string(row, "work_identity"),
+            generation=generation,
+            transition=_required_string(row, "transition"),
+            status=_required_string(row, "status"),
+            canonical_design_identities=_string_tuple(row, "canonical_design_identities"),
+            external_target_identities=_string_tuple(row, "external_target_identities"),
+        )
+
+    def _pending_effects(self, work_identity: str) -> tuple[EffectAttempt, ...]:
+        rows = self._query(
+            "SELECT idempotency_key, work_identity, kind, target_identity, status, "
+            "request_identity "
+            "FROM loop_effect_attempts "
+            f"WHERE work_identity = {_literal(work_identity)} "
+            "AND status IN ('INTENT_RECORDED', 'UNCERTAIN') ORDER BY recorded_at ASC"
+        )
+        return tuple(
+            EffectAttempt(
+                idempotency_key=_required_string(row, "idempotency_key"),
+                work_identity=_required_string(row, "work_identity"),
+                kind=_required_string(row, "kind"),
+                target_identity=_required_string(row, "target_identity"),
+                status=_required_string(row, "status"),
+                request_identity=_optional_string(row, "request_identity"),
+            )
+            for row in rows
         )
 
     def _execute(self, sql: str) -> None:
@@ -233,3 +332,20 @@ def _string_tuple(row: dict[str, object], name: str) -> tuple[str, ...]:
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         raise WorkStateUnavailable("WORK_STATE_ROW_INVALID")
     return tuple(value)
+
+
+def _work_record(row: dict[str, object]) -> WorkRecord:
+    issue_number = row.get("issue_number")
+    if not isinstance(issue_number, int) or issue_number < 1:
+        raise WorkStateUnavailable("WORK_STATE_ROW_INVALID")
+    return WorkRecord(
+        identity=_required_string(row, "identity"),
+        repository=_required_string(row, "repository"),
+        issue_number=issue_number,
+        issue_revision=_required_string(row, "issue_revision"),
+        lifecycle=_required_string(row, "lifecycle"),
+        selected_transition=_optional_string(row, "selected_transition"),
+        active_lineage_identity=_optional_string(row, "active_lineage_identity"),
+        latest_task_packet_identity=_optional_string(row, "latest_task_packet_identity"),
+        latest_checkpoint_identity=_optional_string(row, "latest_checkpoint_identity"),
+    )

--- a/tests/loop_engineering/test_v2_resume.py
+++ b/tests/loop_engineering/test_v2_resume.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from loop_engineering.v2_resume import (
+    EffectReadbackStatus,
+    V2ResumeCoordinator,
+    V2ResumeStatus,
+)
+from loop_engineering.work_state import EffectAttempt, RecoveredWork, WorkRecord
+
+
+def record() -> WorkRecord:
+    return WorkRecord(
+        identity="work:ktan514/loop-engineering:62",
+        repository="ktan514/loop-engineering",
+        issue_number=62,
+        issue_revision="issue:62:1",
+        lifecycle="SELECTED",
+        selected_transition="IMPLEMENT",
+    )
+
+
+@dataclass
+class Recovery:
+    value: RecoveredWork | None
+    synchronized: list[WorkRecord] = field(default_factory=list)
+    outcomes: list[tuple[str, str]] = field(default_factory=list)
+
+    def recover(self, work_identity: str) -> RecoveredWork | None:
+        assert work_identity == record().identity
+        return self.value
+
+    def upsert_work(self, value: WorkRecord) -> None:
+        self.synchronized.append(value)
+
+    def record_effect_outcome(self, idempotency_key: str, status: str) -> None:
+        self.outcomes.append((idempotency_key, status))
+
+
+@dataclass
+class Definitions:
+    value: WorkRecord | None
+    calls: int = 0
+
+    def synchronize(self, current: WorkRecord) -> WorkRecord | None:
+        assert current == record()
+        self.calls += 1
+        return self.value
+
+
+@dataclass
+class Effects:
+    status: EffectReadbackStatus
+    calls: list[EffectAttempt] = field(default_factory=list)
+
+    def readback(self, attempt: EffectAttempt) -> EffectReadbackStatus:
+        self.calls.append(attempt)
+        return self.status
+
+
+def recovered(*, pending: tuple[EffectAttempt, ...] = ()) -> RecoveredWork:
+    return RecoveredWork(record(), None, None, pending)
+
+
+def test_resume_is_ready_after_db_recovery_and_definition_sync() -> None:
+    recovery = Recovery(recovered())
+    definitions = Definitions(record())
+    effects = Effects(EffectReadbackStatus.CONFIRMED)
+
+    result = V2ResumeCoordinator(recovery, definitions, effects).resume(record().identity)
+
+    assert result.status is V2ResumeStatus.READY
+    assert result.detail == "RESUME_READY"
+    assert recovery.synchronized == [record()]
+    assert effects.calls == []
+
+
+def test_unknown_effect_stops_before_any_new_execution() -> None:
+    attempt = EffectAttempt(
+        "effect:62:1",
+        record().identity,
+        "MERGE",
+        "pr:63|head:abc",
+        "UNCERTAIN",
+    )
+    recovery = Recovery(recovered(pending=(attempt,)))
+    effects = Effects(EffectReadbackStatus.UNKNOWN)
+
+    result = V2ResumeCoordinator(recovery, Definitions(record()), effects).resume(record().identity)
+
+    assert result.status is V2ResumeStatus.RECONCILE_REQUIRED
+    assert result.detail == "EFFECT_READBACK_UNKNOWN"
+    assert recovery.outcomes == []
+    assert effects.calls == [attempt]
+
+
+def test_confirmed_and_no_effect_are_recorded_before_ready() -> None:
+    attempt = EffectAttempt(
+        "effect:62:1",
+        record().identity,
+        "PUSH",
+        "branch:feature/v2",
+        "INTENT_RECORDED",
+    )
+    recovery = Recovery(recovered(pending=(attempt,)))
+
+    confirmed = V2ResumeCoordinator(
+        recovery,
+        Definitions(record()),
+        Effects(EffectReadbackStatus.CONFIRMED),
+    ).resume(record().identity)
+
+    assert confirmed.status is V2ResumeStatus.READY
+    assert recovery.outcomes == [(attempt.idempotency_key, "CONFIRMED")]
+
+    recovery = Recovery(recovered(pending=(attempt,)))
+    no_effect = V2ResumeCoordinator(
+        recovery,
+        Definitions(record()),
+        Effects(EffectReadbackStatus.NO_EFFECT),
+    ).resume(record().identity)
+
+    assert no_effect.status is V2ResumeStatus.READY
+    assert recovery.outcomes == [(attempt.idempotency_key, "NO_EFFECT")]
+
+
+def test_missing_or_conflicting_work_stays_blocked() -> None:
+    missing = V2ResumeCoordinator(
+        Recovery(None),
+        Definitions(record()),
+        Effects(EffectReadbackStatus.CONFIRMED),
+    ).resume(record().identity)
+    assert missing.status is V2ResumeStatus.BLOCKED
+    assert missing.detail == "WORK_RECOVERY_MISSING"
+
+    conflicting = WorkRecord(
+        identity="work:other:62",
+        repository=record().repository,
+        issue_number=62,
+        issue_revision="issue:62:2",
+        lifecycle="SELECTED",
+    )
+    recovery = Recovery(recovered())
+    conflict = V2ResumeCoordinator(
+        recovery,
+        Definitions(conflicting),
+        Effects(EffectReadbackStatus.CONFIRMED),
+    ).resume(record().identity)
+
+    assert conflict.status is V2ResumeStatus.BLOCKED
+    assert conflict.detail == "WORK_DEFINITION_CONFLICT"
+    assert recovery.synchronized == []

--- a/tests/loop_engineering/test_v2_resume.py
+++ b/tests/loop_engineering/test_v2_resume.py
@@ -7,7 +7,13 @@ from loop_engineering.v2_resume import (
     V2ResumeCoordinator,
     V2ResumeStatus,
 )
-from loop_engineering.work_state import EffectAttempt, RecoveredWork, WorkRecord
+from loop_engineering.work_state import (
+    EffectAttempt,
+    RecoveredWork,
+    WorkCheckpoint,
+    WorkRecord,
+    WorkTaskPacket,
+)
 
 
 def record() -> WorkRecord:
@@ -18,6 +24,30 @@ def record() -> WorkRecord:
         issue_revision="issue:62:1",
         lifecycle="SELECTED",
         selected_transition="IMPLEMENT",
+        latest_task_packet_identity="packet:62:1",
+        latest_checkpoint_identity="checkpoint:62:1",
+    )
+
+
+def packet() -> WorkTaskPacket:
+    return WorkTaskPacket(
+        identity="packet:62:1",
+        work_identity=record().identity,
+        generation=1,
+        transition="IMPLEMENT",
+        status="ISSUED",
+    )
+
+
+def checkpoint() -> WorkCheckpoint:
+    return WorkCheckpoint(
+        identity="checkpoint:62:1",
+        work_identity=record().identity,
+        run_identity="run:62:1",
+        checkpoint_kind="SAFE_POINT",
+        resumable_state="IMPLEMENT_READY",
+        next_action="作業パケットを実行する",
+        task_packet_identity=packet().identity,
     )
 
 
@@ -59,11 +89,21 @@ class Effects:
         return self.status
 
 
-def recovered(*, pending: tuple[EffectAttempt, ...] = ()) -> RecoveredWork:
-    return RecoveredWork(record(), None, None, pending)
+def recovered(
+    *,
+    pending: tuple[EffectAttempt, ...] = (),
+    task_packet: WorkTaskPacket | None = None,
+    safe_checkpoint: WorkCheckpoint | None = None,
+) -> RecoveredWork:
+    return RecoveredWork(
+        record(),
+        packet() if task_packet is None else task_packet,
+        checkpoint() if safe_checkpoint is None else safe_checkpoint,
+        pending,
+    )
 
 
-def test_resume_is_ready_after_db_recovery_and_definition_sync() -> None:
+def test_resume_is_ready_after_complete_db_recovery_and_definition_sync() -> None:
     recovery = Recovery(recovered())
     definitions = Definitions(record())
     effects = Effects(EffectReadbackStatus.CONFIRMED)
@@ -74,6 +114,39 @@ def test_resume_is_ready_after_db_recovery_and_definition_sync() -> None:
     assert result.detail == "RESUME_READY"
     assert recovery.synchronized == [record()]
     assert effects.calls == []
+
+
+def test_missing_or_inconsistent_recovery_stays_blocked_before_definition_sync() -> None:
+    definitions = Definitions(record())
+    missing_packet = RecoveredWork(record(), None, checkpoint(), ())
+
+    result = V2ResumeCoordinator(
+        Recovery(missing_packet),
+        definitions,
+        Effects(EffectReadbackStatus.CONFIRMED),
+    ).resume(record().identity)
+
+    assert result.status is V2ResumeStatus.BLOCKED
+    assert result.detail == "WORK_RECOVERY_MISSING"
+    assert definitions.calls == 0
+
+    mismatched_checkpoint = WorkCheckpoint(
+        identity="checkpoint:62:1",
+        work_identity=record().identity,
+        run_identity="run:62:1",
+        checkpoint_kind="SAFE_POINT",
+        resumable_state="IMPLEMENT_READY",
+        next_action="作業パケットを実行する",
+        task_packet_identity="packet:other",
+    )
+    inconsistent = V2ResumeCoordinator(
+        Recovery(RecoveredWork(record(), packet(), mismatched_checkpoint, ())),
+        Definitions(record()),
+        Effects(EffectReadbackStatus.CONFIRMED),
+    ).resume(record().identity)
+
+    assert inconsistent.status is V2ResumeStatus.BLOCKED
+    assert inconsistent.detail == "WORK_RECOVERY_MISSING"
 
 
 def test_unknown_effect_stops_before_any_new_execution() -> None:

--- a/tests/loop_engineering/test_work_state.py
+++ b/tests/loop_engineering/test_work_state.py
@@ -10,12 +10,14 @@ from loop_engineering.work_state import (
     WorkCheckpoint,
     WorkRecord,
     WorkStateUnavailable,
+    WorkTaskPacket,
 )
 
 
 @dataclass
 class Database:
     rows: list[dict[str, object]] = field(default_factory=list)
+    query_results: list[list[dict[str, object]]] | None = None
     statements: list[str] = field(default_factory=list)
     writable: bool = True
 
@@ -25,6 +27,8 @@ class Database:
 
     def query_json_rows(self, select_sql: str) -> list[dict[str, object]] | None:
         self.statements.append(select_sql)
+        if self.query_results is not None:
+            return self.query_results.pop(0)
         return self.rows
 
 
@@ -65,18 +69,20 @@ def test_work_and_checkpoint_are_persisted_without_issue_comment_text() -> None:
 
 def test_latest_checkpoint_reconstructs_db_state() -> None:
     database = Database(
-        rows=[
-            {
-                "identity": "checkpoint:62:2",
-                "work_identity": record().identity,
-                "run_identity": "run:2",
-                "task_packet_identity": None,
-                "checkpoint_kind": "EFFECT_PENDING",
-                "resumable_state": "MERGE_PENDING",
-                "next_action": "対象を照合する",
-                "external_target_identities": ["pr:63", "head:abc"],
-                "evidence_identities": ["ci:1"],
-            }
+        query_results=[
+            [
+                {
+                    "identity": "checkpoint:62:2",
+                    "work_identity": record().identity,
+                    "run_identity": "run:2",
+                    "task_packet_identity": None,
+                    "checkpoint_kind": "EFFECT_PENDING",
+                    "resumable_state": "MERGE_PENDING",
+                    "next_action": "対象を照合する",
+                    "external_target_identities": ["pr:63", "head:abc"],
+                    "evidence_identities": ["ci:1"],
+                }
+            ]
         ]
     )
 
@@ -86,6 +92,88 @@ def test_latest_checkpoint_reconstructs_db_state() -> None:
     assert checkpoint.checkpoint_kind == "EFFECT_PENDING"
     assert checkpoint.external_target_identities == ("pr:63", "head:abc")
     assert checkpoint.evidence_identities == ("ci:1",)
+
+
+def test_task_packet_and_pending_effects_are_recovered_from_db() -> None:
+    database = Database(
+        query_results=[
+            [
+                {
+                    "identity": record().identity,
+                    "repository": record().repository,
+                    "issue_number": 62,
+                    "issue_revision": "issue:62:2",
+                    "lifecycle": "RUNNING",
+                    "selected_transition": "IMPLEMENT",
+                    "active_lineage_identity": None,
+                    "latest_task_packet_identity": "packet:62:1",
+                    "latest_checkpoint_identity": "checkpoint:62:2",
+                }
+            ],
+            [
+                {
+                    "identity": "packet:62:1",
+                    "work_identity": record().identity,
+                    "generation": 1,
+                    "transition": "IMPLEMENT",
+                    "status": "ISSUED",
+                    "canonical_design_identities": ["design:62"],
+                    "external_target_identities": ["branch:feature/v2"],
+                }
+            ],
+            [
+                {
+                    "identity": "checkpoint:62:2",
+                    "work_identity": record().identity,
+                    "run_identity": "run:2",
+                    "task_packet_identity": "packet:62:1",
+                    "checkpoint_kind": "EFFECT_PENDING",
+                    "resumable_state": "IMPLEMENT_PENDING",
+                    "next_action": "対象を照合する",
+                    "external_target_identities": ["pr:63"],
+                    "evidence_identities": [],
+                }
+            ],
+            [
+                {
+                    "idempotency_key": "effect:62:1",
+                    "work_identity": record().identity,
+                    "kind": "PUSH",
+                    "target_identity": "branch:feature/v2",
+                    "status": "UNCERTAIN",
+                    "request_identity": None,
+                }
+            ],
+        ]
+    )
+    store = PostgreSQLWorkStateStore(database)
+
+    recovered = store.recover(record().identity)
+
+    assert recovered is not None
+    assert recovered.record.lifecycle == "RUNNING"
+    assert recovered.task_packet is not None
+    assert recovered.task_packet.transition == "IMPLEMENT"
+    assert recovered.checkpoint is not None
+    assert recovered.checkpoint.resumable_state == "IMPLEMENT_PENDING"
+    assert recovered.pending_effects[0].status == "UNCERTAIN"
+
+
+def test_task_packet_updates_recovery_pointer() -> None:
+    database = Database()
+    store = PostgreSQLWorkStateStore(database)
+
+    store.record_task_packet(
+        WorkTaskPacket(
+            identity="packet:62:1",
+            work_identity=record().identity,
+            generation=1,
+            transition="DESIGN",
+            status="ISSUED",
+        )
+    )
+
+    assert "latest_task_packet_identity = 'packet:62:1'" in "\n".join(database.statements)
 
 
 def test_effect_intent_is_idempotent_and_outcome_never_reenables_resend() -> None:

--- a/tests/loop_engineering/test_work_state.py
+++ b/tests/loop_engineering/test_work_state.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from loop_engineering.work_state import (
+    EffectAttempt,
+    PostgreSQLWorkStateStore,
+    WorkCheckpoint,
+    WorkRecord,
+    WorkStateUnavailable,
+)
+
+
+@dataclass
+class Database:
+    rows: list[dict[str, object]] = field(default_factory=list)
+    statements: list[str] = field(default_factory=list)
+    writable: bool = True
+
+    def execute_sql(self, sql: str) -> bool:
+        self.statements.append(sql)
+        return self.writable
+
+    def query_json_rows(self, select_sql: str) -> list[dict[str, object]] | None:
+        self.statements.append(select_sql)
+        return self.rows
+
+
+def record() -> WorkRecord:
+    return WorkRecord(
+        identity="work:ktan514/loop-engineering:62",
+        repository="ktan514/loop-engineering",
+        issue_number=62,
+        issue_revision="issue:62:1",
+        lifecycle="SELECTED",
+        selected_transition="DESIGN",
+    )
+
+
+def test_work_and_checkpoint_are_persisted_without_issue_comment_text() -> None:
+    database = Database()
+    store = PostgreSQLWorkStateStore(database)
+
+    store.upsert_work(record())
+    store.record_checkpoint(
+        WorkCheckpoint(
+            identity="checkpoint:62:1",
+            work_identity=record().identity,
+            run_identity="run:1",
+            checkpoint_kind="SAFE_POINT",
+            resumable_state="DESIGN_READY",
+            next_action="設計を実装する",
+            external_target_identities=("branch:feature/v2",),
+        )
+    )
+
+    written = "\n".join(database.statements)
+    assert "loop_work_records" in written
+    assert "loop_work_checkpoints" in written
+    assert "Issue comment" not in written
+    assert "latest_checkpoint_identity = 'checkpoint:62:1'" in written
+
+
+def test_latest_checkpoint_reconstructs_db_state() -> None:
+    database = Database(
+        rows=[
+            {
+                "identity": "checkpoint:62:2",
+                "work_identity": record().identity,
+                "run_identity": "run:2",
+                "task_packet_identity": None,
+                "checkpoint_kind": "EFFECT_PENDING",
+                "resumable_state": "MERGE_PENDING",
+                "next_action": "対象を照合する",
+                "external_target_identities": ["pr:63", "head:abc"],
+                "evidence_identities": ["ci:1"],
+            }
+        ]
+    )
+
+    checkpoint = PostgreSQLWorkStateStore(database).latest_checkpoint(record().identity)
+
+    assert checkpoint is not None
+    assert checkpoint.checkpoint_kind == "EFFECT_PENDING"
+    assert checkpoint.external_target_identities == ("pr:63", "head:abc")
+    assert checkpoint.evidence_identities == ("ci:1",)
+
+
+def test_effect_intent_is_idempotent_and_outcome_never_reenables_resend() -> None:
+    database = Database(rows=[{"status": "INTENT_RECORDED"}])
+    store = PostgreSQLWorkStateStore(database)
+    attempt = EffectAttempt(
+        idempotency_key="merge:pr:63:head:abc",
+        work_identity=record().identity,
+        kind="MERGE",
+        target_identity="pr:63|head:abc",
+        status="INTENT_RECORDED",
+    )
+
+    assert store.record_effect_intent(attempt)
+    store.record_effect_outcome(attempt.idempotency_key, "UNCERTAIN")
+
+    written = "\n".join(database.statements)
+    assert "ON CONFLICT (idempotency_key) DO NOTHING" in written
+    assert "AND status = 'INTENT_RECORDED'" in written
+    assert "UNCERTAIN" in written
+
+
+def test_issue_report_is_outbox_and_requires_bounded_body() -> None:
+    database = Database()
+    store = PostgreSQLWorkStateStore(database)
+
+    store.enqueue_issue_report(
+        identity="report:62:1",
+        work_identity=record().identity,
+        report_kind="PROGRESS",
+        checkpoint_identity="checkpoint:62:1",
+        body="DB確定済みの進捗報告",
+    )
+    store.mark_issue_report_published("report:62:1")
+
+    written = "\n".join(database.statements)
+    assert "loop_issue_report_outbox" in written
+    assert "'PENDING'" in written
+    assert "'PUBLISHED'" in written
+    with pytest.raises(WorkStateUnavailable, match="ISSUE_REPORT_INVALID"):
+        store.enqueue_issue_report(
+            identity="report:too-long",
+            work_identity=record().identity,
+            report_kind="PROGRESS",
+            checkpoint_identity=None,
+            body="x" * 4001,
+        )
+
+
+def test_invalid_lifecycle_and_database_write_failure_fail_closed() -> None:
+    with pytest.raises(WorkStateUnavailable, match="WORK_RECORD_INVALID"):
+        PostgreSQLWorkStateStore(Database()).upsert_work(
+            WorkRecord("work:bad", "repo", 62, "rev", "UNKNOWN")
+        )
+    with pytest.raises(WorkStateUnavailable, match="WORK_STATE_WRITE_FAILED"):
+        PostgreSQLWorkStateStore(Database(writable=False)).upsert_work(record())


### PR DESCRIPTION
## 関連Issue

Refs #62

## 変更内容

- Issueを課題・受入条件・依存関係・完了判断・人間向け状況報告の元締めとして定義した。
- PostgreSQLを、停止後に復元する選択済み作業、作業パケット、安全Checkpoint、未確定effect、leaseの正本として定義した。
- V2基礎作業復元アルゴリズムを状態機械として再設計した。
- Issue commentの自然文を、再開対象を決定する機械入力から除外した。
- V2作業状態のschema migration `0004_v2_work_state.sql` を追加した。
- DBから作業記録、作業パケット、正本pointerが指す安全Checkpoint、未確定effectを復元する。
- 作業packetまたは安全Checkpointの欠落・pointer不整合時は`READY`へ進めない。
- `V2ResumeCoordinator`がDB復元後にだけIssue / Project定義を同期し、未確定effectを限定照合する。

## 検証

- GitHub Actionsのexact-head品質検査を使用する。
- 修正前HEAD `4e1257d41c7e999a4c06e66818934bb0981c7634` は全品質検査SUCCESS。
- pointer整合修正後のexact HEADはCI結果を再確認する。

## 続く実装

- Issue / Project定義の同期adapter
- 外部effectの限定再照合adapter
- outboxのGitHub投稿adapter
- V2 Host入口の合成

## 非対象

- Issue #61で終了した旧actual-host自動開発方式の復活
