### PR TITLE
feat: V2の作業定義同期adapterを追加する

### DIFF
--- a/docs/architecture/v2/v2_adapters_cutover_and_acceptance.md
+++ b/docs/architecture/v2/v2_adapters_cutover_and_acceptance.md
@@ -31,6 +31,8 @@ dependency issue identities
 priority / Project status / 計画日
 ```
 
+`acceptance criteria digest`は対象Projectの型付きfieldを正本とする。Issue本文・comment、更新時刻、親子関係、追跡関係を代用してはならない。GitHubの`blockedBy`だけを依存関係として同期する。field欠落・提供元読取不能・Issue closed・依存未完了は、それぞれ異なる型付き結果として呼出側へ返す。
+
 IssueがclosedでDBのWorkが`COMPLETED`以外なら`WORK_CLOSED_BEFORE_COMPLETION`、dependencyが未完了なら`WAITING(DEPENDENCY_PENDING)`、同一Issue identityへの異なる受入条件digestは`BLOCKED(WORK_DEFINITION_CONFLICT)`とする。
 
 同期は作業パケットの対象、PR、HEADを作らない。これらはDBに既存のpacketがある場合にだけ、effect読戻しの対象として扱う。

--- a/docs/architecture/v2/work_recovery_algorithm.md
+++ b/docs/architecture/v2/work_recovery_algorithm.md
@@ -29,9 +29,10 @@ READY(packet)
 RECONCILE_REQUIRED(effect identities)
 WAITING(reason)
 BLOCKED(reason)
+COMPLETED
 ```
 
-`READY`以外は新しい外部変更を開始しない。
+`READY`以外は新しい外部変更を開始しない。`COMPLETED`はIssue closedかつDB Workが`COMPLETED`であり、未確定effectの読戻し後にだけ返す終端状態である。
 
 ## 3. データモデル
 

--- a/src/loop_engineering/v2_resume.py
+++ b/src/loop_engineering/v2_resume.py
@@ -12,6 +12,7 @@ from .work_state import EffectAttempt, RecoveredWork, WorkRecord
 class V2ResumeStatus(str, Enum):
     READY = "READY"
     RECONCILE_REQUIRED = "RECONCILE_REQUIRED"
+    WAITING = "WAITING"
     BLOCKED = "BLOCKED"
 
 
@@ -28,6 +29,19 @@ class V2ResumeResult:
     recovered: RecoveredWork | None = None
 
 
+class WorkDefinitionStatus(str, Enum):
+    READY = "READY"
+    UNAVAILABLE = "UNAVAILABLE"
+    CLOSED_BEFORE_COMPLETION = "CLOSED_BEFORE_COMPLETION"
+    DEPENDENCY_PENDING = "DEPENDENCY_PENDING"
+
+
+@dataclass(frozen=True, slots=True)
+class WorkDefinitionResult:
+    status: WorkDefinitionStatus
+    record: WorkRecord | None = None
+
+
 class WorkRecoveryPort(Protocol):
     def recover(self, work_identity: str) -> RecoveredWork | None: ...
 
@@ -39,7 +53,7 @@ class WorkRecoveryPort(Protocol):
 class WorkDefinitionPort(Protocol):
     """IssueとProjectから作業定義だけを同期する。"""
 
-    def synchronize(self, record: WorkRecord) -> WorkRecord | None: ...
+    def synchronize(self, record: WorkRecord) -> WorkDefinitionResult: ...
 
 
 class EffectReadbackPort(Protocol):
@@ -66,8 +80,15 @@ class V2ResumeCoordinator:
         if recovered is None or not _complete_recovery(recovered):
             return V2ResumeResult(V2ResumeStatus.BLOCKED, "WORK_RECOVERY_MISSING", recovered)
 
-        synchronized = self._definitions.synchronize(recovered.record)
-        if synchronized is None:
+        definition = self._definitions.synchronize(recovered.record)
+        if definition.status is WorkDefinitionStatus.DEPENDENCY_PENDING:
+            return V2ResumeResult(V2ResumeStatus.WAITING, "DEPENDENCY_PENDING", recovered)
+        if definition.status is WorkDefinitionStatus.CLOSED_BEFORE_COMPLETION:
+            return V2ResumeResult(
+                V2ResumeStatus.BLOCKED, "WORK_CLOSED_BEFORE_COMPLETION", recovered
+            )
+        synchronized = definition.record
+        if definition.status is not WorkDefinitionStatus.READY or synchronized is None:
             return V2ResumeResult(
                 V2ResumeStatus.BLOCKED,
                 "WORK_DEFINITION_UNAVAILABLE",

--- a/src/loop_engineering/v2_resume.py
+++ b/src/loop_engineering/v2_resume.py
@@ -83,8 +83,6 @@ class V2ResumeCoordinator:
             return V2ResumeResult(V2ResumeStatus.BLOCKED, "WORK_RECOVERY_MISSING", recovered)
 
         definition = self._definitions.synchronize(recovered.record)
-        if definition.status is WorkDefinitionStatus.COMPLETED:
-            return V2ResumeResult(V2ResumeStatus.COMPLETED, "WORK_COMPLETED", recovered)
         if definition.status is WorkDefinitionStatus.DEPENDENCY_PENDING:
             return V2ResumeResult(V2ResumeStatus.WAITING, "DEPENDENCY_PENDING", recovered)
         if definition.status is WorkDefinitionStatus.CLOSED_BEFORE_COMPLETION:
@@ -92,7 +90,8 @@ class V2ResumeCoordinator:
                 V2ResumeStatus.BLOCKED, "WORK_CLOSED_BEFORE_COMPLETION", recovered
             )
         synchronized = definition.record
-        if definition.status is not WorkDefinitionStatus.READY or synchronized is None:
+        accepted_statuses = {WorkDefinitionStatus.READY, WorkDefinitionStatus.COMPLETED}
+        if definition.status not in accepted_statuses or synchronized is None:
             return V2ResumeResult(
                 V2ResumeStatus.BLOCKED,
                 "WORK_DEFINITION_UNAVAILABLE",
@@ -120,6 +119,9 @@ class V2ResumeCoordinator:
                 recovered,
             )
 
+        if definition.status is WorkDefinitionStatus.COMPLETED:
+            return V2ResumeResult(V2ResumeStatus.COMPLETED, "WORK_COMPLETED", recovered)
+
         return V2ResumeResult(V2ResumeStatus.READY, "RESUME_READY", recovered)
 
 
@@ -143,4 +145,5 @@ def _same_work(before: WorkRecord, after: WorkRecord) -> bool:
         before.identity == after.identity
         and before.repository == after.repository
         and before.issue_number == after.issue_number
+        and before.issue_revision == after.issue_revision
     )

--- a/src/loop_engineering/v2_resume.py
+++ b/src/loop_engineering/v2_resume.py
@@ -11,6 +11,7 @@ from .work_state import EffectAttempt, RecoveredWork, WorkRecord
 
 class V2ResumeStatus(str, Enum):
     READY = "READY"
+    COMPLETED = "COMPLETED"
     RECONCILE_REQUIRED = "RECONCILE_REQUIRED"
     WAITING = "WAITING"
     BLOCKED = "BLOCKED"
@@ -31,6 +32,7 @@ class V2ResumeResult:
 
 class WorkDefinitionStatus(str, Enum):
     READY = "READY"
+    COMPLETED = "COMPLETED"
     UNAVAILABLE = "UNAVAILABLE"
     CLOSED_BEFORE_COMPLETION = "CLOSED_BEFORE_COMPLETION"
     DEPENDENCY_PENDING = "DEPENDENCY_PENDING"
@@ -81,6 +83,8 @@ class V2ResumeCoordinator:
             return V2ResumeResult(V2ResumeStatus.BLOCKED, "WORK_RECOVERY_MISSING", recovered)
 
         definition = self._definitions.synchronize(recovered.record)
+        if definition.status is WorkDefinitionStatus.COMPLETED:
+            return V2ResumeResult(V2ResumeStatus.COMPLETED, "WORK_COMPLETED", recovered)
         if definition.status is WorkDefinitionStatus.DEPENDENCY_PENDING:
             return V2ResumeResult(V2ResumeStatus.WAITING, "DEPENDENCY_PENDING", recovered)
         if definition.status is WorkDefinitionStatus.CLOSED_BEFORE_COMPLETION:

--- a/src/loop_engineering/v2_work_definition.py
+++ b/src/loop_engineering/v2_work_definition.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
+from .v2_resume import WorkDefinitionResult, WorkDefinitionStatus
 from .work_state import WorkRecord
 
 
@@ -20,7 +21,7 @@ class WorkDefinitionSnapshot:
     repository: str
     issue_number: int
     issue_state: str
-    acceptance_criteria_digest: str
+    acceptance_criteria_digest: str | None
     dependency_identities: tuple[str, ...]
     dependency_states: tuple[str, ...]
     project_status: str | None
@@ -63,11 +64,17 @@ class GitHubWorkDefinitionAdapter:
         self._runner = runner
         self._project_number = project_number
 
-    def synchronize(self, current: WorkRecord) -> WorkRecord | None:
+    def synchronize(self, current: WorkRecord) -> WorkDefinitionResult:
         snapshot = self._snapshot(current.repository, current.issue_number)
-        if snapshot is None or snapshot.blocking_reason is not None:
-            return None
-        return WorkRecord(
+        if snapshot is None:
+            return WorkDefinitionResult(WorkDefinitionStatus.UNAVAILABLE)
+        if snapshot.issue_state == "CLOSED":
+            return WorkDefinitionResult(WorkDefinitionStatus.CLOSED_BEFORE_COMPLETION)
+        if snapshot.blocking_reason is not None:
+            return WorkDefinitionResult(WorkDefinitionStatus.DEPENDENCY_PENDING)
+        if snapshot.acceptance_criteria_digest is None:
+            return WorkDefinitionResult(WorkDefinitionStatus.UNAVAILABLE)
+        return WorkDefinitionResult(WorkDefinitionStatus.READY, WorkRecord(
             identity=current.identity,
             repository=current.repository,
             issue_number=current.issue_number,
@@ -77,7 +84,7 @@ class GitHubWorkDefinitionAdapter:
             active_lineage_identity=current.active_lineage_identity,
             latest_task_packet_identity=current.latest_task_packet_identity,
             latest_checkpoint_identity=current.latest_checkpoint_identity,
-        )
+        ))
 
     def _snapshot(self, repository: str, issue_number: int) -> WorkDefinitionSnapshot | None:
         if "/" not in repository or issue_number < 1 or self._project_number < 1:
@@ -85,8 +92,8 @@ class GitHubWorkDefinitionAdapter:
         owner, name = repository.split("/", maxsplit=1)
         query = (
             "query($owner:String!,$name:String!,$issue:Int!){"
-            "repository(owner:$owner,name:$name){issue(number:$issue){number state body "
-            "parent{number state} trackedIssues(first:50){nodes{number state}} "
+            "repository(owner:$owner,name:$name){issue(number:$issue){number state "
+            "blockedBy(first:50){nodes{repository{nameWithOwner} number state}} "
             "projectItems(first:20){nodes{project{number} fieldValues(first:20){nodes{"
             "... on ProjectV2ItemFieldSingleSelectValue{field{... on ProjectV2FieldCommon{"
             "name}}name}"
@@ -106,16 +113,26 @@ class GitHubWorkDefinitionAdapter:
         issue = _mapping(_mapping(_mapping(payload, "data"), "repository"), "issue")
         number = issue.get("number")
         state = issue.get("state")
-        body = issue.get("body")
-        if number != issue_number or not isinstance(state, str) or not isinstance(body, str):
+        if number != issue_number or not isinstance(state, str):
             return None
+        if state == "CLOSED":
+            return WorkDefinitionSnapshot(
+                repository, issue_number, state, None, (), (), None, None, None, None
+            )
         values = _project_values(issue, self._project_number)
         if values is None:
             return None
         identities, states = _dependencies(issue)
         return WorkDefinitionSnapshot(
-            repository, issue_number, state, _digest(body), identities, states,
-            values.get("Status"), values.get("Priority"), values.get("Start date"),
+            repository,
+            issue_number,
+            state,
+            values.get("Acceptance criteria digest"),
+            identities,
+            states,
+            values.get("Status"),
+            values.get("Priority"),
+            values.get("Start date"),
             values.get("Target date"),
         )
 
@@ -149,23 +166,21 @@ def _mapping(value: Mapping[str, object], key: str) -> Mapping[str, object]:
     return nested if isinstance(nested, dict) else {}
 
 
-def _digest(value: str) -> str:
-    return hashlib.sha256(value.encode()).hexdigest()
-
-
 def _dependencies(issue: Mapping[str, object]) -> tuple[tuple[str, ...], tuple[str, ...]]:
     candidates: list[Mapping[str, object]] = []
-    parent = _mapping(issue, "parent")
-    if parent:
-        candidates.append(parent)
-    nodes = _mapping(issue, "trackedIssues").get("nodes")
+    nodes = _mapping(issue, "blockedBy").get("nodes")
     if isinstance(nodes, list):
         candidates.extend(node for node in nodes if isinstance(node, dict))
     identities: list[str] = []
     states: list[str] = []
     for candidate in candidates:
         number, state = candidate.get("number"), candidate.get("state")
+        dependency_repository = _mapping(candidate, "repository").get("nameWithOwner")
         if isinstance(number, int) and isinstance(state, str):
-            identities.append(f"issue:{number}")
+            identities.append(
+                f"issue:{dependency_repository}:{number}"
+                if isinstance(dependency_repository, str)
+                else f"issue:{number}"
+            )
             states.append(state)
     return tuple(identities), tuple(states)

--- a/src/loop_engineering/v2_work_definition.py
+++ b/src/loop_engineering/v2_work_definition.py
@@ -20,7 +20,9 @@ class WorkDefinitionSnapshot:
     repository: str
     issue_number: int
     issue_state: str
-    issue_updated_at: str
+    acceptance_criteria_digest: str
+    dependency_identities: tuple[str, ...]
+    dependency_states: tuple[str, ...]
     project_status: str | None
     priority: str | None
     start_date: str | None
@@ -32,7 +34,8 @@ class WorkDefinitionSnapshot:
             {
                 "issue": self.issue_number,
                 "state": self.issue_state,
-                "updated_at": self.issue_updated_at,
+                "acceptance_criteria_digest": self.acceptance_criteria_digest,
+                "dependencies": self.dependency_identities,
                 "project_status": self.project_status,
                 "priority": self.priority,
                 "start_date": self.start_date,
@@ -44,6 +47,14 @@ class WorkDefinitionSnapshot:
         )
         return "definition:" + hashlib.sha256(payload.encode()).hexdigest()
 
+    @property
+    def blocking_reason(self) -> str | None:
+        if self.issue_state == "CLOSED":
+            return "WORK_CLOSED_BEFORE_COMPLETION"
+        if any(state != "CLOSED" for state in self.dependency_states):
+            return "DEPENDENCY_PENDING"
+        return None
+
 
 class GitHubWorkDefinitionAdapter:
     """対象IssueとそのProject項目だけを1回のGraphQL読取りで同期する。"""
@@ -54,7 +65,7 @@ class GitHubWorkDefinitionAdapter:
 
     def synchronize(self, current: WorkRecord) -> WorkRecord | None:
         snapshot = self._snapshot(current.repository, current.issue_number)
-        if snapshot is None or snapshot.issue_state != "OPEN":
+        if snapshot is None or snapshot.blocking_reason is not None:
             return None
         return WorkRecord(
             identity=current.identity,
@@ -73,8 +84,9 @@ class GitHubWorkDefinitionAdapter:
             return None
         owner, name = repository.split("/", maxsplit=1)
         query = (
-            "query($owner:String!,$name:String!,$issue:Int!,$project:Int!){"
-            "repository(owner:$owner,name:$name){issue(number:$issue){number state updatedAt "
+            "query($owner:String!,$name:String!,$issue:Int!){"
+            "repository(owner:$owner,name:$name){issue(number:$issue){number state body "
+            "parent{number state} trackedIssues(first:50){nodes{number state}} "
             "projectItems(first:20){nodes{project{number} fieldValues(first:20){nodes{"
             "... on ProjectV2ItemFieldSingleSelectValue{field{... on ProjectV2FieldCommon{"
             "name}}name}"
@@ -85,8 +97,7 @@ class GitHubWorkDefinitionAdapter:
             raw = self._runner.run(
                 (
                     "gh", "api", "graphql", "-f", f"query={query}", "-f", f"owner={owner}",
-                    "-f", f"name={name}", "-F", f"issue={issue_number}", "-F",
-                    f"project={self._project_number}",
+                    "-f", f"name={name}", "-F", f"issue={issue_number}",
                 )
             )
             payload = json.loads(raw)
@@ -95,15 +106,17 @@ class GitHubWorkDefinitionAdapter:
         issue = _mapping(_mapping(_mapping(payload, "data"), "repository"), "issue")
         number = issue.get("number")
         state = issue.get("state")
-        updated_at = issue.get("updatedAt")
-        if number != issue_number or not isinstance(state, str) or not isinstance(updated_at, str):
+        body = issue.get("body")
+        if number != issue_number or not isinstance(state, str) or not isinstance(body, str):
             return None
         values = _project_values(issue, self._project_number)
         if values is None:
             return None
+        identities, states = _dependencies(issue)
         return WorkDefinitionSnapshot(
-            repository, issue_number, state, updated_at, values.get("Status"),
-            values.get("Priority"), values.get("Start date"), values.get("Target date"),
+            repository, issue_number, state, _digest(body), identities, states,
+            values.get("Status"), values.get("Priority"), values.get("Start date"),
+            values.get("Target date"),
         )
 
 
@@ -134,3 +147,25 @@ def _project_values(
 def _mapping(value: Mapping[str, object], key: str) -> Mapping[str, object]:
     nested = value.get(key)
     return nested if isinstance(nested, dict) else {}
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _dependencies(issue: Mapping[str, object]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    candidates: list[Mapping[str, object]] = []
+    parent = _mapping(issue, "parent")
+    if parent:
+        candidates.append(parent)
+    nodes = _mapping(issue, "trackedIssues").get("nodes")
+    if isinstance(nodes, list):
+        candidates.extend(node for node in nodes if isinstance(node, dict))
+    identities: list[str] = []
+    states: list[str] = []
+    for candidate in candidates:
+        number, state = candidate.get("number"), candidate.get("state")
+        if isinstance(number, int) and isinstance(state, str):
+            identities.append(f"issue:{number}")
+            states.append(state)
+    return tuple(identities), tuple(states)

--- a/src/loop_engineering/v2_work_definition.py
+++ b/src/loop_engineering/v2_work_definition.py
@@ -1,0 +1,136 @@
+"""V2のIssue / Project定義を本文解析なしで同期する接続層。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from .work_state import WorkRecord
+
+
+class WorkDefinitionCommandRunner(Protocol):
+    def run(self, args: Sequence[str]) -> str: ...
+
+
+@dataclass(frozen=True, slots=True)
+class WorkDefinitionSnapshot:
+    repository: str
+    issue_number: int
+    issue_state: str
+    issue_updated_at: str
+    project_status: str | None
+    priority: str | None
+    start_date: str | None
+    target_date: str | None
+
+    @property
+    def revision(self) -> str:
+        payload = json.dumps(
+            {
+                "issue": self.issue_number,
+                "state": self.issue_state,
+                "updated_at": self.issue_updated_at,
+                "project_status": self.project_status,
+                "priority": self.priority,
+                "start_date": self.start_date,
+                "target_date": self.target_date,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return "definition:" + hashlib.sha256(payload.encode()).hexdigest()
+
+
+class GitHubWorkDefinitionAdapter:
+    """対象IssueとそのProject項目だけを1回のGraphQL読取りで同期する。"""
+
+    def __init__(self, runner: WorkDefinitionCommandRunner, project_number: int) -> None:
+        self._runner = runner
+        self._project_number = project_number
+
+    def synchronize(self, current: WorkRecord) -> WorkRecord | None:
+        snapshot = self._snapshot(current.repository, current.issue_number)
+        if snapshot is None or snapshot.issue_state != "OPEN":
+            return None
+        return WorkRecord(
+            identity=current.identity,
+            repository=current.repository,
+            issue_number=current.issue_number,
+            issue_revision=snapshot.revision,
+            lifecycle=current.lifecycle,
+            selected_transition=current.selected_transition,
+            active_lineage_identity=current.active_lineage_identity,
+            latest_task_packet_identity=current.latest_task_packet_identity,
+            latest_checkpoint_identity=current.latest_checkpoint_identity,
+        )
+
+    def _snapshot(self, repository: str, issue_number: int) -> WorkDefinitionSnapshot | None:
+        if "/" not in repository or issue_number < 1 or self._project_number < 1:
+            return None
+        owner, name = repository.split("/", maxsplit=1)
+        query = (
+            "query($owner:String!,$name:String!,$issue:Int!,$project:Int!){"
+            "repository(owner:$owner,name:$name){issue(number:$issue){number state updatedAt "
+            "projectItems(first:20){nodes{project{number} fieldValues(first:20){nodes{"
+            "... on ProjectV2ItemFieldSingleSelectValue{field{... on ProjectV2FieldCommon{"
+            "name}}name}"
+            "... on ProjectV2ItemFieldDateValue{field{... on ProjectV2FieldCommon{name}}date}"
+            "}}}}}}}"
+        )
+        try:
+            raw = self._runner.run(
+                (
+                    "gh", "api", "graphql", "-f", f"query={query}", "-f", f"owner={owner}",
+                    "-f", f"name={name}", "-F", f"issue={issue_number}", "-F",
+                    f"project={self._project_number}",
+                )
+            )
+            payload = json.loads(raw)
+        except (OSError, ValueError, json.JSONDecodeError):
+            return None
+        issue = _mapping(_mapping(_mapping(payload, "data"), "repository"), "issue")
+        number = issue.get("number")
+        state = issue.get("state")
+        updated_at = issue.get("updatedAt")
+        if number != issue_number or not isinstance(state, str) or not isinstance(updated_at, str):
+            return None
+        values = _project_values(issue, self._project_number)
+        if values is None:
+            return None
+        return WorkDefinitionSnapshot(
+            repository, issue_number, state, updated_at, values.get("Status"),
+            values.get("Priority"), values.get("Start date"), values.get("Target date"),
+        )
+
+
+def _project_values(
+    issue: Mapping[str, object], project_number: int
+) -> dict[str, str | None] | None:
+    items = _mapping(issue, "projectItems").get("nodes")
+    if not isinstance(items, list):
+        return None
+    for item in items:
+        if not isinstance(item, dict) or _mapping(item, "project").get("number") != project_number:
+            continue
+        values: dict[str, str | None] = {}
+        nodes = _mapping(item, "fieldValues").get("nodes")
+        if not isinstance(nodes, list):
+            return None
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            name = _mapping(node, "field").get("name")
+            value = node.get("name") if isinstance(node.get("name"), str) else node.get("date")
+            if isinstance(name, str) and (value is None or isinstance(value, str)):
+                values[name] = value
+        return values
+    return None
+
+
+def _mapping(value: Mapping[str, object], key: str) -> Mapping[str, object]:
+    nested = value.get(key)
+    return nested if isinstance(nested, dict) else {}

--- a/src/loop_engineering/v2_work_definition.py
+++ b/src/loop_engineering/v2_work_definition.py
@@ -179,13 +179,19 @@ def _mapping(value: Mapping[str, object], key: str) -> Mapping[str, object]:
 
 
 def _dependencies(issue: Mapping[str, object]) -> tuple[tuple[str, ...], tuple[str, ...]] | None:
-    candidates: list[Mapping[str, object]] = []
-    blocked_by = _mapping(issue, "blockedBy")
-    if _mapping(blocked_by, "pageInfo").get("hasNextPage") is True:
+    blocked_value = issue.get("blockedBy")
+    if not isinstance(blocked_value, dict):
         return None
+    blocked_by = blocked_value
+    page_info = blocked_by.get("pageInfo")
     nodes = blocked_by.get("nodes")
-    if isinstance(nodes, list):
-        candidates.extend(node for node in nodes if isinstance(node, dict))
+    if not isinstance(page_info, dict) or not isinstance(page_info.get("hasNextPage"), bool):
+        return None
+    if page_info["hasNextPage"]:
+        return None
+    if not isinstance(nodes, list):
+        return None
+    candidates = [node for node in nodes if isinstance(node, dict)]
     identities: list[str] = []
     states: list[str] = []
     for candidate in candidates:

--- a/src/loop_engineering/v2_work_definition.py
+++ b/src/loop_engineering/v2_work_definition.py
@@ -68,8 +68,10 @@ class GitHubWorkDefinitionAdapter:
         snapshot = self._snapshot(current.repository, current.issue_number)
         if snapshot is None:
             return WorkDefinitionResult(WorkDefinitionStatus.UNAVAILABLE)
-        if snapshot.issue_state == "CLOSED":
+        if snapshot.issue_state == "CLOSED" and current.lifecycle != "COMPLETED":
             return WorkDefinitionResult(WorkDefinitionStatus.CLOSED_BEFORE_COMPLETION)
+        if snapshot.issue_state == "CLOSED":
+            return WorkDefinitionResult(WorkDefinitionStatus.READY, current)
         if snapshot.blocking_reason is not None:
             return WorkDefinitionResult(WorkDefinitionStatus.DEPENDENCY_PENDING)
         if snapshot.acceptance_criteria_digest is None:
@@ -93,11 +95,13 @@ class GitHubWorkDefinitionAdapter:
         query = (
             "query($owner:String!,$name:String!,$issue:Int!){"
             "repository(owner:$owner,name:$name){issue(number:$issue){number state "
-            "blockedBy(first:50){nodes{repository{nameWithOwner} number state}} "
+            "blockedBy(first:50){nodes{repository{nameWithOwner} number state}"
+            "pageInfo{hasNextPage}} "
             "projectItems(first:20){nodes{project{number} fieldValues(first:20){nodes{"
             "... on ProjectV2ItemFieldSingleSelectValue{field{... on ProjectV2FieldCommon{"
             "name}}name}"
             "... on ProjectV2ItemFieldDateValue{field{... on ProjectV2FieldCommon{name}}date}"
+            "... on ProjectV2ItemFieldTextValue{field{... on ProjectV2FieldCommon{name}}text}"
             "}}}}}}}"
         )
         try:
@@ -122,7 +126,10 @@ class GitHubWorkDefinitionAdapter:
         values = _project_values(issue, self._project_number)
         if values is None:
             return None
-        identities, states = _dependencies(issue)
+        dependencies = _dependencies(issue)
+        if dependencies is None:
+            return None
+        identities, states = dependencies
         return WorkDefinitionSnapshot(
             repository,
             issue_number,
@@ -155,6 +162,8 @@ def _project_values(
                 continue
             name = _mapping(node, "field").get("name")
             value = node.get("name") if isinstance(node.get("name"), str) else node.get("date")
+            if not isinstance(value, str):
+                value = node.get("text")
             if isinstance(name, str) and (value is None or isinstance(value, str)):
                 values[name] = value
         return values
@@ -166,9 +175,12 @@ def _mapping(value: Mapping[str, object], key: str) -> Mapping[str, object]:
     return nested if isinstance(nested, dict) else {}
 
 
-def _dependencies(issue: Mapping[str, object]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+def _dependencies(issue: Mapping[str, object]) -> tuple[tuple[str, ...], tuple[str, ...]] | None:
     candidates: list[Mapping[str, object]] = []
-    nodes = _mapping(issue, "blockedBy").get("nodes")
+    blocked_by = _mapping(issue, "blockedBy")
+    if _mapping(blocked_by, "pageInfo").get("hasNextPage") is True:
+        return None
+    nodes = blocked_by.get("nodes")
     if isinstance(nodes, list):
         candidates.extend(node for node in nodes if isinstance(node, dict))
     identities: list[str] = []

--- a/src/loop_engineering/v2_work_definition.py
+++ b/src/loop_engineering/v2_work_definition.py
@@ -71,7 +71,7 @@ class GitHubWorkDefinitionAdapter:
         if snapshot.issue_state == "CLOSED" and current.lifecycle != "COMPLETED":
             return WorkDefinitionResult(WorkDefinitionStatus.CLOSED_BEFORE_COMPLETION)
         if snapshot.issue_state == "CLOSED":
-            return WorkDefinitionResult(WorkDefinitionStatus.READY, current)
+            return WorkDefinitionResult(WorkDefinitionStatus.COMPLETED, current)
         if snapshot.blocking_reason is not None:
             return WorkDefinitionResult(WorkDefinitionStatus.DEPENDENCY_PENDING)
         if snapshot.acceptance_criteria_digest is None:
@@ -102,7 +102,7 @@ class GitHubWorkDefinitionAdapter:
             "name}}name}"
             "... on ProjectV2ItemFieldDateValue{field{... on ProjectV2FieldCommon{name}}date}"
             "... on ProjectV2ItemFieldTextValue{field{... on ProjectV2FieldCommon{name}}text}"
-            "}}}}}}}"
+            "}pageInfo{hasNextPage}}}}}}}"
         )
         try:
             raw = self._runner.run(
@@ -154,7 +154,10 @@ def _project_values(
         if not isinstance(item, dict) or _mapping(item, "project").get("number") != project_number:
             continue
         values: dict[str, str | None] = {}
-        nodes = _mapping(item, "fieldValues").get("nodes")
+        field_values = _mapping(item, "fieldValues")
+        if _mapping(field_values, "pageInfo").get("hasNextPage") is True:
+            return None
+        nodes = field_values.get("nodes")
         if not isinstance(nodes, list):
             return None
         for node in nodes:

--- a/tests/loop_engineering/test_v2_resume.py
+++ b/tests/loop_engineering/test_v2_resume.py
@@ -6,6 +6,8 @@ from loop_engineering.v2_resume import (
     EffectReadbackStatus,
     V2ResumeCoordinator,
     V2ResumeStatus,
+    WorkDefinitionResult,
+    WorkDefinitionStatus,
 )
 from loop_engineering.work_state import (
     EffectAttempt,
@@ -73,10 +75,18 @@ class Definitions:
     value: WorkRecord | None
     calls: int = 0
 
-    def synchronize(self, current: WorkRecord) -> WorkRecord | None:
+    def synchronize(self, current: WorkRecord) -> WorkDefinitionResult:
         assert current == record()
         self.calls += 1
-        return self.value
+        status = (
+            WorkDefinitionStatus.READY
+            if self.value is not None
+            else WorkDefinitionStatus.UNAVAILABLE
+        )
+        return WorkDefinitionResult(
+            status,
+            self.value,
+        )
 
 
 @dataclass

--- a/tests/loop_engineering/test_v2_work_definition.py
+++ b/tests/loop_engineering/test_v2_work_definition.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from loop_engineering.v2_work_definition import GitHubWorkDefinitionAdapter
+from loop_engineering.work_state import WorkRecord
+
+
+@dataclass
+class Runner:
+    output: str
+    calls: list[Sequence[str]]
+
+    def run(self, args: Sequence[str]) -> str:
+        self.calls.append(args)
+        return self.output
+
+
+def record() -> WorkRecord:
+    return WorkRecord("work:repo:65", "ktan514/loop-engineering", 65, "old", "SELECTED")
+
+
+def test_synchronizes_only_typed_issue_and_project_fields() -> None:
+    payload = {
+        "data": {"repository": {"issue": {
+            "number": 65, "state": "OPEN", "updatedAt": "2026-08-31T00:00:00Z",
+            "body": "この本文は読まない",
+            "projectItems": {"nodes": [{"project": {"number": 9}, "fieldValues": {"nodes": [
+                {"field": {"name": "Status"}, "name": "In Progress"},
+                {"field": {"name": "Priority"}, "name": "P1"},
+                {"field": {"name": "Start date"}, "date": "2026-09-02"},
+            ]}}]},
+        }}}}
+    runner = Runner(json.dumps(payload), [])
+
+    actual = GitHubWorkDefinitionAdapter(runner, 9).synchronize(record())
+
+    assert actual is not None
+    assert actual.issue_revision.startswith("definition:")
+    assert actual.identity == record().identity
+    assert len(runner.calls) == 1
+    command = " ".join(runner.calls[0])
+    assert "projectItems" in command
+    assert "body" not in command
+    assert "comments" not in command
+
+
+def test_closed_or_missing_project_is_unavailable() -> None:
+    closed = {"data": {"repository": {"issue": {
+        "number": 65, "state": "CLOSED", "updatedAt": "2026-08-31T00:00:00Z",
+        "projectItems": {"nodes": []},
+    }}}}
+    adapter = GitHubWorkDefinitionAdapter(Runner(json.dumps(closed), []), 9)
+    assert adapter.synchronize(record()) is None

--- a/tests/loop_engineering/test_v2_work_definition.py
+++ b/tests/loop_engineering/test_v2_work_definition.py
@@ -96,9 +96,9 @@ def test_text_digest_completed_closed_and_truncated_dependencies_are_safe() -> N
     issue["state"] = "CLOSED"
     completed = WorkRecord("work:repo:65", "ktan514/loop-engineering", 65, "old", "COMPLETED")
     adapter = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9)
-    assert adapter.synchronize(completed).status is WorkDefinitionStatus.READY
+    assert adapter.synchronize(completed).status is WorkDefinitionStatus.COMPLETED
 
     issue["state"] = "OPEN"
-    issue["blockedBy"]["pageInfo"] = {"hasNextPage": True}
+    issue["blockedBy"] = {"nodes": [], "pageInfo": {"hasNextPage": True}}
     adapter = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9)
     assert adapter.synchronize(record()).status is WorkDefinitionStatus.UNAVAILABLE

--- a/tests/loop_engineering/test_v2_work_definition.py
+++ b/tests/loop_engineering/test_v2_work_definition.py
@@ -43,7 +43,7 @@ def test_synchronizes_only_typed_issue_and_project_fields() -> None:
     assert len(runner.calls) == 1
     command = " ".join(runner.calls[0])
     assert "projectItems" in command
-    assert "body" not in command
+    assert " body " in command
     assert "comments" not in command
 
 
@@ -53,4 +53,23 @@ def test_closed_or_missing_project_is_unavailable() -> None:
         "projectItems": {"nodes": []},
     }}}}
     adapter = GitHubWorkDefinitionAdapter(Runner(json.dumps(closed), []), 9)
+    assert adapter.synchronize(record()) is None
+
+
+def test_comment_updates_do_not_change_revision_and_open_dependency_waits() -> None:
+    issue = {
+        "number": 65, "state": "OPEN", "body": "## 受入条件\n\n- 同期する",
+        "updatedAt": "comment-update-only", "parent": {"number": 62, "state": "CLOSED"},
+        "trackedIssues": {"nodes": []},
+        "projectItems": {"nodes": [{"project": {"number": 9}, "fieldValues": {"nodes": []}}]},
+    }
+    payload = {"data": {"repository": {"issue": issue}}}
+    first = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9).synchronize(record())
+    issue["updatedAt"] = "another-comment-update"
+    second = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9).synchronize(record())
+    assert first is not None and second is not None
+    assert first.issue_revision == second.issue_revision
+
+    issue["trackedIssues"] = {"nodes": [{"number": 66, "state": "OPEN"}]}
+    adapter = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9)
     assert adapter.synchronize(record()) is None

--- a/tests/loop_engineering/test_v2_work_definition.py
+++ b/tests/loop_engineering/test_v2_work_definition.py
@@ -34,6 +34,7 @@ def test_synchronizes_only_typed_issue_and_project_fields() -> None:
                 {"field": {"name": "Start date"}, "date": "2026-09-02"},
                 {"field": {"name": "Acceptance criteria digest"}, "name": "sha256:abc"},
             ]}}]},
+            "blockedBy": {"nodes": [], "pageInfo": {"hasNextPage": False}},
         }}}}
     runner = Runner(json.dumps(payload), [])
 
@@ -63,7 +64,7 @@ def test_comment_updates_do_not_change_revision_and_open_dependency_waits() -> N
     issue = {
         "number": 65, "state": "OPEN",
         "updatedAt": "comment-update-only", "parent": {"number": 62, "state": "CLOSED"},
-        "blockedBy": {"nodes": []},
+        "blockedBy": {"nodes": [], "pageInfo": {"hasNextPage": False}},
         "projectItems": {"nodes": [{"project": {"number": 9}, "fieldValues": {"nodes": [
             {"field": {"name": "Acceptance criteria digest"}, "name": "sha256:abc"},
         ]}}]},
@@ -75,7 +76,10 @@ def test_comment_updates_do_not_change_revision_and_open_dependency_waits() -> N
     assert first.record is not None and second.record is not None
     assert first.record.issue_revision == second.record.issue_revision
 
-    issue["blockedBy"] = {"nodes": [{"number": 66, "state": "OPEN"}]}
+    issue["blockedBy"] = {
+        "nodes": [{"number": 66, "state": "OPEN"}],
+        "pageInfo": {"hasNextPage": False},
+    }
     adapter = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9)
     assert adapter.synchronize(record()).status is WorkDefinitionStatus.DEPENDENCY_PENDING
 
@@ -101,4 +105,7 @@ def test_text_digest_completed_closed_and_truncated_dependencies_are_safe() -> N
     issue["state"] = "OPEN"
     issue["blockedBy"] = {"nodes": [], "pageInfo": {"hasNextPage": True}}
     adapter = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9)
+    assert adapter.synchronize(record()).status is WorkDefinitionStatus.UNAVAILABLE
+
+    issue.pop("blockedBy")
     assert adapter.synchronize(record()).status is WorkDefinitionStatus.UNAVAILABLE

--- a/tests/loop_engineering/test_v2_work_definition.py
+++ b/tests/loop_engineering/test_v2_work_definition.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+from loop_engineering.v2_resume import WorkDefinitionStatus
 from loop_engineering.v2_work_definition import GitHubWorkDefinitionAdapter
 from loop_engineering.work_state import WorkRecord
 
@@ -31,19 +32,21 @@ def test_synchronizes_only_typed_issue_and_project_fields() -> None:
                 {"field": {"name": "Status"}, "name": "In Progress"},
                 {"field": {"name": "Priority"}, "name": "P1"},
                 {"field": {"name": "Start date"}, "date": "2026-09-02"},
+                {"field": {"name": "Acceptance criteria digest"}, "name": "sha256:abc"},
             ]}}]},
         }}}}
     runner = Runner(json.dumps(payload), [])
 
     actual = GitHubWorkDefinitionAdapter(runner, 9).synchronize(record())
 
-    assert actual is not None
-    assert actual.issue_revision.startswith("definition:")
-    assert actual.identity == record().identity
+    assert actual.status is WorkDefinitionStatus.READY
+    assert actual.record is not None
+    assert actual.record.issue_revision.startswith("definition:")
+    assert actual.record.identity == record().identity
     assert len(runner.calls) == 1
     command = " ".join(runner.calls[0])
     assert "projectItems" in command
-    assert " body " in command
+    assert "body" not in command
     assert "comments" not in command
 
 
@@ -53,23 +56,25 @@ def test_closed_or_missing_project_is_unavailable() -> None:
         "projectItems": {"nodes": []},
     }}}}
     adapter = GitHubWorkDefinitionAdapter(Runner(json.dumps(closed), []), 9)
-    assert adapter.synchronize(record()) is None
+    assert adapter.synchronize(record()).status is WorkDefinitionStatus.CLOSED_BEFORE_COMPLETION
 
 
 def test_comment_updates_do_not_change_revision_and_open_dependency_waits() -> None:
     issue = {
-        "number": 65, "state": "OPEN", "body": "## 受入条件\n\n- 同期する",
+        "number": 65, "state": "OPEN",
         "updatedAt": "comment-update-only", "parent": {"number": 62, "state": "CLOSED"},
-        "trackedIssues": {"nodes": []},
-        "projectItems": {"nodes": [{"project": {"number": 9}, "fieldValues": {"nodes": []}}]},
+        "blockedBy": {"nodes": []},
+        "projectItems": {"nodes": [{"project": {"number": 9}, "fieldValues": {"nodes": [
+            {"field": {"name": "Acceptance criteria digest"}, "name": "sha256:abc"},
+        ]}}]},
     }
     payload = {"data": {"repository": {"issue": issue}}}
     first = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9).synchronize(record())
     issue["updatedAt"] = "another-comment-update"
     second = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9).synchronize(record())
-    assert first is not None and second is not None
-    assert first.issue_revision == second.issue_revision
+    assert first.record is not None and second.record is not None
+    assert first.record.issue_revision == second.record.issue_revision
 
-    issue["trackedIssues"] = {"nodes": [{"number": 66, "state": "OPEN"}]}
+    issue["blockedBy"] = {"nodes": [{"number": 66, "state": "OPEN"}]}
     adapter = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9)
-    assert adapter.synchronize(record()) is None
+    assert adapter.synchronize(record()).status is WorkDefinitionStatus.DEPENDENCY_PENDING

--- a/tests/loop_engineering/test_v2_work_definition.py
+++ b/tests/loop_engineering/test_v2_work_definition.py
@@ -78,3 +78,27 @@ def test_comment_updates_do_not_change_revision_and_open_dependency_waits() -> N
     issue["blockedBy"] = {"nodes": [{"number": 66, "state": "OPEN"}]}
     adapter = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9)
     assert adapter.synchronize(record()).status is WorkDefinitionStatus.DEPENDENCY_PENDING
+
+
+def test_text_digest_completed_closed_and_truncated_dependencies_are_safe() -> None:
+    issue = {
+        "number": 65,
+        "state": "OPEN",
+        "blockedBy": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+        "projectItems": {"nodes": [{"project": {"number": 9}, "fieldValues": {"nodes": [
+            {"field": {"name": "Acceptance criteria digest"}, "text": "digest:65"},
+        ]}}]},
+    }
+    payload = {"data": {"repository": {"issue": issue}}}
+    result = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9).synchronize(record())
+    assert result.status is WorkDefinitionStatus.READY
+
+    issue["state"] = "CLOSED"
+    completed = WorkRecord("work:repo:65", "ktan514/loop-engineering", 65, "old", "COMPLETED")
+    adapter = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9)
+    assert adapter.synchronize(completed).status is WorkDefinitionStatus.READY
+
+    issue["state"] = "OPEN"
+    issue["blockedBy"]["pageInfo"] = {"hasNextPage": True}
+    adapter = GitHubWorkDefinitionAdapter(Runner(json.dumps(payload), []), 9)
+    assert adapter.synchronize(record()).status is WorkDefinitionStatus.UNAVAILABLE


### PR DESCRIPTION
## 関連Issue

Refs #65

## 変更内容

- 指定Issueと対象Project fieldだけを一回のGraphQL読取りで同期するadapterを追加
- 本文・commentを取得・解析せず、型付きfieldから安定した定義revisionを生成
- closed Issueまたは対象Project項目なしでは安全側で同期不可にする

## 検証

- `pipenv run pytest` — 205 passed
- `pipenv run ruff check .`
- `pipenv run mypy --strict src`
- `pipenv run python -m compileall -q src`
- `git diff --check`