### PR TITLE
feat: V2外部効果読戻しとoutbox投稿を実装する

### DIFF
--- a/docs/architecture/v2/v2_effect_readback_and_outbox.md
+++ b/docs/architecture/v2/v2_effect_readback_and_outbox.md
@@ -1,0 +1,161 @@
+# V2外部効果読戻し・Issue報告outbox設計
+
+管理Issue: #66
+
+上位設計: `v2_adapters_cutover_and_acceptance.md`
+
+状態: 製造仕様
+
+## 1. 目的
+
+V2でDBへ確定済みの外部効果意図だけを、記録済み対象identityへ限定して読戻す。また、DB確定後に生成されたIssue報告outboxだけを重複なく投稿する。
+
+本仕様は外部効果の再実行を扱わない。`INTENT_RECORDED`または`UNCERTAIN`の効果を読戻しても、同じidempotency keyを自動再送してはならない。
+
+## 2. DBに保持する効果契約
+
+`EffectAttempt`は次を保持する。
+
+- `idempotency_key`
+- `work_identity`
+- `kind`
+- `target_identity`
+- `status`
+- `request_identity`
+- `expected_preconditions`
+- `expected_effect`
+
+`expected_preconditions`と`expected_effect`は秘密情報を含まない文字列key/valueだけを保存する。既存の`loop_effect_attempts`へversioned migrationでJSONB列を追加し、旧行は空objectとして読み込めるようにする。
+
+新規効果意図では、読戻しに必要な期待値を空のまま発行してはならない。旧行や不完全行を読戻せない場合は`UNKNOWN`とし、推測で`CONFIRMED`または`NO_EFFECT`へ進めない。
+
+## 3. 読戻し状態遷移
+
+読戻し入力はDBから復元した`INTENT_RECORDED`または`UNCERTAIN`だけである。
+
+- 現在値が`expected_effect`と一致する: `CONFIRMED`
+- 現在値が`expected_preconditions`と一致し、効果未発生を証明できる: `NO_EFFECT`
+- 対象identityが移動した、必要値が欠落した、提供元読取りに失敗した、現在値がどちらとも一致しない: `UNKNOWN`
+
+`UNCERTAIN`は「再送可能」を意味しない。対象限定の読戻しによって結果を証明できた場合に限り`CONFIRMED`または`NO_EFFECT`へ確定できる。`UNKNOWN`のままならDB状態を変更しない。
+
+このためDBの効果結果更新は、`INTENT_RECORDED`と`UNCERTAIN`の双方から`CONFIRMED`または`NO_EFFECT`への一方向確定を許可する。`CONFIRMED`、`NO_EFFECT`から別状態へ戻してはならない。
+
+## 4. GitHub読戻しadapter
+
+adapterは対象Repositoryを生成時に固定し、`EffectAttempt.target_identity`以外のIssue、PR、branchを探索しない。
+
+### 4.1 PUSH
+
+`target_identity`は`branch:<branch-name>`とする。
+
+- `expected_preconditions["head"]`: 実行前HEAD
+- `expected_effect["head"]`: 実行後に期待するHEAD
+
+対象branchだけを読み、現在HEADが実行後HEADなら`CONFIRMED`、実行前HEADなら`NO_EFFECT`、それ以外は`UNKNOWN`とする。
+
+### 4.2 READY
+
+`target_identity`は`pr:<number>`とする。
+
+必須値:
+
+- `expected_preconditions["head"]`
+- `expected_preconditions["draft"]`
+- `expected_effect["draft"]`
+
+対象PRだけを読み、HEAD一致を先に確認する。HEADが異なる場合は`UNKNOWN`とする。HEAD一致後、draft状態が期待効果なら`CONFIRMED`、実行前状態なら`NO_EFFECT`、それ以外は`UNKNOWN`とする。
+
+### 4.3 MERGE
+
+`target_identity`は`pr:<number>`とする。
+
+必須値:
+
+- `expected_preconditions["head"]`
+- `expected_preconditions["base"]`
+- `expected_preconditions["state"]`
+- `expected_effect["state"]`
+
+対象PRだけを読み、head/baseが期待identityと一致することを先に確認する。現在stateが期待効果なら`CONFIRMED`、実行前stateなら`NO_EFFECT`、それ以外は`UNKNOWN`とする。merge済み判定で別PRやbranchを探索しない。
+
+### 4.4 ISSUE_UPDATE
+
+`target_identity`は`issue:<number>`とする。
+
+`expected_preconditions`と`expected_effect`は、今回変更するGitHub Issueの型付きscalar fieldだけを同じkey集合で持つ。初期対応fieldは`state`と`title`に限定する。
+
+対象Issueだけを読み、全fieldが期待効果なら`CONFIRMED`、全fieldが実行前値なら`NO_EFFECT`、混在・未対応field・欠落は`UNKNOWN`とする。
+
+### 4.5 REPORT
+
+Issue報告は通常の作業effectと分離し、5節のoutbox publisherで扱う。`EffectReadbackPort`へ`REPORT`が渡された場合は`UNKNOWN`とし、通常effectの再実行経路へ流さない。
+
+## 5. Issue報告outbox publisher
+
+### 5.1 DB取得
+
+`WorkStatePort`は指定`work_identity`の`PENDING`報告だけを`recorded_at ASC`で返す。返却型は少なくとも次を持つ。
+
+- outbox identity
+- work identity
+- report kind
+- checkpoint identity
+- body
+
+`body`は既存契約どおり4000文字以下とし、秘密値、認証情報、無加工診断、作業パケット全体を含めない。
+
+### 5.2 重複識別子
+
+GitHubへ投稿する本文には、outbox identityそのものではなく、そのSHA-256 digestを使った機械識別commentを付加する。
+
+```text
+<!-- loop-engineering:v2-report:<sha256> -->
+```
+
+これによりDB内部identityを人間向け本文へ公開せず、同じoutboxの投稿済み判定を行う。
+
+### 5.3 投稿手順
+
+1. DBから`PENDING`報告を取得する。
+2. 対象WorkのRepositoryとIssue番号だけを使用する。
+3. 対象Issueのcommentを全ページ読み、同じdigest markerを探す。
+4. markerが既に存在する場合、投稿せずDBを`PUBLISHED`へ確定する。
+5. markerが無い場合だけ1回投稿する。
+6. 投稿後に同じ対象Issueを再読戻しし、markerを確認できた場合だけDBを`PUBLISHED`へ確定する。
+7. 投稿または読戻しに失敗した場合は`PENDING`のまま終了する。
+
+publisherは作業effectを呼び出さない。報告再試行が発生してもPUSH、MERGE、READY、ISSUE_UPDATEを再実行しない。
+
+## 6. 失敗時契約
+
+- GitHub読取り失敗: `UNKNOWN`
+- target identity不正: `UNKNOWN`
+- 期待値不足: `UNKNOWN`
+- target HEAD/base不一致: `UNKNOWN`
+- outbox一覧DB読取り失敗: fail-closed
+- Issue comment読取り失敗: 報告は`PENDING`のまま
+- Issue comment投稿失敗: 報告は`PENDING`のまま
+- 投稿後readback失敗: 報告は`PENDING`のまま
+
+いずれも同じ外部効果を再送する理由にしてはならない。
+
+## 7. 試験
+
+最低限、次を決定論的なfake runner / fake DBで固定する。
+
+1. `PUSH`の期待後HEAD一致、期待前HEAD一致、別HEAD。
+2. `READY`のexact HEAD一致とdraft前後状態、別HEAD。
+3. `MERGE`のexact head/base一致とstate前後、別head/base。
+4. `ISSUE_UPDATE`のstate/title前後、一部混在、未対応field。
+5. `UNCERTAIN`を読戻しだけで`CONFIRMED`または`NO_EFFECT`へ確定でき、再送処理が存在しない。
+6. `UNKNOWN`ではDB結果を変更しない。
+7. outbox marker既存時は投稿0回で`PUBLISHED`。
+8. marker無し時は投稿1回、readback成功後だけ`PUBLISHED`。
+9. 投稿失敗、投稿後readback失敗は`PENDING`維持。
+10. pending outboxの取得順序とwork境界を固定する。
+11. Ruff、strict Mypy、全pytest、compileall、diff-checkを通す。
+
+## 8. #67への引継ぎ
+
+#66では読戻しadapter、outbox publisher、DB契約と試験までを実装する。`--v2-once`への合成、明示Work選択、旧入口拒否、実機受入は#67で行う。

--- a/docs/architecture/v2/v2_effect_readback_and_outbox.md
+++ b/docs/architecture/v2/v2_effect_readback_and_outbox.md
@@ -18,6 +18,7 @@ V2でDBへ確定済みの外部効果意図だけを、記録済み対象identit
 
 - `idempotency_key`
 - `work_identity`
+- `packet_generation`
 - `kind`
 - `target_identity`
 - `status`
@@ -25,9 +26,11 @@ V2でDBへ確定済みの外部効果意図だけを、記録済み対象identit
 - `expected_preconditions`
 - `expected_effect`
 
-`expected_preconditions`と`expected_effect`は秘密情報を含まない文字列key/valueだけを保存する。既存の`loop_effect_attempts`へversioned migrationでJSONB列を追加し、旧行は空objectとして読み込めるようにする。
+`packet_generation`は効果意図を発行した`TaskPacket.generation`と同一でなければならない。再開時はDBから復元した最新task packetのgenerationとpending effectの`packet_generation`を照合し、不一致・欠落なら外部提供元を読まず`RECONCILE_REQUIRED(EFFECT_PACKET_MISMATCH)`へ安全側停止する。
 
-新規効果意図では、読戻しに必要な期待値を空のまま発行してはならない。旧行や不完全行を読戻せない場合は`UNKNOWN`とし、推測で`CONFIRMED`または`NO_EFFECT`へ進めない。
+`expected_preconditions`と`expected_effect`は秘密情報を含まない文字列key/valueだけを保存する。既存の`loop_effect_attempts`へversioned migrationで`packet_generation`とJSONB列を追加し、旧行はgeneration欠落・空objectとして読み込めるようにする。旧行や不完全行は自動補完しない。
+
+新規効果意図では、正の`packet_generation`と読戻しに必要な期待値を空のまま発行してはならない。旧行や不完全行を読戻せない場合は`UNKNOWN`またはgeneration不一致として停止し、推測で`CONFIRMED`または`NO_EFFECT`へ進めない。
 
 ## 3. 読戻し状態遷移
 
@@ -40,6 +43,8 @@ V2でDBへ確定済みの外部効果意図だけを、記録済み対象identit
 `UNCERTAIN`は「再送可能」を意味しない。対象限定の読戻しによって結果を証明できた場合に限り`CONFIRMED`または`NO_EFFECT`へ確定できる。`UNKNOWN`のままならDB状態を変更しない。
 
 このためDBの効果結果更新は、`INTENT_RECORDED`と`UNCERTAIN`の双方から`CONFIRMED`または`NO_EFFECT`への一方向確定を許可する。`CONFIRMED`、`NO_EFFECT`から別状態へ戻してはならない。
+
+`NO_EFFECT`は同じpacket・同じidempotency keyの再送許可ではない。新しい効果が必要な場合は、上位の再調整処理で異なるgenerationの新規TaskPacketを明示発行しなければならない。#66のreadback adapterは新規packetを生成しない。
 
 ## 4. GitHub読戻しadapter
 
@@ -93,7 +98,7 @@ Issue報告は通常の作業effectと分離し、5節のoutbox publisherで扱�
 
 ## 5. Issue報告outbox publisher
 
-### 5.1 DB取得
+### 5.1 DB取得と一意性
 
 `WorkStatePort`は指定`work_identity`の`PENDING`報告だけを`recorded_at ASC`で返す。返却型は少なくとも次を持つ。
 
@@ -103,7 +108,9 @@ Issue報告は通常の作業effectと分離し、5節のoutbox publisherで扱�
 - checkpoint identity
 - body
 
-`body`は既存契約どおり4000文字以下とし、秘密値、認証情報、無加工診断、作業パケット全体を含めない。
+outboxの論理一意キーは上位正本どおり`work identity + checkpoint identity + report kind`とし、DB unique indexで強制する。`checkpoint_identity`がNULLの場合も同じWork・report kindで複数行を許可しない。`enqueue`はidentity主キーだけでなくこの論理一意制約の競合でも既存行を維持し、新しい重複行を作らない。
+
+`body`は既存契約どおり4000文字以下とし、秘密値、認証情報、無加工診断、作業パケット全体を含めない。publisher側でも空本文・上限超過を再検証し、不正本文をGitHubへ送らない。
 
 ### 5.2 重複識別子
 
@@ -127,13 +134,17 @@ GitHubへ投稿する本文には、outbox identityそのものではなく、�
 
 publisherは作業effectを呼び出さない。報告再試行が発生してもPUSH、MERGE、READY、ISSUE_UPDATEを再実行しない。
 
+GitHub commentの「marker確認→投稿」は提供元側で原子的にできないため、production Hostでは同一Work leaseを保持した実行者だけがpublisherを呼ぶ。#66のpublisherはleaseを取得せず、#67のHost合成でこの呼出し前提を固定する。
+
 ## 6. 失敗時契約
 
+- pending effectのpacket generation欠落・不一致: `RECONCILE_REQUIRED(EFFECT_PACKET_MISMATCH)`、GitHub読取り0回
 - GitHub読取り失敗: `UNKNOWN`
 - target identity不正: `UNKNOWN`
 - 期待値不足: `UNKNOWN`
 - target HEAD/base不一致: `UNKNOWN`
 - outbox一覧DB読取り失敗: fail-closed
+- outbox本文不正: GitHub投稿0回、`PENDING`維持
 - Issue comment読取り失敗: 報告は`PENDING`のまま
 - Issue comment投稿失敗: 報告は`PENDING`のまま
 - 投稿後readback失敗: 報告は`PENDING`のまま
@@ -149,13 +160,15 @@ publisherは作業effectを呼び出さない。報告再試行が発生して�
 3. `MERGE`のexact head/base一致とstate前後、別head/base。
 4. `ISSUE_UPDATE`のstate/title前後、一部混在、未対応field。
 5. `UNCERTAIN`を読戻しだけで`CONFIRMED`または`NO_EFFECT`へ確定でき、再送処理が存在しない。
-6. `UNKNOWN`ではDB結果を変更しない。
-7. outbox marker既存時は投稿0回で`PUBLISHED`。
-8. marker無し時は投稿1回、readback成功後だけ`PUBLISHED`。
-9. 投稿失敗、投稿後readback失敗は`PENDING`維持。
-10. pending outboxの取得順序とwork境界を固定する。
-11. Ruff、strict Mypy、全pytest、compileall、diff-checkを通す。
+6. pending effectのpacket generationが最新TaskPacketと不一致・欠落ならGitHub読取り0回で停止する。
+7. `UNKNOWN`ではDB結果を変更しない。
+8. outboxの論理一意キーがDB制約で固定され、enqueueが別identityによる重複行を作らない。
+9. outbox marker既存時は投稿0回で`PUBLISHED`。
+10. marker無し時は投稿1回、readback成功後だけ`PUBLISHED`。
+11. 不正本文、投稿失敗、投稿後readback失敗は`PENDING`維持。
+12. pending outboxの取得順序とwork境界を固定する。
+13. Ruff、strict Mypy、全pytest、compileall、diff-checkを通す。
 
 ## 8. #67への引継ぎ
 
-#66では読戻しadapter、outbox publisher、DB契約と試験までを実装する。`--v2-once`への合成、明示Work選択、旧入口拒否、実機受入は#67で行う。
+#66では読戻しadapter、outbox publisher、DB契約と試験までを実装する。`--v2-once`への合成、明示Work選択、旧入口拒否、Work lease保持下でのoutbox publisher呼出し、`CONFIRMED`/`NO_EFFECT`後のTaskPacket・Checkpoint遷移、実機受入は#67で行う。

--- a/src/loop_engineering/migrations/0006_v2_effect_readback_outbox.sql
+++ b/src/loop_engineering/migrations/0006_v2_effect_readback_outbox.sql
@@ -1,0 +1,5 @@
+ALTER TABLE loop_effect_attempts
+    ADD COLUMN IF NOT EXISTS expected_preconditions JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE loop_effect_attempts
+    ADD COLUMN IF NOT EXISTS expected_effect JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/src/loop_engineering/migrations/0006_v2_effect_readback_outbox.sql
+++ b/src/loop_engineering/migrations/0006_v2_effect_readback_outbox.sql
@@ -1,5 +1,15 @@
 ALTER TABLE loop_effect_attempts
+    ADD COLUMN IF NOT EXISTS packet_generation BIGINT;
+
+ALTER TABLE loop_effect_attempts
     ADD COLUMN IF NOT EXISTS expected_preconditions JSONB NOT NULL DEFAULT '{}'::jsonb;
 
 ALTER TABLE loop_effect_attempts
     ADD COLUMN IF NOT EXISTS expected_effect JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE UNIQUE INDEX IF NOT EXISTS loop_issue_report_outbox_logical_identity_key
+    ON loop_issue_report_outbox (
+        work_identity,
+        COALESCE(checkpoint_identity, ''),
+        report_kind
+    );

--- a/src/loop_engineering/v2_effect_readback.py
+++ b/src/loop_engineering/v2_effect_readback.py
@@ -63,7 +63,7 @@ class GitHubEffectReadbackAdapter:
             if attempt.kind == "ISSUE_UPDATE":
                 return self._read_issue_update(attempt.target_identity, before, after)
             return EffectReadbackStatus.UNKNOWN
-        except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError):
+        except (OSError, subprocess.SubprocessError, ValueError):
             return EffectReadbackStatus.UNKNOWN
 
     def _read_push(
@@ -241,7 +241,7 @@ class GitHubIssueReportPublisher:
             readback = self._comments(record)
             if readback is not None and _contains_marker(readback, marker):
                 return IssueReportPublishStatus.PUBLISHED
-        except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError):
+        except (OSError, subprocess.SubprocessError, ValueError):
             return IssueReportPublishStatus.PENDING
         return IssueReportPublishStatus.PENDING
 

--- a/src/loop_engineering/v2_effect_readback.py
+++ b/src/loop_engineering/v2_effect_readback.py
@@ -1,0 +1,351 @@
+"""V2の外部効果読戻しとIssue報告outbox投稿を提供する。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+from urllib.parse import quote
+
+from .v2_resume import EffectReadbackStatus
+from .work_state import EffectAttempt, IssueReportOutboxItem, WorkRecord
+
+
+class GitHubReadbackCommandRunner(Protocol):
+    def run(self, args: Sequence[str]) -> str: ...
+
+
+class IssueReportStatePort(Protocol):
+    def pending_issue_reports(self, work_identity: str) -> tuple[IssueReportOutboxItem, ...]: ...
+
+    def mark_issue_report_published(self, identity: str) -> None: ...
+
+
+class IssueReportPublishStatus(str, Enum):
+    PUBLISHED = "PUBLISHED"
+    PENDING = "PENDING"
+
+
+@dataclass(frozen=True, slots=True)
+class IssueReportPublishResult:
+    attempted: int
+    published: int
+    pending: int
+
+
+@dataclass(slots=True)
+class GitHubEffectReadbackAdapter:
+    """DBに記録済みの対象identityだけをGitHubから読戻す。"""
+
+    runner: GitHubReadbackCommandRunner
+    repository: str
+
+    def readback(self, attempt: EffectAttempt) -> EffectReadbackStatus:
+        if not _valid_repository(self.repository):
+            return EffectReadbackStatus.UNKNOWN
+        if attempt.status not in {"INTENT_RECORDED", "UNCERTAIN"}:
+            return EffectReadbackStatus.UNKNOWN
+        before = _pairs(attempt.expected_preconditions)
+        after = _pairs(attempt.expected_effect)
+        if before is None or after is None or not before or not after or before == after:
+            return EffectReadbackStatus.UNKNOWN
+        try:
+            if attempt.kind == "PUSH":
+                return self._read_push(attempt.target_identity, before, after)
+            if attempt.kind == "READY":
+                return self._read_ready(attempt.target_identity, before, after)
+            if attempt.kind == "MERGE":
+                return self._read_merge(attempt.target_identity, before, after)
+            if attempt.kind == "ISSUE_UPDATE":
+                return self._read_issue_update(attempt.target_identity, before, after)
+            return EffectReadbackStatus.UNKNOWN
+        except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError):
+            return EffectReadbackStatus.UNKNOWN
+
+    def _read_push(
+        self,
+        target_identity: str,
+        before: Mapping[str, str],
+        after: Mapping[str, str],
+    ) -> EffectReadbackStatus:
+        branch = _target_suffix(target_identity, "branch")
+        if branch is None or set(before) != {"head"} or set(after) != {"head"}:
+            return EffectReadbackStatus.UNKNOWN
+        raw = self.runner.run(
+            (
+                "gh",
+                "api",
+                f"repos/{self.repository}/git/ref/heads/{quote(branch, safe='')}",
+            )
+        )
+        payload = _json_mapping(raw)
+        observed = _nested_string(payload, "object", "sha")
+        return _compare_scalar(observed, before["head"], after["head"])
+
+    def _read_ready(
+        self,
+        target_identity: str,
+        before: Mapping[str, str],
+        after: Mapping[str, str],
+    ) -> EffectReadbackStatus:
+        number = _target_number(target_identity, "pr")
+        required_before = {"head", "draft"}
+        if (
+            number is None
+            or set(before) != required_before
+            or set(after) != {"draft"}
+            or before["draft"] not in {"true", "false"}
+            or after["draft"] not in {"true", "false"}
+        ):
+            return EffectReadbackStatus.UNKNOWN
+        payload = self._pr(number)
+        if payload.get("number") != number or payload.get("headRefOid") != before["head"]:
+            return EffectReadbackStatus.UNKNOWN
+        draft = payload.get("isDraft")
+        if not isinstance(draft, bool):
+            return EffectReadbackStatus.UNKNOWN
+        return _compare_scalar(_bool_text(draft), before["draft"], after["draft"])
+
+    def _read_merge(
+        self,
+        target_identity: str,
+        before: Mapping[str, str],
+        after: Mapping[str, str],
+    ) -> EffectReadbackStatus:
+        number = _target_number(target_identity, "pr")
+        required_before = {"head", "base", "state"}
+        if number is None or set(before) != required_before or set(after) != {"state"}:
+            return EffectReadbackStatus.UNKNOWN
+        payload = self._pr(number)
+        if (
+            payload.get("number") != number
+            or payload.get("headRefOid") != before["head"]
+            or payload.get("baseRefName") != before["base"]
+        ):
+            return EffectReadbackStatus.UNKNOWN
+        state = payload.get("state")
+        if not isinstance(state, str):
+            return EffectReadbackStatus.UNKNOWN
+        return _compare_scalar(state, before["state"], after["state"])
+
+    def _read_issue_update(
+        self,
+        target_identity: str,
+        before: Mapping[str, str],
+        after: Mapping[str, str],
+    ) -> EffectReadbackStatus:
+        number = _target_number(target_identity, "issue")
+        supported = {"state", "title"}
+        if (
+            number is None
+            or set(before) != set(after)
+            or not set(before)
+            or not set(before).issubset(supported)
+        ):
+            return EffectReadbackStatus.UNKNOWN
+        raw = self.runner.run(
+            (
+                "gh",
+                "issue",
+                "view",
+                str(number),
+                "--repo",
+                self.repository,
+                "--json",
+                "number,state,title",
+            )
+        )
+        payload = _json_mapping(raw)
+        if payload.get("number") != number:
+            return EffectReadbackStatus.UNKNOWN
+        observed: dict[str, str] = {}
+        for key in before:
+            value = payload.get(key)
+            if not isinstance(value, str):
+                return EffectReadbackStatus.UNKNOWN
+            observed[key] = value
+        if observed == dict(after):
+            return EffectReadbackStatus.CONFIRMED
+        if observed == dict(before):
+            return EffectReadbackStatus.NO_EFFECT
+        return EffectReadbackStatus.UNKNOWN
+
+    def _pr(self, number: int) -> Mapping[str, object]:
+        raw = self.runner.run(
+            (
+                "gh",
+                "pr",
+                "view",
+                str(number),
+                "--repo",
+                self.repository,
+                "--json",
+                "number,state,isDraft,headRefOid,baseRefName,mergeCommit",
+            )
+        )
+        return _json_mapping(raw)
+
+
+@dataclass(slots=True)
+class GitHubIssueReportPublisher:
+    """DB確定済みoutboxをIssue commentへ重複なく投影する。"""
+
+    runner: GitHubReadbackCommandRunner
+    state: IssueReportStatePort
+
+    def publish_pending(self, record: WorkRecord) -> IssueReportPublishResult:
+        if not _valid_repository(record.repository) or record.issue_number < 1:
+            raise ValueError("ISSUE_REPORT_TARGET_INVALID")
+        reports = self.state.pending_issue_reports(record.identity)
+        published = 0
+        pending = 0
+        for report in reports:
+            if report.work_identity != record.identity:
+                raise ValueError("ISSUE_REPORT_WORK_MISMATCH")
+            status = self._publish_one(record, report)
+            if status is IssueReportPublishStatus.PUBLISHED:
+                self.state.mark_issue_report_published(report.identity)
+                published += 1
+            else:
+                pending += 1
+        return IssueReportPublishResult(len(reports), published, pending)
+
+    def _publish_one(
+        self,
+        record: WorkRecord,
+        report: IssueReportOutboxItem,
+    ) -> IssueReportPublishStatus:
+        marker = _report_marker(report.identity)
+        try:
+            comments = self._comments(record)
+            if comments is None:
+                return IssueReportPublishStatus.PENDING
+            if _contains_marker(comments, marker):
+                return IssueReportPublishStatus.PUBLISHED
+            body = f"{marker}\n{report.body}"
+            self.runner.run(
+                (
+                    "gh",
+                    "api",
+                    f"repos/{record.repository}/issues/{record.issue_number}/comments",
+                    "--method",
+                    "POST",
+                    "--raw-field",
+                    f"body={body}",
+                )
+            )
+            readback = self._comments(record)
+            if readback is not None and _contains_marker(readback, marker):
+                return IssueReportPublishStatus.PUBLISHED
+        except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError):
+            return IssueReportPublishStatus.PENDING
+        return IssueReportPublishStatus.PENDING
+
+    def _comments(self, record: WorkRecord) -> tuple[Mapping[str, object], ...] | None:
+        raw = self.runner.run(
+            (
+                "gh",
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{record.repository}/issues/{record.issue_number}/comments?per_page=100",
+            )
+        )
+        payload = json.loads(raw)
+        return _comment_pages(payload)
+
+
+def _valid_repository(repository: str) -> bool:
+    if repository.count("/") != 1 or "\x00" in repository or len(repository) > 200:
+        return False
+    owner, name = repository.split("/", maxsplit=1)
+    return bool(owner and name and owner.strip() == owner and name.strip() == name)
+
+
+def _pairs(values: tuple[tuple[str, str], ...]) -> dict[str, str] | None:
+    result: dict[str, str] = {}
+    for key, value in values:
+        if not key or key in result or "\x00" in key or "\x00" in value:
+            return None
+        result[key] = value
+    return result
+
+
+def _target_suffix(identity: str, prefix: str) -> str | None:
+    marker = f"{prefix}:"
+    if not identity.startswith(marker):
+        return None
+    value = identity[len(marker) :]
+    if not value or "\x00" in value or len(value) > 255:
+        return None
+    return value
+
+
+def _target_number(identity: str, prefix: str) -> int | None:
+    value = _target_suffix(identity, prefix)
+    if value is None or not value.isdigit():
+        return None
+    number = int(value)
+    return number if number > 0 else None
+
+
+def _json_mapping(raw: str) -> Mapping[str, object]:
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("GITHUB_READBACK_INVALID")
+    return payload
+
+
+def _nested_string(payload: Mapping[str, object], key: str, nested_key: str) -> str | None:
+    nested = payload.get(key)
+    if not isinstance(nested, dict):
+        return None
+    value = nested.get(nested_key)
+    return value if isinstance(value, str) else None
+
+
+def _compare_scalar(observed: str | None, before: str, after: str) -> EffectReadbackStatus:
+    if observed == after:
+        return EffectReadbackStatus.CONFIRMED
+    if observed == before:
+        return EffectReadbackStatus.NO_EFFECT
+    return EffectReadbackStatus.UNKNOWN
+
+
+def _bool_text(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _report_marker(identity: str) -> str:
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    return f"<!-- loop-engineering:v2-report:{digest} -->"
+
+
+def _comment_pages(payload: object) -> tuple[Mapping[str, object], ...] | None:
+    if not isinstance(payload, list):
+        return None
+    comments: list[Mapping[str, object]] = []
+    for page in payload:
+        if isinstance(page, list):
+            for item in page:
+                if not isinstance(item, dict):
+                    return None
+                comments.append(item)
+            continue
+        if isinstance(page, dict):
+            comments.append(page)
+            continue
+        return None
+    return tuple(comments)
+
+
+def _contains_marker(comments: tuple[Mapping[str, object], ...], marker: str) -> bool:
+    for comment in comments:
+        body = comment.get("body")
+        if isinstance(body, str) and marker in body:
+            return True
+    return False

--- a/src/loop_engineering/v2_effect_readback.py
+++ b/src/loop_engineering/v2_effect_readback.py
@@ -219,6 +219,8 @@ class GitHubIssueReportPublisher:
         record: WorkRecord,
         report: IssueReportOutboxItem,
     ) -> IssueReportPublishStatus:
+        if not report.body or len(report.body) > 4000:
+            return IssueReportPublishStatus.PENDING
         marker = _report_marker(report.identity)
         try:
             comments = self._comments(record)

--- a/src/loop_engineering/v2_resume.py
+++ b/src/loop_engineering/v2_resume.py
@@ -81,6 +81,15 @@ class V2ResumeCoordinator:
         recovered = self._recovery.recover(work_identity)
         if recovered is None or not _complete_recovery(recovered):
             return V2ResumeResult(V2ResumeStatus.BLOCKED, "WORK_RECOVERY_MISSING", recovered)
+        packet = recovered.task_packet
+        if packet is None or any(
+            attempt.packet_generation != packet.generation for attempt in recovered.pending_effects
+        ):
+            return V2ResumeResult(
+                V2ResumeStatus.RECONCILE_REQUIRED,
+                "EFFECT_PACKET_MISMATCH",
+                recovered,
+            )
 
         definition = self._definitions.synchronize(recovered.record)
         if definition.status is WorkDefinitionStatus.DEPENDENCY_PENDING:

--- a/src/loop_engineering/work_state.py
+++ b/src/loop_engineering/work_state.py
@@ -64,6 +64,7 @@ class EffectAttempt:
     target_identity: str
     status: str
     request_identity: str | None = None
+    packet_generation: int | None = None
     expected_preconditions: tuple[tuple[str, str], ...] = ()
     expected_effect: tuple[tuple[str, str], ...] = ()
 
@@ -183,15 +184,21 @@ class PostgreSQLWorkStateStore:
         return _work_checkpoint(rows[0])
 
     def record_effect_intent(self, attempt: EffectAttempt) -> bool:
-        if attempt.status != "INTENT_RECORDED":
+        if (
+            attempt.status != "INTENT_RECORDED"
+            or attempt.packet_generation is None
+            or attempt.packet_generation < 1
+            or not attempt.expected_preconditions
+            or not attempt.expected_effect
+        ):
             raise WorkStateUnavailable("EFFECT_INTENT_INVALID")
         self._execute(
             "INSERT INTO loop_effect_attempts "
-            "(idempotency_key, work_identity, kind, target_identity, status, "
+            "(idempotency_key, work_identity, packet_generation, kind, target_identity, status, "
             "request_identity, expected_preconditions, expected_effect) VALUES ("
             f"{_literal(attempt.idempotency_key)}, {_literal(attempt.work_identity)}, "
-            f"{_literal(attempt.kind)}, {_literal(attempt.target_identity)}, "
-            "'INTENT_RECORDED', "
+            f"{attempt.packet_generation}, {_literal(attempt.kind)}, "
+            f"{_literal(attempt.target_identity)}, 'INTENT_RECORDED', "
             f"{_nullable_literal(attempt.request_identity)}, "
             f"{_pairs_json_literal(attempt.expected_preconditions)}, "
             f"{_pairs_json_literal(attempt.expected_effect)}) "
@@ -233,6 +240,9 @@ class PostgreSQLWorkStateStore:
             or checkpoint.task_packet_identity != packet.identity
             or packet.status != "STARTED"
             or effect.status != "INTENT_RECORDED"
+            or effect.packet_generation != packet.generation
+            or not effect.expected_preconditions
+            or not effect.expected_effect
             or checkpoint.checkpoint_kind != "EFFECT_PENDING"
             or packet.generation != lease.packet_generation
             or lease.packet_generation < 1
@@ -277,7 +287,7 @@ class PostgreSQLWorkStateStore:
             "(identity, work_identity, status, report_kind, checkpoint_identity, body) VALUES ("
             f"{_literal(identity)}, {_literal(work_identity)}, 'PENDING', {_literal(report_kind)}, "
             f"{_nullable_literal(checkpoint_identity)}, {_literal(body)}) "
-            "ON CONFLICT (identity) DO NOTHING"
+            "ON CONFLICT DO NOTHING"
         )
 
     def pending_issue_reports(self, work_identity: str) -> tuple[IssueReportOutboxItem, ...]:
@@ -349,8 +359,8 @@ class PostgreSQLWorkStateStore:
 
     def _pending_effects(self, work_identity: str) -> tuple[EffectAttempt, ...]:
         rows = self._query(
-            "SELECT idempotency_key, work_identity, kind, target_identity, status, "
-            "request_identity, expected_preconditions, expected_effect "
+            "SELECT idempotency_key, work_identity, packet_generation, kind, target_identity, "
+            "status, request_identity, expected_preconditions, expected_effect "
             "FROM loop_effect_attempts "
             f"WHERE work_identity = {_literal(work_identity)} "
             "AND status IN ('INTENT_RECORDED', 'UNCERTAIN') ORDER BY recorded_at ASC"
@@ -363,6 +373,7 @@ class PostgreSQLWorkStateStore:
                 target_identity=_required_string(row, "target_identity"),
                 status=_required_string(row, "status"),
                 request_identity=_optional_string(row, "request_identity"),
+                packet_generation=_optional_positive_int(row, "packet_generation"),
                 expected_preconditions=_string_pairs(row, "expected_preconditions"),
                 expected_effect=_string_pairs(row, "expected_effect"),
             )
@@ -424,6 +435,15 @@ def _required_string(row: dict[str, object], name: str) -> str:
 def _optional_string(row: dict[str, object], name: str) -> str | None:
     value = row.get(name)
     return value if isinstance(value, str) else None
+
+
+def _optional_positive_int(row: dict[str, object], name: str) -> int | None:
+    value = row.get(name)
+    if value is None:
+        return None
+    if not isinstance(value, int) or value < 1:
+        raise WorkStateUnavailable("WORK_STATE_ROW_INVALID")
+    return value
 
 
 def _string_tuple(row: dict[str, object], name: str) -> tuple[str, ...]:
@@ -491,6 +511,9 @@ def _issue_packet_transaction_sql(
         f"WHERE work_identity = {_literal(record.identity)} "
         "AND status IN ('INTENT_RECORDED', 'UNCERTAIN')"
     )
+    packet_generation = effect.packet_generation
+    if packet_generation is None:
+        raise WorkStateUnavailable("EFFECT_INTENT_INVALID")
     return (
         "WITH eligible AS ("
         "SELECT identity FROM loop_work_records "
@@ -527,10 +550,11 @@ def _issue_packet_transaction_sql(
         "RETURNING identity"
         "), recorded_effect AS ("
         "INSERT INTO loop_effect_attempts "
-        "(idempotency_key, work_identity, kind, target_identity, status, request_identity, "
-        "expected_preconditions, expected_effect) SELECT "
+        "(idempotency_key, work_identity, packet_generation, kind, target_identity, status, "
+        "request_identity, expected_preconditions, expected_effect) SELECT "
         f"{_literal(effect.idempotency_key)}, {_literal(effect.work_identity)}, "
-        f"{_literal(effect.kind)}, {_literal(effect.target_identity)}, 'INTENT_RECORDED', "
+        f"{packet_generation}, {_literal(effect.kind)}, {_literal(effect.target_identity)}, "
+        "'INTENT_RECORDED', "
         f"{_nullable_literal(effect.request_identity)}, "
         f"{_pairs_json_literal(effect.expected_preconditions)}, "
         f"{_pairs_json_literal(effect.expected_effect)} FROM recorded_packet "

--- a/src/loop_engineering/work_state.py
+++ b/src/loop_engineering/work_state.py
@@ -64,6 +64,8 @@ class EffectAttempt:
     target_identity: str
     status: str
     request_identity: str | None = None
+    expected_preconditions: tuple[tuple[str, str], ...] = ()
+    expected_effect: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,6 +82,15 @@ class RecoveredWork:
     task_packet: WorkTaskPacket | None
     checkpoint: WorkCheckpoint | None
     pending_effects: tuple[EffectAttempt, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class IssueReportOutboxItem:
+    identity: str
+    work_identity: str
+    report_kind: str
+    checkpoint_identity: str | None
+    body: str
 
 
 class PostgreSQLWorkStateStore:
@@ -177,11 +188,13 @@ class PostgreSQLWorkStateStore:
         self._execute(
             "INSERT INTO loop_effect_attempts "
             "(idempotency_key, work_identity, kind, target_identity, status, "
-            "request_identity) VALUES ("
+            "request_identity, expected_preconditions, expected_effect) VALUES ("
             f"{_literal(attempt.idempotency_key)}, {_literal(attempt.work_identity)}, "
             f"{_literal(attempt.kind)}, {_literal(attempt.target_identity)}, "
             "'INTENT_RECORDED', "
-            f"{_nullable_literal(attempt.request_identity)}) "
+            f"{_nullable_literal(attempt.request_identity)}, "
+            f"{_pairs_json_literal(attempt.expected_preconditions)}, "
+            f"{_pairs_json_literal(attempt.expected_effect)}) "
             "ON CONFLICT (idempotency_key) DO NOTHING"
         )
         rows = self._query(
@@ -199,7 +212,7 @@ class PostgreSQLWorkStateStore:
             "confirmed_at = CASE WHEN "
             f"{_literal(status)} = 'CONFIRMED' THEN now() ELSE confirmed_at END "
             f"WHERE idempotency_key = {_literal(idempotency_key)} "
-            "AND status = 'INTENT_RECORDED'"
+            "AND status IN ('INTENT_RECORDED', 'UNCERTAIN')"
         )
 
     def issue_packet_transaction(
@@ -267,6 +280,29 @@ class PostgreSQLWorkStateStore:
             "ON CONFLICT (identity) DO NOTHING"
         )
 
+    def pending_issue_reports(self, work_identity: str) -> tuple[IssueReportOutboxItem, ...]:
+        rows = self._query(
+            "SELECT identity, work_identity, report_kind, checkpoint_identity, body "
+            "FROM loop_issue_report_outbox "
+            f"WHERE work_identity = {_literal(work_identity)} AND status = 'PENDING' "
+            "ORDER BY recorded_at ASC, identity ASC"
+        )
+        reports: list[IssueReportOutboxItem] = []
+        for row in rows:
+            body = _required_string(row, "body")
+            if not body or len(body) > 4000:
+                raise WorkStateUnavailable("WORK_STATE_ROW_INVALID")
+            reports.append(
+                IssueReportOutboxItem(
+                    identity=_required_string(row, "identity"),
+                    work_identity=_required_string(row, "work_identity"),
+                    report_kind=_required_string(row, "report_kind"),
+                    checkpoint_identity=_optional_string(row, "checkpoint_identity"),
+                    body=body,
+                )
+            )
+        return tuple(reports)
+
     def mark_issue_report_published(self, identity: str) -> None:
         self._execute(
             "UPDATE loop_issue_report_outbox SET status = 'PUBLISHED', published_at = now() "
@@ -314,7 +350,7 @@ class PostgreSQLWorkStateStore:
     def _pending_effects(self, work_identity: str) -> tuple[EffectAttempt, ...]:
         rows = self._query(
             "SELECT idempotency_key, work_identity, kind, target_identity, status, "
-            "request_identity "
+            "request_identity, expected_preconditions, expected_effect "
             "FROM loop_effect_attempts "
             f"WHERE work_identity = {_literal(work_identity)} "
             "AND status IN ('INTENT_RECORDED', 'UNCERTAIN') ORDER BY recorded_at ASC"
@@ -327,6 +363,8 @@ class PostgreSQLWorkStateStore:
                 target_identity=_required_string(row, "target_identity"),
                 status=_required_string(row, "status"),
                 request_identity=_optional_string(row, "request_identity"),
+                expected_preconditions=_string_pairs(row, "expected_preconditions"),
+                expected_effect=_string_pairs(row, "expected_effect"),
             )
             for row in rows
         )
@@ -358,6 +396,24 @@ def _json_literal(values: tuple[str, ...]) -> str:
     return _literal(json.dumps(values, ensure_ascii=False, separators=(",", ":"))) + "::jsonb"
 
 
+def _pairs_json_literal(values: tuple[tuple[str, str], ...]) -> str:
+    payload: dict[str, str] = {}
+    for key, value in values:
+        if (
+            not key
+            or key in payload
+            or "\x00" in key
+            or "\x00" in value
+            or len(key) > 128
+            or len(value) > 1024
+        ):
+            raise WorkStateUnavailable("WORK_STATE_VALUE_INVALID")
+        payload[key] = value
+    return _literal(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    ) + "::jsonb"
+
+
 def _required_string(row: dict[str, object], name: str) -> str:
     value = _optional_string(row, name)
     if value is None:
@@ -375,6 +431,20 @@ def _string_tuple(row: dict[str, object], name: str) -> tuple[str, ...]:
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         raise WorkStateUnavailable("WORK_STATE_ROW_INVALID")
     return tuple(value)
+
+
+def _string_pairs(row: dict[str, object], name: str) -> tuple[tuple[str, str], ...]:
+    value = row.get(name)
+    if value is None:
+        return ()
+    if not isinstance(value, dict):
+        raise WorkStateUnavailable("WORK_STATE_ROW_INVALID")
+    pairs: list[tuple[str, str]] = []
+    for key, item in value.items():
+        if not isinstance(key, str) or not isinstance(item, str):
+            raise WorkStateUnavailable("WORK_STATE_ROW_INVALID")
+        pairs.append((key, item))
+    return tuple(sorted(pairs))
 
 
 def _work_record(row: dict[str, object]) -> WorkRecord:
@@ -457,10 +527,13 @@ def _issue_packet_transaction_sql(
         "RETURNING identity"
         "), recorded_effect AS ("
         "INSERT INTO loop_effect_attempts "
-        "(idempotency_key, work_identity, kind, target_identity, status, request_identity) SELECT "
+        "(idempotency_key, work_identity, kind, target_identity, status, request_identity, "
+        "expected_preconditions, expected_effect) SELECT "
         f"{_literal(effect.idempotency_key)}, {_literal(effect.work_identity)}, "
         f"{_literal(effect.kind)}, {_literal(effect.target_identity)}, 'INTENT_RECORDED', "
-        f"{_nullable_literal(effect.request_identity)} FROM recorded_packet "
+        f"{_nullable_literal(effect.request_identity)}, "
+        f"{_pairs_json_literal(effect.expected_preconditions)}, "
+        f"{_pairs_json_literal(effect.expected_effect)} FROM recorded_packet "
         "RETURNING idempotency_key"
         "), recorded_checkpoint AS ("
         "INSERT INTO loop_work_checkpoints "

--- a/tests/loop_engineering/test_v2_effect_readback.py
+++ b/tests/loop_engineering/test_v2_effect_readback.py
@@ -66,6 +66,7 @@ def attempt(
         kind=kind,
         target_identity=target,
         status=status,
+        packet_generation=1,
         expected_preconditions=before,
         expected_effect=after,
     )
@@ -189,6 +190,7 @@ def test_missing_expectations_report_kind_and_command_failure_fail_closed() -> N
         "PUSH",
         "branch:feature/v2",
         "UNCERTAIN",
+        packet_generation=1,
     )
     runner = Runner([])
     assert GitHubEffectReadbackAdapter(runner, record().repository).readback(
@@ -251,6 +253,26 @@ def test_new_outbox_report_is_marked_only_after_post_readback() -> None:
     assert len(runner.calls) == 3
     assert "--method" in runner.calls[1]
     assert marker in " ".join(runner.calls[1])
+
+
+def test_invalid_outbox_body_never_reads_or_posts_github() -> None:
+    invalid = IssueReportOutboxItem(
+        "report:66:invalid",
+        record().identity,
+        "PROGRESS",
+        "checkpoint:66:invalid",
+        "",
+    )
+    runner = Runner([])
+    state = ReportState((invalid,))
+
+    result = GitHubIssueReportPublisher(runner, state).publish_pending(record())
+
+    assert result.attempted == 1
+    assert result.published == 0
+    assert result.pending == 1
+    assert state.published == []
+    assert runner.calls == []
 
 
 def test_post_or_readback_failure_leaves_outbox_pending() -> None:

--- a/tests/loop_engineering/test_v2_effect_readback.py
+++ b/tests/loop_engineering/test_v2_effect_readback.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from loop_engineering.v2_effect_readback import (
+    GitHubEffectReadbackAdapter,
+    GitHubIssueReportPublisher,
+)
+from loop_engineering.v2_resume import EffectReadbackStatus
+from loop_engineering.work_state import EffectAttempt, IssueReportOutboxItem, WorkRecord
+
+
+@dataclass
+class Runner:
+    outputs: list[str]
+    calls: list[Sequence[str]] = field(default_factory=list)
+    fail_at: int | None = None
+
+    def run(self, args: Sequence[str]) -> str:
+        self.calls.append(args)
+        if self.fail_at == len(self.calls):
+            raise subprocess.CalledProcessError(1, tuple(args))
+        if not self.outputs:
+            raise AssertionError("想定していないGitHub呼出しです")
+        return self.outputs.pop(0)
+
+
+@dataclass
+class ReportState:
+    reports: tuple[IssueReportOutboxItem, ...]
+    published: list[str] = field(default_factory=list)
+
+    def pending_issue_reports(self, work_identity: str) -> tuple[IssueReportOutboxItem, ...]:
+        assert work_identity == record().identity
+        return self.reports
+
+    def mark_issue_report_published(self, identity: str) -> None:
+        self.published.append(identity)
+
+
+def record() -> WorkRecord:
+    return WorkRecord(
+        identity="work:ktan514/loop-engineering:66",
+        repository="ktan514/loop-engineering",
+        issue_number=66,
+        issue_revision="definition:66",
+        lifecycle="RUNNING",
+    )
+
+
+def attempt(
+    kind: str,
+    target: str,
+    before: tuple[tuple[str, str], ...],
+    after: tuple[tuple[str, str], ...],
+    *,
+    status: str = "INTENT_RECORDED",
+) -> EffectAttempt:
+    return EffectAttempt(
+        idempotency_key=f"effect:{kind.lower()}:66",
+        work_identity=record().identity,
+        kind=kind,
+        target_identity=target,
+        status=status,
+        expected_preconditions=before,
+        expected_effect=after,
+    )
+
+
+def test_push_readback_distinguishes_confirmed_no_effect_and_unknown() -> None:
+    effect = attempt(
+        "PUSH",
+        "branch:feature/v2",
+        (("head", "before"),),
+        (("head", "after"),),
+    )
+
+    confirmed = GitHubEffectReadbackAdapter(
+        Runner([json.dumps({"object": {"sha": "after"}})]), record().repository
+    ).readback(effect)
+    no_effect = GitHubEffectReadbackAdapter(
+        Runner([json.dumps({"object": {"sha": "before"}})]), record().repository
+    ).readback(effect)
+    unknown = GitHubEffectReadbackAdapter(
+        Runner([json.dumps({"object": {"sha": "other"}})]), record().repository
+    ).readback(effect)
+
+    assert confirmed is EffectReadbackStatus.CONFIRMED
+    assert no_effect is EffectReadbackStatus.NO_EFFECT
+    assert unknown is EffectReadbackStatus.UNKNOWN
+
+
+def test_ready_readback_requires_exact_head_before_draft_comparison() -> None:
+    effect = attempt(
+        "READY",
+        "pr:69",
+        (("head", "abc"), ("draft", "true")),
+        (("draft", "false"),),
+        status="UNCERTAIN",
+    )
+    ready_payload = {
+        "number": 69,
+        "state": "OPEN",
+        "isDraft": False,
+        "headRefOid": "abc",
+        "baseRefName": "main",
+        "mergeCommit": None,
+    }
+    moved_payload = dict(ready_payload, headRefOid="different")
+
+    confirmed = GitHubEffectReadbackAdapter(
+        Runner([json.dumps(ready_payload)]), record().repository
+    ).readback(effect)
+    moved = GitHubEffectReadbackAdapter(
+        Runner([json.dumps(moved_payload)]), record().repository
+    ).readback(effect)
+
+    assert confirmed is EffectReadbackStatus.CONFIRMED
+    assert moved is EffectReadbackStatus.UNKNOWN
+
+
+def test_merge_readback_requires_exact_pr_head_and_base() -> None:
+    effect = attempt(
+        "MERGE",
+        "pr:69",
+        (("head", "abc"), ("base", "main"), ("state", "OPEN")),
+        (("state", "MERGED"),),
+    )
+    merged = {
+        "number": 69,
+        "state": "MERGED",
+        "isDraft": False,
+        "headRefOid": "abc",
+        "baseRefName": "main",
+        "mergeCommit": {"oid": "merge"},
+    }
+    still_open = dict(merged, state="OPEN", mergeCommit=None)
+    wrong_base = dict(merged, baseRefName="develop")
+
+    assert GitHubEffectReadbackAdapter(
+        Runner([json.dumps(merged)]), record().repository
+    ).readback(effect) is EffectReadbackStatus.CONFIRMED
+    assert GitHubEffectReadbackAdapter(
+        Runner([json.dumps(still_open)]), record().repository
+    ).readback(effect) is EffectReadbackStatus.NO_EFFECT
+    assert GitHubEffectReadbackAdapter(
+        Runner([json.dumps(wrong_base)]), record().repository
+    ).readback(effect) is EffectReadbackStatus.UNKNOWN
+
+
+def test_issue_update_readback_uses_only_supported_typed_fields() -> None:
+    effect = attempt(
+        "ISSUE_UPDATE",
+        "issue:66",
+        (("state", "OPEN"), ("title", "旧題")),
+        (("state", "CLOSED"), ("title", "新題")),
+    )
+    after = {"number": 66, "state": "CLOSED", "title": "新題"}
+    mixed = {"number": 66, "state": "CLOSED", "title": "旧題"}
+
+    assert GitHubEffectReadbackAdapter(
+        Runner([json.dumps(after)]), record().repository
+    ).readback(effect) is EffectReadbackStatus.CONFIRMED
+    assert GitHubEffectReadbackAdapter(
+        Runner([json.dumps(mixed)]), record().repository
+    ).readback(effect) is EffectReadbackStatus.UNKNOWN
+
+    unsupported = attempt(
+        "ISSUE_UPDATE",
+        "issue:66",
+        (("labels", "old"),),
+        (("labels", "new"),),
+    )
+    runner = Runner([])
+    assert GitHubEffectReadbackAdapter(runner, record().repository).readback(
+        unsupported
+    ) is EffectReadbackStatus.UNKNOWN
+    assert runner.calls == []
+
+
+def test_missing_expectations_report_kind_and_command_failure_fail_closed() -> None:
+    missing = EffectAttempt(
+        "effect:missing",
+        record().identity,
+        "PUSH",
+        "branch:feature/v2",
+        "UNCERTAIN",
+    )
+    runner = Runner([])
+    assert GitHubEffectReadbackAdapter(runner, record().repository).readback(
+        missing
+    ) is EffectReadbackStatus.UNKNOWN
+    assert runner.calls == []
+
+    report = attempt("REPORT", "issue:66", (("marker", "before"),), (("marker", "after"),))
+    assert GitHubEffectReadbackAdapter(runner, record().repository).readback(
+        report
+    ) is EffectReadbackStatus.UNKNOWN
+    assert runner.calls == []
+
+    failing = Runner(["unused"], fail_at=1)
+    effect = attempt(
+        "PUSH", "branch:feature/v2", (("head", "before"),), (("head", "after"),)
+    )
+    assert GitHubEffectReadbackAdapter(failing, record().repository).readback(
+        effect
+    ) is EffectReadbackStatus.UNKNOWN
+
+
+def test_existing_outbox_marker_suppresses_duplicate_post() -> None:
+    report = IssueReportOutboxItem(
+        "report:66:1", record().identity, "PROGRESS", "checkpoint:66:1", "進捗報告"
+    )
+    digest = hashlib.sha256(report.identity.encode()).hexdigest()
+    marker = f"<!-- loop-engineering:v2-report:{digest} -->"
+    runner = Runner([json.dumps([[{"body": f"{marker}\n既存報告"}]])])
+    state = ReportState((report,))
+
+    result = GitHubIssueReportPublisher(runner, state).publish_pending(record())
+
+    assert result.attempted == 1
+    assert result.published == 1
+    assert result.pending == 0
+    assert state.published == [report.identity]
+    assert len(runner.calls) == 1
+
+
+def test_new_outbox_report_is_marked_only_after_post_readback() -> None:
+    report = IssueReportOutboxItem(
+        "report:66:2", record().identity, "PROGRESS", "checkpoint:66:2", "DB確定済みの報告"
+    )
+    digest = hashlib.sha256(report.identity.encode()).hexdigest()
+    marker = f"<!-- loop-engineering:v2-report:{digest} -->"
+    runner = Runner(
+        [
+            json.dumps([[]]),
+            json.dumps({"id": 100}),
+            json.dumps([[{"body": f"{marker}\nDB確定済みの報告"}]]),
+        ]
+    )
+    state = ReportState((report,))
+
+    result = GitHubIssueReportPublisher(runner, state).publish_pending(record())
+
+    assert result == type(result)(attempted=1, published=1, pending=0)
+    assert state.published == [report.identity]
+    assert len(runner.calls) == 3
+    assert "--method" in runner.calls[1]
+    assert marker in " ".join(runner.calls[1])
+
+
+def test_post_or_readback_failure_leaves_outbox_pending() -> None:
+    report = IssueReportOutboxItem(
+        "report:66:3", record().identity, "PROGRESS", None, "再試行可能な報告"
+    )
+    state = ReportState((report,))
+    failed_post = Runner([json.dumps([[]])], fail_at=2)
+
+    result = GitHubIssueReportPublisher(failed_post, state).publish_pending(record())
+
+    assert result.published == 0
+    assert result.pending == 1
+    assert state.published == []
+
+    state = ReportState((report,))
+    failed_readback = Runner([json.dumps([[]]), json.dumps({"id": 100})], fail_at=3)
+    result = GitHubIssueReportPublisher(failed_readback, state).publish_pending(record())
+    assert result.pending == 1
+    assert state.published == []

--- a/tests/loop_engineering/test_v2_resume.py
+++ b/tests/loop_engineering/test_v2_resume.py
@@ -159,13 +159,58 @@ def test_missing_or_inconsistent_recovery_stays_blocked_before_definition_sync()
     assert inconsistent.detail == "WORK_RECOVERY_MISSING"
 
 
+def test_effect_packet_generation_mismatch_stops_before_any_provider_read() -> None:
+    mismatch = EffectAttempt(
+        "effect:62:old",
+        record().identity,
+        "PUSH",
+        "branch:feature/v2",
+        "UNCERTAIN",
+        packet_generation=2,
+        expected_preconditions=(("head", "before"),),
+        expected_effect=(("head", "after"),),
+    )
+    definitions = Definitions(record())
+    effects = Effects(EffectReadbackStatus.CONFIRMED)
+    recovery = Recovery(recovered(pending=(mismatch,)))
+
+    result = V2ResumeCoordinator(recovery, definitions, effects).resume(record().identity)
+
+    assert result.status is V2ResumeStatus.RECONCILE_REQUIRED
+    assert result.detail == "EFFECT_PACKET_MISMATCH"
+    assert definitions.calls == 0
+    assert effects.calls == []
+    assert recovery.synchronized == []
+    assert recovery.outcomes == []
+
+    missing_generation = EffectAttempt(
+        "effect:62:legacy",
+        record().identity,
+        "PUSH",
+        "branch:feature/v2",
+        "UNCERTAIN",
+        expected_preconditions=(("head", "before"),),
+        expected_effect=(("head", "after"),),
+    )
+    result = V2ResumeCoordinator(
+        Recovery(recovered(pending=(missing_generation,))),
+        Definitions(record()),
+        Effects(EffectReadbackStatus.CONFIRMED),
+    ).resume(record().identity)
+    assert result.status is V2ResumeStatus.RECONCILE_REQUIRED
+    assert result.detail == "EFFECT_PACKET_MISMATCH"
+
+
 def test_unknown_effect_stops_before_any_new_execution() -> None:
     attempt = EffectAttempt(
         "effect:62:1",
         record().identity,
         "MERGE",
-        "pr:63|head:abc",
+        "pr:63",
         "UNCERTAIN",
+        packet_generation=1,
+        expected_preconditions=(("head", "abc"), ("base", "main"), ("state", "OPEN")),
+        expected_effect=(("state", "MERGED"),),
     )
     recovery = Recovery(recovered(pending=(attempt,)))
     effects = Effects(EffectReadbackStatus.UNKNOWN)
@@ -185,6 +230,9 @@ def test_confirmed_and_no_effect_are_recorded_before_ready() -> None:
         "PUSH",
         "branch:feature/v2",
         "INTENT_RECORDED",
+        packet_generation=1,
+        expected_preconditions=(("head", "before"),),
+        expected_effect=(("head", "after"),),
     )
     recovery = Recovery(recovered(pending=(attempt,)))
 

--- a/tests/loop_engineering/test_work_state.py
+++ b/tests/loop_engineering/test_work_state.py
@@ -148,6 +148,8 @@ def test_task_packet_and_pending_effects_are_recovered_from_db() -> None:
                     "target_identity": "branch:feature/v2",
                     "status": "UNCERTAIN",
                     "request_identity": None,
+                    "expected_preconditions": {"head": "before"},
+                    "expected_effect": {"head": "after"},
                 }
             ],
         ]
@@ -163,6 +165,8 @@ def test_task_packet_and_pending_effects_are_recovered_from_db() -> None:
     assert recovered.checkpoint is not None
     assert recovered.checkpoint.resumable_state == "IMPLEMENT_PENDING"
     assert recovered.pending_effects[0].status == "UNCERTAIN"
+    assert recovered.pending_effects[0].expected_preconditions == (("head", "before"),)
+    assert recovered.pending_effects[0].expected_effect == (("head", "after"),)
 
 
 def test_task_packet_updates_recovery_pointer() -> None:
@@ -182,24 +186,30 @@ def test_task_packet_updates_recovery_pointer() -> None:
     assert "latest_task_packet_identity = 'packet:62:1'" in "\n".join(database.statements)
 
 
-def test_effect_intent_is_idempotent_and_outcome_never_reenables_resend() -> None:
+def test_effect_intent_is_idempotent_and_readback_can_settle_uncertain() -> None:
     database = Database(rows=[{"status": "INTENT_RECORDED"}])
     store = PostgreSQLWorkStateStore(database)
     attempt = EffectAttempt(
         idempotency_key="merge:pr:63:head:abc",
         work_identity=record().identity,
         kind="MERGE",
-        target_identity="pr:63|head:abc",
+        target_identity="pr:63",
         status="INTENT_RECORDED",
+        expected_preconditions=(("head", "abc"), ("base", "main"), ("state", "OPEN")),
+        expected_effect=(("state", "MERGED"),),
     )
 
     assert store.record_effect_intent(attempt)
     store.record_effect_outcome(attempt.idempotency_key, "UNCERTAIN")
+    store.record_effect_outcome(attempt.idempotency_key, "CONFIRMED")
 
     written = "\n".join(database.statements)
     assert "ON CONFLICT (idempotency_key) DO NOTHING" in written
-    assert "AND status = 'INTENT_RECORDED'" in written
+    assert "expected_preconditions" in written
+    assert "expected_effect" in written
+    assert "AND status IN ('INTENT_RECORDED', 'UNCERTAIN')" in written
     assert "UNCERTAIN" in written
+    assert "CONFIRMED" in written
 
 
 def test_issue_report_is_outbox_and_requires_bounded_body() -> None:
@@ -229,6 +239,32 @@ def test_issue_report_is_outbox_and_requires_bounded_body() -> None:
         )
 
 
+def test_pending_issue_reports_are_loaded_in_recorded_order_for_one_work() -> None:
+    database = Database(
+        query_results=[
+            [
+                {
+                    "identity": "report:62:1",
+                    "work_identity": record().identity,
+                    "report_kind": "PROGRESS",
+                    "checkpoint_identity": "checkpoint:62:1",
+                    "body": "DB確定済みの進捗報告",
+                }
+            ]
+        ]
+    )
+
+    reports = PostgreSQLWorkStateStore(database).pending_issue_reports(record().identity)
+
+    assert len(reports) == 1
+    assert reports[0].identity == "report:62:1"
+    assert reports[0].body == "DB確定済みの進捗報告"
+    query = database.statements[0]
+    assert "status = 'PENDING'" in query
+    assert f"work_identity = '{record().identity}'" in query
+    assert "ORDER BY recorded_at ASC, identity ASC" in query
+
+
 def test_invalid_lifecycle_and_database_write_failure_fail_closed() -> None:
     with pytest.raises(WorkStateUnavailable, match="WORK_RECORD_INVALID"):
         PostgreSQLWorkStateStore(Database()).upsert_work(
@@ -255,6 +291,8 @@ def test_packet_intent_checkpoint_and_work_lease_are_one_transaction() -> None:
         kind="PUSH",
         target_identity="branch:feature/v2",
         status="INTENT_RECORDED",
+        expected_preconditions=(("head", "before"),),
+        expected_effect=(("head", "after"),),
     )
     checkpoint = WorkCheckpoint(
         identity="checkpoint:62:3",
@@ -283,6 +321,8 @@ def test_packet_intent_checkpoint_and_work_lease_are_one_transaction() -> None:
     assert "loop_work_checkpoints" in transaction
     assert "'INTENT_RECORDED'" in transaction
     assert "'EFFECT_PENDING'" in transaction
+    assert "expected_preconditions" in transaction
+    assert "expected_effect" in transaction
     assert "status IN ('INTENT_RECORDED', 'UNCERTAIN')" in transaction
     assert transaction.count("ON CONFLICT") == 1
     assert "ON CONFLICT (identity) DO NOTHING" not in transaction
@@ -294,7 +334,13 @@ def test_lease_conflict_never_issues_packet_or_starts_external_effect() -> None:
     store = PostgreSQLWorkStateStore(database)
     packet = WorkTaskPacket("packet:62:2", record().identity, 2, "IMPLEMENT", "STARTED")
     effect = EffectAttempt(
-        "effect:62:2", record().identity, "PUSH", "branch:feature/v2", "INTENT_RECORDED"
+        "effect:62:2",
+        record().identity,
+        "PUSH",
+        "branch:feature/v2",
+        "INTENT_RECORDED",
+        expected_preconditions=(("head", "before"),),
+        expected_effect=(("head", "after"),),
     )
     checkpoint = WorkCheckpoint(
         "checkpoint:62:3",
@@ -322,7 +368,13 @@ def test_failed_transaction_leaves_no_partial_packet_state() -> None:
     store = PostgreSQLWorkStateStore(database)
     packet = WorkTaskPacket("packet:62:2", record().identity, 2, "IMPLEMENT", "STARTED")
     effect = EffectAttempt(
-        "effect:62:2", record().identity, "PUSH", "branch:feature/v2", "INTENT_RECORDED"
+        "effect:62:2",
+        record().identity,
+        "PUSH",
+        "branch:feature/v2",
+        "INTENT_RECORDED",
+        expected_preconditions=(("head", "before"),),
+        expected_effect=(("head", "after"),),
     )
     checkpoint = WorkCheckpoint(
         "checkpoint:62:3",

--- a/tests/loop_engineering/test_work_state.py
+++ b/tests/loop_engineering/test_work_state.py
@@ -144,6 +144,7 @@ def test_task_packet_and_pending_effects_are_recovered_from_db() -> None:
                 {
                     "idempotency_key": "effect:62:1",
                     "work_identity": record().identity,
+                    "packet_generation": 1,
                     "kind": "PUSH",
                     "target_identity": "branch:feature/v2",
                     "status": "UNCERTAIN",
@@ -165,6 +166,7 @@ def test_task_packet_and_pending_effects_are_recovered_from_db() -> None:
     assert recovered.checkpoint is not None
     assert recovered.checkpoint.resumable_state == "IMPLEMENT_PENDING"
     assert recovered.pending_effects[0].status == "UNCERTAIN"
+    assert recovered.pending_effects[0].packet_generation == 1
     assert recovered.pending_effects[0].expected_preconditions == (("head", "before"),)
     assert recovered.pending_effects[0].expected_effect == (("head", "after"),)
 
@@ -195,6 +197,7 @@ def test_effect_intent_is_idempotent_and_readback_can_settle_uncertain() -> None
         kind="MERGE",
         target_identity="pr:63",
         status="INTENT_RECORDED",
+        packet_generation=1,
         expected_preconditions=(("head", "abc"), ("base", "main"), ("state", "OPEN")),
         expected_effect=(("state", "MERGED"),),
     )
@@ -205,11 +208,38 @@ def test_effect_intent_is_idempotent_and_readback_can_settle_uncertain() -> None
 
     written = "\n".join(database.statements)
     assert "ON CONFLICT (idempotency_key) DO NOTHING" in written
+    assert "packet_generation" in written
     assert "expected_preconditions" in written
     assert "expected_effect" in written
     assert "AND status IN ('INTENT_RECORDED', 'UNCERTAIN')" in written
     assert "UNCERTAIN" in written
     assert "CONFIRMED" in written
+
+
+def test_new_effect_intent_requires_packet_generation_and_expectations() -> None:
+    store = PostgreSQLWorkStateStore(Database())
+    missing_generation = EffectAttempt(
+        "effect:legacy",
+        record().identity,
+        "PUSH",
+        "branch:feature/v2",
+        "INTENT_RECORDED",
+        expected_preconditions=(("head", "before"),),
+        expected_effect=(("head", "after"),),
+    )
+    with pytest.raises(WorkStateUnavailable, match="EFFECT_INTENT_INVALID"):
+        store.record_effect_intent(missing_generation)
+
+    missing_expectation = EffectAttempt(
+        "effect:empty",
+        record().identity,
+        "PUSH",
+        "branch:feature/v2",
+        "INTENT_RECORDED",
+        packet_generation=1,
+    )
+    with pytest.raises(WorkStateUnavailable, match="EFFECT_INTENT_INVALID"):
+        store.record_effect_intent(missing_expectation)
 
 
 def test_issue_report_is_outbox_and_requires_bounded_body() -> None:
@@ -229,6 +259,7 @@ def test_issue_report_is_outbox_and_requires_bounded_body() -> None:
     assert "loop_issue_report_outbox" in written
     assert "'PENDING'" in written
     assert "'PUBLISHED'" in written
+    assert "ON CONFLICT DO NOTHING" in written
     with pytest.raises(WorkStateUnavailable, match="ISSUE_REPORT_INVALID"):
         store.enqueue_issue_report(
             identity="report:too-long",
@@ -291,6 +322,7 @@ def test_packet_intent_checkpoint_and_work_lease_are_one_transaction() -> None:
         kind="PUSH",
         target_identity="branch:feature/v2",
         status="INTENT_RECORDED",
+        packet_generation=2,
         expected_preconditions=(("head", "before"),),
         expected_effect=(("head", "after"),),
     )
@@ -321,12 +353,46 @@ def test_packet_intent_checkpoint_and_work_lease_are_one_transaction() -> None:
     assert "loop_work_checkpoints" in transaction
     assert "'INTENT_RECORDED'" in transaction
     assert "'EFFECT_PENDING'" in transaction
+    assert "packet_generation" in transaction
     assert "expected_preconditions" in transaction
     assert "expected_effect" in transaction
     assert "status IN ('INTENT_RECORDED', 'UNCERTAIN')" in transaction
     assert transaction.count("ON CONFLICT") == 1
     assert "ON CONFLICT (identity) DO NOTHING" not in transaction
     assert "ON CONFLICT (idempotency_key) DO NOTHING" not in transaction
+
+
+def test_transaction_rejects_effect_from_different_packet_generation() -> None:
+    store = PostgreSQLWorkStateStore(Database(transaction_result={"acquired": True}))
+    packet = WorkTaskPacket("packet:62:2", record().identity, 2, "IMPLEMENT", "STARTED")
+    effect = EffectAttempt(
+        "effect:62:old",
+        record().identity,
+        "PUSH",
+        "branch:feature/v2",
+        "INTENT_RECORDED",
+        packet_generation=1,
+        expected_preconditions=(("head", "before"),),
+        expected_effect=(("head", "after"),),
+    )
+    checkpoint = WorkCheckpoint(
+        "checkpoint:62:3",
+        record().identity,
+        "run:3",
+        "EFFECT_PENDING",
+        "EFFECT_INTENT_RECORDED",
+        "外部効果を実行する",
+        task_packet_identity=packet.identity,
+    )
+
+    with pytest.raises(WorkStateUnavailable, match="TRANSACTION_PACKET_INVALID"):
+        store.issue_packet_transaction(
+            record=record(),
+            lease=WorkLease(record().identity, "run:3", 2, 300),
+            packet=packet,
+            effect=effect,
+            checkpoint=checkpoint,
+        )
 
 
 def test_lease_conflict_never_issues_packet_or_starts_external_effect() -> None:
@@ -339,6 +405,7 @@ def test_lease_conflict_never_issues_packet_or_starts_external_effect() -> None:
         "PUSH",
         "branch:feature/v2",
         "INTENT_RECORDED",
+        packet_generation=2,
         expected_preconditions=(("head", "before"),),
         expected_effect=(("head", "after"),),
     )
@@ -373,6 +440,7 @@ def test_failed_transaction_leaves_no_partial_packet_state() -> None:
         "PUSH",
         "branch:feature/v2",
         "INTENT_RECORDED",
+        packet_generation=2,
         expected_preconditions=(("head", "before"),),
         expected_effect=(("head", "after"),),
     )


### PR DESCRIPTION
Closes #66

## 目的

V2でDBへ確定済みの外部効果意図だけを対象identityへ限定して読戻し、Issue報告outboxを重複なく投稿できるようにする。

## 設計

- `docs/architecture/v2/v2_effect_readback_and_outbox.md` を製造仕様として追加
- `INTENT_RECORDED` / `UNCERTAIN` は再送せず、対象限定readbackだけで `CONFIRMED` / `NO_EFFECT` へ確定
- effectを発行元 `TaskPacket.generation` とDB上で結び付け、欠落・不一致時は外部提供元を読まず `EFFECT_PACKET_MISMATCH` で停止
- GitHub読戻し対象を `PUSH` / `READY` / `MERGE` / `ISSUE_UPDATE` の記録済みidentityへ限定
- Issue報告outboxの論理identityを `work + checkpoint + report kind` とし、DB unique indexで重複行を抑止
- Issue報告はoutbox identityのSHA-256 markerで投稿済みを判定し、投稿後readback成功時だけ `PUBLISHED` に確定
- outbox本文はGitHub読取り前に再検証し、不正本文では外部アクセスしない
- Host合成、Work lease保持下でのpublisher呼出し、`CONFIRMED` / `NO_EFFECT` 後のTaskPacket・Checkpoint遷移、`--v2-once` は #67 の範囲として分離

## 実装

- `0006_v2_effect_readback_outbox.sql`
  - `loop_effect_attempts.packet_generation`
  - `expected_preconditions` / `expected_effect`
  - outbox論理一意index
- `EffectAttempt` と `PostgreSQLWorkStateStore` を拡張
- `V2ResumeCoordinator` にeffect/task packet generation整合性gateを追加
- `GitHubEffectReadbackAdapter` を追加
- `GitHubIssueReportPublisher` を追加
- `PENDING` outboxの作業単位読出しを追加

## 試験

- PUSHの前後HEAD・別HEAD
- READYのexact HEADとdraft前後
- MERGEのexact head/baseとstate前後
- ISSUE_UPDATEの型付きscalar field前後
- 不完全target・通信失敗のfail-closed
- effect packet generation不一致・欠落時にprovider readback 0回
- `UNCERTAIN`をreadbackだけで `CONFIRMED` / `NO_EFFECT` へ確定
- 新規effect intentのgeneration / expected state必須化
- outbox enqueueの論理重複抑止契約
- outbox marker既存時の投稿0回
- 新規投稿後readback成功時だけPUBLISHED
- 不正本文・投稿失敗・投稿後readback失敗時のPENDING維持

Ruff / strict Mypy / full pytest / compileall / diff-check はこのPRの最新exact HEADで確認する。