### PR TITLE
feat: V2 Goal bootstrapとProduct Planningを実装する

### DIFF
--- a/docs/architecture/v2/goal_bootstrap_and_planning.md
+++ b/docs/architecture/v2/goal_bootstrap_and_planning.md
@@ -1,0 +1,175 @@
+# V2 Goal bootstrap / Product Planning仕様
+
+管理Issue: #83
+親Issue: #81
+上位正本: `autonomous_development_completion_contract.md`
+
+状態: 製造仕様
+
+## 1. 目的
+
+Product側にWork Issue、branch、PR、TaskPacketが存在しない状態から、Hostが与えたProduct登録とGoalを型付きWork Planへ変換し、GitHub Issue / Projectへ冪等に投影できるbootstrap境界を定義する。
+
+本仕様は実行中current Workを決めない。PlanningのAuthorityをGitHubへ確立した後、#84のV2 Supervisor / SchedulerがPostgreSQL実行状態とGitHub typed planning stateを組み合わせてWorkを選択する。
+
+## 2. 初期入力
+
+`ProductDevelopmentRegistration`:
+
+- `product_key`
+- `workspace_canonical_path`
+- `repository_identity`
+- `project_owner`
+- `project_number`
+- `trunk_branch`
+- `goal_definition_identity`
+- `goal_revision`
+- `goal_text`
+- `acceptance_criteria[]`
+- `work_branch_template`
+- `ci_workflow_name`
+- `human_verification_policy`
+- `self_improvement_target?`
+
+Product側の既存Mission Issue番号は必須入力にしない。旧Host互換用`mission_issue`は本bootstrap契約のAuthorityではない。
+
+## 3. Planner境界
+
+`GoalPlannerPort.plan(registration) -> WorkPlanProposal` とする。
+
+PlannerはGitHub mutationやProduct Workspace変更を行わない。出力は次の型付きproposalのみとする。
+
+`WorkPlanProposal`:
+
+- `proposal_identity`
+- `goal_revision`
+- `works[]`
+- `completion_conditions[]`
+
+各`PlannedWork`:
+
+- `logical_key`
+- `title`
+- `purpose`
+- `acceptance_criteria[]`
+- `dependencies[]`（logical key）
+- `work_kind`
+- `human_verification_required`
+- `canonical_design_targets[]`
+
+最初のproduction実装では、外部Planning LLMが未接続でもbootstrap能力そのものを失わないよう、Goal全体を1 Workへ正規化する`SingleWorkGoalPlanner`をgeneric fallbackとして持つ。複雑なGoal分解は同Portの別Adapterへ差し替え可能とする。
+
+## 4. Proposal validation
+
+mutation前に次をすべて検証する。
+
+1. Product / Goal identityが空でない。
+2. acceptance criteriaが1件以上存在する。
+3. Work件数が1〜64の範囲内。
+4. logical keyが安全な小文字ASCII識別子で一意。
+5. title / purpose / acceptanceが空でない。
+6. dependencyが同proposal内の既知logical keyだけを参照する。
+7. self dependencyがない。
+8. dependency graphにcycleがない。
+9. completion conditionが1件以上ある。
+10. 同一Goal revisionから決定論的なproposal identityを再生成できる。
+
+不正proposalは外部effectへ変換しない。
+
+## 5. GitHub Planning Projection
+
+`PlanningProjectionPort.ensure_plan(registration, proposal)` はGitHub側の課題・Project構造を確立する。
+
+Product Work Issue本文へmachine bootstrap identityとして次のHTML comment markerを1つだけ埋め込む。
+
+```text
+<!-- loop-engineering-work:{product_key}:{goal_revision}:{logical_key} -->
+```
+
+このmarkerはbootstrap時の冪等identityであり、current Work / PR / HEAD / next transitionのAuthorityには使用しない。
+
+再bootstrap時はIssue一覧からmarker完全一致を検索し、既存Issueへ収束する。create commandが失敗・timeoutした場合も直ちに再作成せず、同markerをfresh readして存在確認する。
+
+## 6. Issue作成
+
+Issue本文は人間向け情報と受入条件を保持する。
+
+最低限:
+
+- marker
+- 目的
+- スコープ
+- 受入条件
+- logical dependency一覧
+- canonical design target
+- Human Verification要否
+
+日付、Status、Priority等、Project fieldを正本とする値を本文へ重複管理しない。
+
+## 7. Project登録
+
+Issueを指定Projectへ追加し、少なくとも次を設定する。
+
+- `Acceptance criteria digest`: acceptance criteriaのcanonical SHA-256
+- `Status`: templateに存在する初期未着手optionを使用
+
+Project field / option identityは名前からfresh解決し、IDをPlatform coreへハードコードしない。必要fieldが無ければfail-closedする。
+
+Project item add / field update後はProject itemをfresh readbackし、対象Issue URL、field valueが一致することを確認する。
+
+## 8. Dependency
+
+Projection結果はlogical dependencyを`ProjectedWork.dependencies`として型付きで保持する。
+
+GitHub native dependency mutationはprovider capabilityとして扱う。利用可能な場合は設定してreadbackする。利用不能な場合でもdependencyを推測で失わず、後続#84へ型付きPlan snapshotとして渡せるようにする。
+
+production Completion Gateまでには、SchedulerがdependencyをGitHub planning stateからfresh取得できるprovider経路を完成させる。
+
+## 9. 冪等性
+
+冪等key:
+
+```text
+product_key + goal_revision + logical_key
+```
+
+以下を二重作成しない。
+
+- Issue
+- Project item
+- Project field updateの論理effect
+
+同markerのIssueが複数存在する場合は競合として停止し、どれかを推測採用しない。
+
+## 10. Self-Improvement境界
+
+Product bootstrapのPlanning projectionはProduct Issueだけを作成する。
+
+Loop Engineering Platform自体の不具合・改善は`self_improvement_target`へ別系統で公開し、Product Repositoryへ汎用Platform改善Issueを混入させない。
+
+## 11. 実装構成
+
+- `v2_goal_planning.py`
+  - registration / plan model
+  - proposal validator
+  - deterministic fallback planner
+  - bootstrap service
+- `v2_planning_projection.py`
+  - GitHub Issue / Project projection adapter
+  - marker / digest / readback
+- tests
+  - proposal validation
+  - cycle / duplicate / invalid dependency
+  - repeated bootstrap convergence
+  - duplicate marker conflict
+  - create command failure後readback
+  - Project field不足のfail-closed
+
+## 12. 完了条件
+
+- Product側に事前Issueが0件でもGoalからWork Planを生成できる。
+- 同Goal revisionを再bootstrapしても同一Issue / Project itemへ収束する。
+- Acceptance criteria digestをProjectへ投影できる。
+- Project field不足・duplicate marker・曖昧readbackではmutationを継続しない。
+- Product固有identityをPlatform coreへハードコードしない。
+- #82のAuthority境界を維持する。

--- a/docs/architecture/v2/goal_bootstrap_and_planning.md
+++ b/docs/architecture/v2/goal_bootstrap_and_planning.md
@@ -28,6 +28,7 @@ Product側にWork Issue、branch、PR、TaskPacketが存在しない状態から
 - `acceptance_criteria[]`
 - `work_branch_template`
 - `ci_workflow_name`
+- `initial_project_status`
 - `human_verification_policy`
 - `self_improvement_target?`
 
@@ -76,9 +77,54 @@ mutation前に次をすべて検証する。
 
 不正proposalは外部effectへ変換しない。
 
-## 5. GitHub Planning Projection
+## 5. Bootstrap effect状態
+
+最初のIssue作成前にはGitHub Issue番号由来の`WorkRecord`が存在しないため、通常の`loop_effect_attempts.work_identity`へbootstrap mutationを記録できない。
+
+この不足を理由にGitHubへ直接mutationしてはならない。versioned migrationで`loop_bootstrap_effects`を追加し、Goal bootstrap専用のintent / readback / idempotency正本をPostgreSQLへ置く。
+
+最低限:
+
+```text
+loop_bootstrap_effects
+- idempotency_key PRIMARY KEY
+- product_key
+- repository
+- goal_revision
+- kind
+- target_identity
+- status: INTENT_RECORDED | CONFIRMED | NO_EFFECT | UNCERTAIN
+- expected_preconditions JSONB
+- expected_effect JSONB
+- request_identity?
+- confirmed_at?
+- recorded_at
+```
+
+bootstrap effectも通常V2 effectと同じ順序を守る。
+
+```text
+DB intent
+→ target限定fresh readback
+→ precondition検証
+→ mutation最大1回
+→ fresh readback
+→ DB outcome
+```
+
+command failure / timeout後に同じeffectを即再送しない。結果をreadbackできなければ`UNCERTAIN`として停止する。
+
+Goal / Work Issueが確定して通常`WorkRecord`を作成できる段階以降は、#62〜#67の通常V2 work/effect状態へ移行する。
+
+## 6. GitHub Planning Projection
 
 `PlanningProjectionPort.ensure_plan(registration, proposal)` はGitHub側の課題・Project構造を確立する。
+
+Goal管理Issueへ次のmarkerを埋め込む。
+
+```text
+<!-- loop-engineering-goal:{product_key}:{goal_revision} -->
+```
 
 Product Work Issue本文へmachine bootstrap identityとして次のHTML comment markerを1つだけ埋め込む。
 
@@ -86,17 +132,18 @@ Product Work Issue本文へmachine bootstrap identityとして次のHTML comment
 <!-- loop-engineering-work:{product_key}:{goal_revision}:{logical_key} -->
 ```
 
-このmarkerはbootstrap時の冪等identityであり、current Work / PR / HEAD / next transitionのAuthorityには使用しない。
+markerはbootstrap時の冪等identityであり、current Work / PR / HEAD / next transitionのAuthorityには使用しない。
 
 再bootstrap時はIssue一覧からmarker完全一致を検索し、既存Issueへ収束する。create commandが失敗・timeoutした場合も直ちに再作成せず、同markerをfresh readして存在確認する。
 
-## 6. Issue作成
+## 7. Issue作成
 
-Issue本文は人間向け情報と受入条件を保持する。
+Goal管理IssueはGoal原文、Goal acceptance criteria、proposal identityを人間向けに保持する。
 
-最低限:
+Work Issue本文は最低限次を持つ。
 
 - marker
+- Goal管理Issue参照
 - 目的
 - スコープ
 - 受入条件
@@ -106,18 +153,20 @@ Issue本文は人間向け情報と受入条件を保持する。
 
 日付、Status、Priority等、Project fieldを正本とする値を本文へ重複管理しない。
 
-## 7. Project登録
+## 8. Project登録
 
-Issueを指定Projectへ追加し、少なくとも次を設定する。
+Goal管理IssueとWork Issueを指定Projectへ追加する。
+
+Work Issueには少なくとも次を設定する。
 
 - `Acceptance criteria digest`: acceptance criteriaのcanonical SHA-256
-- `Status`: templateに存在する初期未着手optionを使用
+- `Status`: `initial_project_status`と一致するoption
 
-Project field / option identityは名前からfresh解決し、IDをPlatform coreへハードコードしない。必要fieldが無ければfail-closedする。
+Project field / option identityは名前からfresh解決し、IDをPlatform coreへハードコードしない。必要field・Status optionが無ければfail-closedする。
 
 Project item add / field update後はProject itemをfresh readbackし、対象Issue URL、field valueが一致することを確認する。
 
-## 8. Dependency
+## 9. Dependency
 
 Projection結果はlogical dependencyを`ProjectedWork.dependencies`として型付きで保持する。
 
@@ -125,38 +174,42 @@ GitHub native dependency mutationはprovider capabilityとして扱う。利用�
 
 production Completion Gateまでには、SchedulerがdependencyをGitHub planning stateからfresh取得できるprovider経路を完成させる。
 
-## 9. 冪等性
+## 10. 冪等性
 
-冪等key:
+冪等keyはeffect種別と次の論理identityから決定論的に生成する。
 
 ```text
-product_key + goal_revision + logical_key
+product_key + goal_revision + logical_key? + target role
 ```
 
 以下を二重作成しない。
 
-- Issue
+- Goal Issue
+- Work Issue
 - Project item
 - Project field updateの論理effect
 
 同markerのIssueが複数存在する場合は競合として停止し、どれかを推測採用しない。
 
-## 10. Self-Improvement境界
+## 11. Self-Improvement境界
 
 Product bootstrapのPlanning projectionはProduct Issueだけを作成する。
 
 Loop Engineering Platform自体の不具合・改善は`self_improvement_target`へ別系統で公開し、Product Repositoryへ汎用Platform改善Issueを混入させない。
 
-## 11. 実装構成
+## 12. 実装構成
 
 - `v2_goal_planning.py`
   - registration / plan model
   - proposal validator
   - deterministic fallback planner
   - bootstrap service
+- `v2_bootstrap_state.py`
+  - bootstrap専用PostgreSQL effect state
 - `v2_planning_projection.py`
   - GitHub Issue / Project projection adapter
-  - marker / digest / readback
+  - marker / digest / effect intent / readback
+- migration `0008_v2_bootstrap_effects.sql`
 - tests
   - proposal validation
   - cycle / duplicate / invalid dependency
@@ -164,10 +217,12 @@ Loop Engineering Platform自体の不具合・改善は`self_improvement_target`
   - duplicate marker conflict
   - create command failure後readback
   - Project field不足のfail-closed
+  - DB intent未確定ではmutation 0回
 
-## 12. 完了条件
+## 13. 完了条件
 
 - Product側に事前Issueが0件でもGoalからWork Planを生成できる。
+- 最初のIssue作成を含むbootstrap mutationがPostgreSQL intentを経由する。
 - 同Goal revisionを再bootstrapしても同一Issue / Project itemへ収束する。
 - Acceptance criteria digestをProjectへ投影できる。
 - Project field不足・duplicate marker・曖昧readbackではmutationを継続しない。

--- a/src/loop_engineering/migrations/0008_v2_bootstrap_effects.sql
+++ b/src/loop_engineering/migrations/0008_v2_bootstrap_effects.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS loop_bootstrap_effects (
+    idempotency_key TEXT PRIMARY KEY,
+    product_key TEXT NOT NULL,
+    repository TEXT NOT NULL,
+    goal_revision TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    target_identity TEXT NOT NULL,
+    status TEXT NOT NULL,
+    request_identity TEXT,
+    expected_preconditions JSONB NOT NULL DEFAULT '{}'::jsonb,
+    expected_effect JSONB NOT NULL DEFAULT '{}'::jsonb,
+    confirmed_at TIMESTAMPTZ,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS loop_bootstrap_effects_goal_status_index
+    ON loop_bootstrap_effects (repository, product_key, goal_revision, status, recorded_at ASC);

--- a/src/loop_engineering/v2_bootstrap_state.py
+++ b/src/loop_engineering/v2_bootstrap_state.py
@@ -1,0 +1,211 @@
+"""Work Issue作成前のbootstrap外部effectをPostgreSQLへ安全に記録する。"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class BootstrapStateUnavailable(RuntimeError):
+    """bootstrap状態を安全に読み書きできない。"""
+
+
+class BootstrapStateDatabase(Protocol):
+    def execute_sql(self, sql: str) -> bool: ...
+
+    def query_json_rows(self, select_sql: str) -> list[dict[str, object]] | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class BootstrapEffect:
+    idempotency_key: str
+    product_key: str
+    repository: str
+    goal_revision: str
+    kind: str
+    target_identity: str
+    status: str = "INTENT_RECORDED"
+    request_identity: str | None = None
+    expected_preconditions: tuple[tuple[str, str], ...] = ()
+    expected_effect: tuple[tuple[str, str], ...] = ()
+
+
+class PostgreSQLBootstrapStateStore:
+    _STATUSES = frozenset({"INTENT_RECORDED", "CONFIRMED", "NO_EFFECT", "UNCERTAIN"})
+
+    def __init__(self, database: BootstrapStateDatabase) -> None:
+        self._database = database
+
+    def ensure_intent(self, effect: BootstrapEffect) -> BootstrapEffect:
+        _validate_effect(effect)
+        existing = self.get(effect.idempotency_key)
+        if existing is not None:
+            if not _same_plan(existing, effect):
+                raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_CONFLICT")
+            return existing
+        if not self._database.execute_sql(
+            "INSERT INTO loop_bootstrap_effects "
+            "(idempotency_key, product_key, repository, goal_revision, kind, target_identity, "
+            "status, request_identity, expected_preconditions, expected_effect) VALUES ("
+            f"{_literal(effect.idempotency_key)}, {_literal(effect.product_key)}, "
+            f"{_literal(effect.repository)}, {_literal(effect.goal_revision)}, "
+            f"{_literal(effect.kind)}, {_literal(effect.target_identity)}, 'INTENT_RECORDED', "
+            f"{_nullable_literal(effect.request_identity)}, "
+            f"{_pairs_json_literal(effect.expected_preconditions)}, "
+            f"{_pairs_json_literal(effect.expected_effect)}) "
+            "ON CONFLICT (idempotency_key) DO NOTHING"
+        ):
+            raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_INTENT_WRITE_FAILED")
+        stored = self.get(effect.idempotency_key)
+        if stored is None or not _same_plan(stored, effect):
+            raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_INTENT_READBACK_FAILED")
+        return stored
+
+    def get(self, idempotency_key: str) -> BootstrapEffect | None:
+        rows = self._database.query_json_rows(
+            "SELECT idempotency_key, product_key, repository, goal_revision, kind, "
+            "target_identity, status, request_identity, expected_preconditions, expected_effect "
+            "FROM loop_bootstrap_effects "
+            f"WHERE idempotency_key = {_literal(idempotency_key)} LIMIT 1"
+        )
+        if rows is None:
+            raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_READ_FAILED")
+        if not rows:
+            return None
+        return _effect_from_row(rows[0])
+
+    def record_outcome(self, idempotency_key: str, status: str) -> BootstrapEffect:
+        if status not in self._STATUSES or status == "INTENT_RECORDED":
+            raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_OUTCOME_INVALID")
+        current = self.get(idempotency_key)
+        if current is None:
+            raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_MISSING")
+        if current.status == status:
+            return current
+        if current.status in {"CONFIRMED", "NO_EFFECT"}:
+            raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_ALREADY_TERMINAL")
+        if not self._database.execute_sql(
+            "UPDATE loop_bootstrap_effects SET "
+            f"status = {_literal(status)}, "
+            "confirmed_at = CASE WHEN "
+            f"{_literal(status)} = 'CONFIRMED' THEN now() ELSE confirmed_at END, "
+            "updated_at = now() "
+            f"WHERE idempotency_key = {_literal(idempotency_key)} "
+            "AND status IN ('INTENT_RECORDED', 'UNCERTAIN')"
+        ):
+            raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_OUTCOME_WRITE_FAILED")
+        stored = self.get(idempotency_key)
+        if stored is None or stored.status != status:
+            raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_OUTCOME_READBACK_FAILED")
+        return stored
+
+    def unresolved(
+        self,
+        *,
+        repository: str,
+        product_key: str,
+        goal_revision: str,
+    ) -> tuple[BootstrapEffect, ...]:
+        rows = self._database.query_json_rows(
+            "SELECT idempotency_key, product_key, repository, goal_revision, kind, "
+            "target_identity, status, request_identity, expected_preconditions, expected_effect "
+            "FROM loop_bootstrap_effects WHERE "
+            f"repository = {_literal(repository)} AND product_key = {_literal(product_key)} "
+            f"AND goal_revision = {_literal(goal_revision)} "
+            "AND status IN ('INTENT_RECORDED', 'UNCERTAIN') "
+            "ORDER BY recorded_at ASC, idempotency_key ASC"
+        )
+        if rows is None:
+            raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_READ_FAILED")
+        return tuple(_effect_from_row(row) for row in rows)
+
+
+def _validate_effect(effect: BootstrapEffect) -> None:
+    values = (
+        effect.idempotency_key,
+        effect.product_key,
+        effect.repository,
+        effect.goal_revision,
+        effect.kind,
+        effect.target_identity,
+    )
+    if any(not value or "\x00" in value for value in values):
+        raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_INVALID")
+    if effect.status != "INTENT_RECORDED":
+        raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_INVALID")
+    if not effect.expected_effect:
+        raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_INVALID")
+
+
+def _same_plan(left: BootstrapEffect, right: BootstrapEffect) -> bool:
+    return (
+        left.idempotency_key == right.idempotency_key
+        and left.product_key == right.product_key
+        and left.repository == right.repository
+        and left.goal_revision == right.goal_revision
+        and left.kind == right.kind
+        and left.target_identity == right.target_identity
+        and left.request_identity == right.request_identity
+        and left.expected_preconditions == right.expected_preconditions
+        and left.expected_effect == right.expected_effect
+    )
+
+
+def _effect_from_row(row: dict[str, object]) -> BootstrapEffect:
+    status = _required_string(row, "status")
+    if status not in PostgreSQLBootstrapStateStore._STATUSES:
+        raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_ROW_INVALID")
+    return BootstrapEffect(
+        idempotency_key=_required_string(row, "idempotency_key"),
+        product_key=_required_string(row, "product_key"),
+        repository=_required_string(row, "repository"),
+        goal_revision=_required_string(row, "goal_revision"),
+        kind=_required_string(row, "kind"),
+        target_identity=_required_string(row, "target_identity"),
+        status=status,
+        request_identity=_optional_string(row, "request_identity"),
+        expected_preconditions=_pairs(row, "expected_preconditions"),
+        expected_effect=_pairs(row, "expected_effect"),
+    )
+
+
+def _required_string(row: dict[str, object], key: str) -> str:
+    value = row.get(key)
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_ROW_INVALID")
+    return value
+
+
+def _optional_string(row: dict[str, object], key: str) -> str | None:
+    value = row.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_ROW_INVALID")
+    return value
+
+
+def _pairs(row: dict[str, object], key: str) -> tuple[tuple[str, str], ...]:
+    value = row.get(key)
+    if not isinstance(value, dict):
+        raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_ROW_INVALID")
+    result: list[tuple[str, str]] = []
+    for raw_key, raw_value in value.items():
+        if not isinstance(raw_key, str) or not isinstance(raw_value, str):
+            raise BootstrapStateUnavailable("BOOTSTRAP_EFFECT_ROW_INVALID")
+        result.append((raw_key, raw_value))
+    return tuple(sorted(result))
+
+
+def _literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _nullable_literal(value: str | None) -> str:
+    return "NULL" if value is None else _literal(value)
+
+
+def _pairs_json_literal(values: tuple[tuple[str, str], ...]) -> str:
+    payload = json.dumps(dict(values), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return _literal(payload) + "::jsonb"

--- a/src/loop_engineering/v2_goal_planning.py
+++ b/src/loop_engineering/v2_goal_planning.py
@@ -58,7 +58,9 @@ class ProductDevelopmentRegistration:
             raise PlanningValidationError("REGISTRATION_IDENTITY_INVALID")
         if not self.workspace_canonical_path.is_absolute():
             raise PlanningValidationError("REGISTRATION_WORKSPACE_INVALID")
-        if not self.acceptance_criteria or any(not item.strip() for item in self.acceptance_criteria):
+        if not self.acceptance_criteria or any(
+            not item.strip() for item in self.acceptance_criteria
+        ):
             raise PlanningValidationError("REGISTRATION_ACCEPTANCE_INVALID")
         if self.self_improvement_target is not None and "/" not in self.self_improvement_target:
             raise PlanningValidationError("REGISTRATION_IMPROVEMENT_TARGET_INVALID")

--- a/src/loop_engineering/v2_goal_planning.py
+++ b/src/loop_engineering/v2_goal_planning.py
@@ -1,0 +1,274 @@
+"""初期Goalを型付きWork Planへ変換し、検証済みPlanだけをprojectionする。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+_LOGICAL_KEY_RE = re.compile(r"[a-z0-9][a-z0-9-]{0,62}")
+_ALLOWED_WORK_KINDS = frozenset(
+    {"DESIGN_IMPLEMENT", "IMPLEMENTATION", "DOCUMENTATION", "VERIFICATION", "INTEGRATION"}
+)
+_MAX_WORKS = 64
+
+
+class PlanningValidationError(RuntimeError):
+    """GoalまたはPlanning proposalを安全に採用できない。"""
+
+
+@dataclass(frozen=True, slots=True)
+class ProductDevelopmentRegistration:
+    product_key: str
+    workspace_canonical_path: Path
+    repository_identity: str
+    project_owner: str
+    project_number: int
+    trunk_branch: str
+    goal_definition_identity: str
+    goal_revision: str
+    goal_text: str
+    acceptance_criteria: tuple[str, ...]
+    work_branch_template: str
+    ci_workflow_name: str
+    initial_project_status: str
+    human_verification_policy: str = "WHEN_REQUIRED"
+    self_improvement_target: str | None = None
+
+    def __post_init__(self) -> None:
+        text_values = (
+            self.product_key,
+            self.repository_identity,
+            self.project_owner,
+            self.trunk_branch,
+            self.goal_definition_identity,
+            self.goal_revision,
+            self.goal_text,
+            self.work_branch_template,
+            self.ci_workflow_name,
+            self.initial_project_status,
+            self.human_verification_policy,
+        )
+        if any(not value.strip() or value.strip() != value for value in text_values):
+            raise PlanningValidationError("REGISTRATION_TEXT_INVALID")
+        if "/" not in self.repository_identity or self.project_number < 1:
+            raise PlanningValidationError("REGISTRATION_IDENTITY_INVALID")
+        if not self.workspace_canonical_path.is_absolute():
+            raise PlanningValidationError("REGISTRATION_WORKSPACE_INVALID")
+        if not self.acceptance_criteria or any(not item.strip() for item in self.acceptance_criteria):
+            raise PlanningValidationError("REGISTRATION_ACCEPTANCE_INVALID")
+        if self.self_improvement_target is not None and "/" not in self.self_improvement_target:
+            raise PlanningValidationError("REGISTRATION_IMPROVEMENT_TARGET_INVALID")
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedWork:
+    logical_key: str
+    title: str
+    purpose: str
+    acceptance_criteria: tuple[str, ...]
+    dependencies: tuple[str, ...] = ()
+    work_kind: str = "DESIGN_IMPLEMENT"
+    human_verification_required: bool = False
+    canonical_design_targets: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class WorkPlanProposal:
+    proposal_identity: str
+    goal_revision: str
+    works: tuple[PlannedWork, ...]
+    completion_conditions: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectedWork:
+    logical_key: str
+    issue_number: int
+    issue_url: str
+    project_item_id: str
+    acceptance_digest: str
+    dependencies: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectedPlan:
+    goal_issue_number: int
+    goal_issue_url: str
+    goal_project_item_id: str
+    works: tuple[ProjectedWork, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class BootstrapResult:
+    proposal: WorkPlanProposal
+    projection: ProjectedPlan
+
+
+class GoalPlannerPort(Protocol):
+    def plan(self, registration: ProductDevelopmentRegistration) -> WorkPlanProposal: ...
+
+
+class PlanningProjectionPort(Protocol):
+    def ensure_plan(
+        self,
+        registration: ProductDevelopmentRegistration,
+        proposal: WorkPlanProposal,
+    ) -> ProjectedPlan: ...
+
+
+class SingleWorkGoalPlanner:
+    """外部Plannerが無い場合もbootstrapを失わないgeneric fallback。"""
+
+    def plan(self, registration: ProductDevelopmentRegistration) -> WorkPlanProposal:
+        logical_key = "goal-implementation"
+        work = PlannedWork(
+            logical_key=logical_key,
+            title=_goal_title(registration.goal_text),
+            purpose=registration.goal_text,
+            acceptance_criteria=registration.acceptance_criteria,
+            work_kind="DESIGN_IMPLEMENT",
+            human_verification_required=registration.human_verification_policy == "ALWAYS",
+            canonical_design_targets=("docs/design.md",),
+        )
+        proposal = WorkPlanProposal(
+            proposal_identity=proposal_identity(registration, (work,)),
+            goal_revision=registration.goal_revision,
+            works=(work,),
+            completion_conditions=registration.acceptance_criteria,
+        )
+        validate_work_plan(registration, proposal)
+        return proposal
+
+
+class V2GoalBootstrapService:
+    def __init__(self, planner: GoalPlannerPort, projection: PlanningProjectionPort) -> None:
+        self._planner = planner
+        self._projection = projection
+
+    def bootstrap(self, registration: ProductDevelopmentRegistration) -> BootstrapResult:
+        proposal = self._planner.plan(registration)
+        validate_work_plan(registration, proposal)
+        projection = self._projection.ensure_plan(registration, proposal)
+        if tuple(item.logical_key for item in projection.works) != tuple(
+            item.logical_key for item in proposal.works
+        ):
+            raise PlanningValidationError("PROJECTION_WORK_IDENTITY_MISMATCH")
+        return BootstrapResult(proposal, projection)
+
+
+def validate_work_plan(
+    registration: ProductDevelopmentRegistration,
+    proposal: WorkPlanProposal,
+) -> None:
+    if proposal.goal_revision != registration.goal_revision:
+        raise PlanningValidationError("PLAN_GOAL_REVISION_MISMATCH")
+    if not 1 <= len(proposal.works) <= _MAX_WORKS:
+        raise PlanningValidationError("PLAN_WORK_COUNT_INVALID")
+    if not proposal.completion_conditions or any(
+        not condition.strip() for condition in proposal.completion_conditions
+    ):
+        raise PlanningValidationError("PLAN_COMPLETION_INVALID")
+
+    keys: set[str] = set()
+    for work in proposal.works:
+        if _LOGICAL_KEY_RE.fullmatch(work.logical_key) is None or work.logical_key in keys:
+            raise PlanningValidationError("PLAN_LOGICAL_KEY_INVALID")
+        keys.add(work.logical_key)
+        if (
+            not work.title.strip()
+            or not work.purpose.strip()
+            or not work.acceptance_criteria
+            or any(not item.strip() for item in work.acceptance_criteria)
+        ):
+            raise PlanningValidationError("PLAN_WORK_CONTENT_INVALID")
+        if work.work_kind not in _ALLOWED_WORK_KINDS:
+            raise PlanningValidationError("PLAN_WORK_KIND_INVALID")
+        if len(set(work.dependencies)) != len(work.dependencies):
+            raise PlanningValidationError("PLAN_DEPENDENCY_DUPLICATE")
+        if any(not target.strip() for target in work.canonical_design_targets):
+            raise PlanningValidationError("PLAN_DESIGN_TARGET_INVALID")
+
+    for work in proposal.works:
+        for dependency in work.dependencies:
+            if dependency == work.logical_key or dependency not in keys:
+                raise PlanningValidationError("PLAN_DEPENDENCY_INVALID")
+    _assert_acyclic(proposal.works)
+
+    expected = proposal_identity(registration, proposal.works)
+    if proposal.proposal_identity != expected:
+        raise PlanningValidationError("PLAN_IDENTITY_MISMATCH")
+
+
+def proposal_identity(
+    registration: ProductDevelopmentRegistration,
+    works: tuple[PlannedWork, ...],
+) -> str:
+    payload = {
+        "product_key": registration.product_key,
+        "repository": registration.repository_identity,
+        "goal_identity": registration.goal_definition_identity,
+        "goal_revision": registration.goal_revision,
+        "works": [
+            {
+                "logical_key": item.logical_key,
+                "title": item.title,
+                "purpose": item.purpose,
+                "acceptance": list(item.acceptance_criteria),
+                "dependencies": list(item.dependencies),
+                "work_kind": item.work_kind,
+                "human_verification_required": item.human_verification_required,
+                "design_targets": list(item.canonical_design_targets),
+            }
+            for item in works
+        ],
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return "plan:" + hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def acceptance_digest(criteria: tuple[str, ...]) -> str:
+    encoded = json.dumps(list(criteria), ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def goal_marker(registration: ProductDevelopmentRegistration) -> str:
+    return (
+        "<!-- loop-engineering-goal:"
+        f"{registration.product_key}:{registration.goal_revision} -->"
+    )
+
+
+def work_marker(registration: ProductDevelopmentRegistration, logical_key: str) -> str:
+    return (
+        "<!-- loop-engineering-work:"
+        f"{registration.product_key}:{registration.goal_revision}:{logical_key} -->"
+    )
+
+
+def _assert_acyclic(works: tuple[PlannedWork, ...]) -> None:
+    graph = {item.logical_key: item.dependencies for item in works}
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(key: str) -> None:
+        if key in visiting:
+            raise PlanningValidationError("PLAN_DEPENDENCY_CYCLE")
+        if key in visited:
+            return
+        visiting.add(key)
+        for dependency in graph[key]:
+            visit(dependency)
+        visiting.remove(key)
+        visited.add(key)
+
+    for key in graph:
+        visit(key)
+
+
+def _goal_title(goal_text: str) -> str:
+    first_line = next((line.strip() for line in goal_text.splitlines() if line.strip()), "Goal")
+    return first_line[:120]

--- a/src/loop_engineering/v2_planning_projection.py
+++ b/src/loop_engineering/v2_planning_projection.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Protocol, TypeVar
 
-from .v2_bootstrap_state import BootstrapEffect, BootstrapStateUnavailable
+from .v2_bootstrap_state import BootstrapEffect
 from .v2_goal_planning import (
     PlannedWork,
     ProductDevelopmentRegistration,
@@ -20,6 +20,8 @@ from .v2_goal_planning import (
     goal_marker,
     work_marker,
 )
+
+T = TypeVar("T")
 
 
 class PlanningProjectionError(RuntimeError):
@@ -85,18 +87,20 @@ class GitHubPlanningProjectionAdapter:
             title=f"Goal: {_title(registration.goal_text)}",
             body=_goal_body(registration, proposal),
         )
-        goal_item = self._ensure_project_item(registration, project_id, goal_issue.url, "goal")
+        goal_item = self._ensure_project_item(
+            registration, project_id, goal_issue.url, role="goal"
+        )
         self._ensure_field(
             registration,
             project_id,
             goal_item.item_id,
             status_field,
             registration.initial_project_status,
-            option_id=status_option,
             role="goal-status",
+            option_id=status_option,
         )
 
-        projected: list[ProjectedWork] = []
+        works: list[ProjectedWork] = []
         for work in proposal.works:
             issue = self._ensure_issue(
                 registration,
@@ -109,7 +113,7 @@ class GitHubPlanningProjectionAdapter:
                 registration,
                 project_id,
                 issue.url,
-                f"work:{work.logical_key}",
+                role=f"work:{work.logical_key}",
             )
             digest = acceptance_digest(work.acceptance_criteria)
             self._ensure_field(
@@ -126,24 +130,24 @@ class GitHubPlanningProjectionAdapter:
                 item.item_id,
                 status_field,
                 registration.initial_project_status,
-                option_id=status_option,
                 role=f"work:{work.logical_key}:status",
+                option_id=status_option,
             )
-            projected.append(
+            works.append(
                 ProjectedWork(
-                    logical_key=work.logical_key,
-                    issue_number=issue.number,
-                    issue_url=issue.url,
-                    project_item_id=item.item_id,
-                    acceptance_digest=digest,
-                    dependencies=work.dependencies,
+                    work.logical_key,
+                    issue.number,
+                    issue.url,
+                    item.item_id,
+                    digest,
+                    work.dependencies,
                 )
             )
         return ProjectedPlan(
-            goal_issue_number=goal_issue.number,
-            goal_issue_url=goal_issue.url,
-            goal_project_item_id=goal_item.item_id,
-            works=tuple(projected),
+            goal_issue.number,
+            goal_issue.url,
+            goal_item.item_id,
+            tuple(works),
         )
 
     def _ensure_issue(
@@ -155,44 +159,10 @@ class GitHubPlanningProjectionAdapter:
         title: str,
         body: str,
     ) -> _Issue:
-        found = self._find_issue(registration.repository_identity, marker)
-        if found is not None:
-            return found
-        effect = self._prepare_effect(
-            registration,
-            kind="ISSUE_CREATE",
-            role=role,
-            target_identity=f"issue-marker:{marker}",
-            expected_preconditions=(("marker_count", "0"),),
-            expected_effect=(("marker", marker),),
-        )
-        if effect.status == "CONFIRMED":
-            found = self._find_issue(registration.repository_identity, marker)
-            if found is None:
-                raise PlanningProjectionError("ISSUE_CONFIRMED_BUT_MISSING")
-            return found
-        if effect.status == "UNCERTAIN":
-            found = self._find_issue(registration.repository_identity, marker)
-            if found is not None:
-                self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
-                return found
-            raise PlanningProjectionError("ISSUE_CREATE_UNCERTAIN")
-        if effect.status == "NO_EFFECT":
-            effect = self._next_intent(
-                registration,
-                kind="ISSUE_CREATE",
-                role=role,
-                target_identity=f"issue-marker:{marker}",
-                expected_preconditions=(("marker_count", "0"),),
-                expected_effect=(("marker", marker),),
-            )
+        def readback() -> _Issue | None:
+            return self._find_issue(registration.repository_identity, marker)
 
-        if self._find_issue(registration.repository_identity, marker) is not None:
-            self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
-            found = self._find_issue(registration.repository_identity, marker)
-            assert found is not None
-            return found
-        try:
+        def mutate() -> None:
             self._run_json(
                 (
                     "gh",
@@ -206,59 +176,29 @@ class GitHubPlanningProjectionAdapter:
                     f"body={body}",
                 )
             )
-        except PlanningProjectionError:
-            found = self._find_issue(registration.repository_identity, marker)
-            if found is not None:
-                self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
-                return found
-            self._state.record_outcome(effect.idempotency_key, "NO_EFFECT")
-            raise
-        found = self._find_issue(registration.repository_identity, marker)
-        if found is None:
-            self._state.record_outcome(effect.idempotency_key, "UNCERTAIN")
-            raise PlanningProjectionError("ISSUE_CREATE_READBACK_UNPROVEN")
-        self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
-        return found
+
+        return self._ensure_created(
+            registration,
+            kind="ISSUE_CREATE",
+            role=role,
+            target_identity=f"issue-marker:{marker}",
+            expected_effect=(("marker", marker),),
+            readback=readback,
+            mutate=mutate,
+        )
 
     def _ensure_project_item(
         self,
         registration: ProductDevelopmentRegistration,
         project_id: str,
         issue_url: str,
+        *,
         role: str,
     ) -> _ProjectItem:
-        existing = self._find_project_item(project_id, issue_url)
-        if existing is not None:
-            return existing
-        effect = self._prepare_effect(
-            registration,
-            kind="PROJECT_ITEM_ADD",
-            role=role,
-            target_identity=f"project:{project_id}:issue:{issue_url}",
-            expected_preconditions=(("present", "false"),),
-            expected_effect=(("issue_url", issue_url),),
-        )
-        if effect.status == "CONFIRMED":
-            existing = self._find_project_item(project_id, issue_url)
-            if existing is None:
-                raise PlanningProjectionError("PROJECT_ITEM_CONFIRMED_BUT_MISSING")
-            return existing
-        if effect.status == "UNCERTAIN":
-            existing = self._find_project_item(project_id, issue_url)
-            if existing is not None:
-                self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
-                return existing
-            raise PlanningProjectionError("PROJECT_ITEM_ADD_UNCERTAIN")
-        if effect.status == "NO_EFFECT":
-            effect = self._next_intent(
-                registration,
-                kind="PROJECT_ITEM_ADD",
-                role=role,
-                target_identity=f"project:{project_id}:issue:{issue_url}",
-                expected_preconditions=(("present", "false"),),
-                expected_effect=(("issue_url", issue_url),),
-            )
-        try:
+        def readback() -> _ProjectItem | None:
+            return self._find_project_item(project_id, issue_url)
+
+        def mutate() -> None:
             self._run_json(
                 (
                     "gh",
@@ -273,19 +213,70 @@ class GitHubPlanningProjectionAdapter:
                     "json",
                 )
             )
+
+        return self._ensure_created(
+            registration,
+            kind="PROJECT_ITEM_ADD",
+            role=role,
+            target_identity=f"project:{project_id}:issue:{issue_url}",
+            expected_effect=(("issue_url", issue_url),),
+            readback=readback,
+            mutate=mutate,
+        )
+
+    def _ensure_created(
+        self,
+        registration: ProductDevelopmentRegistration,
+        *,
+        kind: str,
+        role: str,
+        target_identity: str,
+        expected_effect: tuple[tuple[str, str], ...],
+        readback: Callable[[], T | None],
+        mutate: Callable[[], None],
+    ) -> T:
+        observed = readback()
+        if observed is not None:
+            return observed
+        effect = self._prepare_effect(
+            registration,
+            kind=kind,
+            role=role,
+            target_identity=target_identity,
+            expected_preconditions=(("present", "false"),),
+            expected_effect=expected_effect,
+        )
+        if effect.status == "CONFIRMED":
+            confirmed = readback()
+            if confirmed is None:
+                raise PlanningProjectionError("CONFIRMED_EFFECT_MISSING")
+            return confirmed
+        if effect.status == "UNCERTAIN":
+            reconciled = readback()
+            if reconciled is None:
+                raise PlanningProjectionError("BOOTSTRAP_EFFECT_UNCERTAIN")
+            self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+            return reconciled
+
+        reconciled = readback()
+        if reconciled is not None:
+            self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+            return reconciled
+        try:
+            mutate()
         except PlanningProjectionError:
-            existing = self._find_project_item(project_id, issue_url)
-            if existing is not None:
+            reconciled = readback()
+            if reconciled is not None:
                 self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
-                return existing
+                return reconciled
             self._state.record_outcome(effect.idempotency_key, "NO_EFFECT")
             raise
-        existing = self._find_project_item(project_id, issue_url)
-        if existing is None:
+        reconciled = readback()
+        if reconciled is None:
             self._state.record_outcome(effect.idempotency_key, "UNCERTAIN")
-            raise PlanningProjectionError("PROJECT_ITEM_ADD_READBACK_UNPROVEN")
+            raise PlanningProjectionError("BOOTSTRAP_CREATE_READBACK_UNPROVEN")
         self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
-        return existing
+        return reconciled
 
     def _ensure_field(
         self,
@@ -299,9 +290,10 @@ class GitHubPlanningProjectionAdapter:
         option_id: str | None = None,
     ) -> None:
         observed = self._item_fields(item_id)
-        if observed.get(field.name) == value:
+        current = observed.get(field.name)
+        if current == value:
             return
-        before = observed.get(field.name, "<unset>")
+        before = current or "<unset>"
         effect = self._prepare_effect(
             registration,
             kind="PROJECT_FIELD_UPDATE",
@@ -312,29 +304,22 @@ class GitHubPlanningProjectionAdapter:
         )
         if effect.status == "CONFIRMED":
             if self._item_fields(item_id).get(field.name) != value:
-                raise PlanningProjectionError("PROJECT_FIELD_CONFIRMED_BUT_MISMATCH")
+                raise PlanningProjectionError("CONFIRMED_FIELD_MISMATCH")
             return
         if effect.status == "UNCERTAIN":
             if self._item_fields(item_id).get(field.name) == value:
                 self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
                 return
             raise PlanningProjectionError("PROJECT_FIELD_UPDATE_UNCERTAIN")
-        if effect.status == "NO_EFFECT":
-            effect = self._next_intent(
-                registration,
-                kind="PROJECT_FIELD_UPDATE",
-                role=role,
-                target_identity=f"project-item:{item_id}:field:{field.name}",
-                expected_preconditions=(("value", before),),
-                expected_effect=(("value", value),),
-            )
-        fresh_before = self._item_fields(item_id).get(field.name, "<unset>")
-        if fresh_before != before:
-            if fresh_before == value:
+
+        fresh = self._item_fields(item_id).get(field.name) or "<unset>"
+        if fresh != before:
+            if fresh == value:
                 self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
                 return
             self._state.record_outcome(effect.idempotency_key, "NO_EFFECT")
             raise PlanningProjectionError("PROJECT_FIELD_STALE_PRECONDITION")
+
         command = [
             "gh",
             "project",
@@ -402,25 +387,6 @@ class GitHubPlanningProjectionAdapter:
                 return existing
         raise PlanningProjectionError("BOOTSTRAP_EFFECT_GENERATION_EXHAUSTED")
 
-    def _next_intent(
-        self,
-        registration: ProductDevelopmentRegistration,
-        *,
-        kind: str,
-        role: str,
-        target_identity: str,
-        expected_preconditions: tuple[tuple[str, str], ...],
-        expected_effect: tuple[tuple[str, str], ...],
-    ) -> BootstrapEffect:
-        return self._prepare_effect(
-            registration,
-            kind=kind,
-            role=role,
-            target_identity=target_identity,
-            expected_preconditions=expected_preconditions,
-            expected_effect=expected_effect,
-        )
-
     def _find_issue(self, repository: str, marker: str) -> _Issue | None:
         payload = self._run_json(
             (
@@ -441,9 +407,12 @@ class GitHubPlanningProjectionAdapter:
             raise PlanningProjectionError("ISSUE_LIST_INVALID")
         matches: list[_Issue] = []
         for raw in payload:
-            if not isinstance(raw, dict) or raw.get("body") is None:
+            if not isinstance(raw, dict):
                 continue
-            body, title, url, number = raw.get("body"), raw.get("title"), raw.get("url"), raw.get("number")
+            body = raw.get("body")
+            title = raw.get("title")
+            url = raw.get("url")
+            number = raw.get("number")
             if (
                 isinstance(body, str)
                 and marker in body
@@ -469,21 +438,33 @@ class GitHubPlanningProjectionAdapter:
                 "json",
             )
         )
-        if not isinstance(raw, dict) or not isinstance(raw.get("id"), str):
+        if not isinstance(raw, dict):
             raise PlanningProjectionError("PROJECT_ID_UNAVAILABLE")
-        return raw["id"]
+        project_id = raw.get("id")
+        if not isinstance(project_id, str) or not project_id:
+            raise PlanningProjectionError("PROJECT_ID_UNAVAILABLE")
+        return project_id
 
     def _project_fields(self, project_id: str) -> tuple[_ProjectField, ...]:
         query = (
             "query($project:ID!){node(id:$project){... on ProjectV2{fields(first:100){"
-            "nodes{... on ProjectV2Field{id name dataType} ... on ProjectV2SingleSelectField{"
-            "id name options{id name}}} pageInfo{hasNextPage}}}}}"
+            "nodes{... on ProjectV2Field{id name dataType} "
+            "... on ProjectV2SingleSelectField{id name options{id name}}} "
+            "pageInfo{hasNextPage}}}}}"
         )
         raw = self._run_json(
-            ("gh", "api", "graphql", "-f", f"query={query}", "-f", f"project={project_id}")
+            (
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-f",
+                f"project={project_id}",
+            )
         )
         fields = _nested(raw, "data", "node", "fields")
-        if fields.get("pageInfo", {}).get("hasNextPage") is True:
+        if _has_next_page(fields):
             raise PlanningProjectionError("PROJECT_FIELDS_PAGINATED")
         nodes = fields.get("nodes")
         if not isinstance(nodes, list):
@@ -492,34 +473,45 @@ class GitHubPlanningProjectionAdapter:
         for node in nodes:
             if not isinstance(node, dict):
                 continue
-            field_id, name = node.get("id"), node.get("name")
+            field_id = node.get("id")
+            name = node.get("name")
             if not isinstance(field_id, str) or not isinstance(name, str):
                 continue
             options_raw = node.get("options")
             if isinstance(options_raw, list):
-                options = tuple(
-                    (option["id"], option["name"])
-                    for option in options_raw
-                    if isinstance(option, dict)
-                    and isinstance(option.get("id"), str)
-                    and isinstance(option.get("name"), str)
-                )
-                result.append(_ProjectField(field_id, name, "SINGLE_SELECT", options))
-            else:
-                data_type = node.get("dataType")
-                result.append(_ProjectField(field_id, name, str(data_type or "UNKNOWN")))
+                options: list[tuple[str, str]] = []
+                for option in options_raw:
+                    if not isinstance(option, dict):
+                        continue
+                    option_id = option.get("id")
+                    option_name = option.get("name")
+                    if isinstance(option_id, str) and isinstance(option_name, str):
+                        options.append((option_id, option_name))
+                result.append(_ProjectField(field_id, name, "SINGLE_SELECT", tuple(options)))
+                continue
+            data_type = node.get("dataType")
+            kind = data_type if isinstance(data_type, str) else "UNKNOWN"
+            result.append(_ProjectField(field_id, name, kind))
         return tuple(result)
 
     def _find_project_item(self, project_id: str, issue_url: str) -> _ProjectItem | None:
         query = (
-            "query($project:ID!){node(id:$project){... on ProjectV2{items(first:100){nodes{"
-            "id content{... on Issue{url}}} pageInfo{hasNextPage}}}}}"
+            "query($project:ID!){node(id:$project){... on ProjectV2{items(first:100){"
+            "nodes{id content{... on Issue{url}}} pageInfo{hasNextPage}}}}}"
         )
         raw = self._run_json(
-            ("gh", "api", "graphql", "-f", f"query={query}", "-f", f"project={project_id}")
+            (
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-f",
+                f"project={project_id}",
+            )
         )
         items = _nested(raw, "data", "node", "items")
-        if items.get("pageInfo", {}).get("hasNextPage") is True:
+        if _has_next_page(items):
             raise PlanningProjectionError("PROJECT_ITEMS_PAGINATED")
         nodes = items.get("nodes")
         if not isinstance(nodes, list):
@@ -528,12 +520,12 @@ class GitHubPlanningProjectionAdapter:
         for node in nodes:
             if not isinstance(node, dict):
                 continue
-            item_id, content = node.get("id"), node.get("content")
-            if (
-                isinstance(item_id, str)
-                and isinstance(content, dict)
-                and content.get("url") == issue_url
-            ):
+            item_id = node.get("id")
+            content = node.get("content")
+            if not isinstance(content, dict):
+                continue
+            observed_url = content.get("url")
+            if isinstance(item_id, str) and observed_url == issue_url:
                 matches.append(_ProjectItem(item_id, issue_url))
         if len(matches) > 1:
             raise PlanningProjectionError("PROJECT_ITEM_CONFLICT")
@@ -541,16 +533,26 @@ class GitHubPlanningProjectionAdapter:
 
     def _item_fields(self, item_id: str) -> dict[str, str]:
         query = (
-            "query($item:ID!){node(id:$item){... on ProjectV2Item{fieldValues(first:100){nodes{"
-            "... on ProjectV2ItemFieldTextValue{text field{... on ProjectV2FieldCommon{name}}} "
-            "... on ProjectV2ItemFieldSingleSelectValue{name field{... on ProjectV2FieldCommon{name}}}"
-            "} pageInfo{hasNextPage}}}}}"
+            "query($item:ID!){node(id:$item){... on ProjectV2Item{"
+            "fieldValues(first:100){nodes{"
+            "... on ProjectV2ItemFieldTextValue{text field{"
+            "... on ProjectV2FieldCommon{name}}} "
+            "... on ProjectV2ItemFieldSingleSelectValue{name field{"
+            "... on ProjectV2FieldCommon{name}}}} pageInfo{hasNextPage}}}}}"
         )
         raw = self._run_json(
-            ("gh", "api", "graphql", "-f", f"query={query}", "-f", f"item={item_id}")
+            (
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-f",
+                f"item={item_id}",
+            )
         )
         values = _nested(raw, "data", "node", "fieldValues")
-        if values.get("pageInfo", {}).get("hasNextPage") is True:
+        if _has_next_page(values):
             raise PlanningProjectionError("PROJECT_ITEM_FIELDS_PAGINATED")
         nodes = values.get("nodes")
         if not isinstance(nodes, list):
@@ -560,11 +562,16 @@ class GitHubPlanningProjectionAdapter:
             if not isinstance(node, dict):
                 continue
             field = node.get("field")
-            if not isinstance(field, dict) or not isinstance(field.get("name"), str):
+            if not isinstance(field, dict):
                 continue
-            value = node.get("text") if isinstance(node.get("text"), str) else node.get("name")
+            field_name = field.get("name")
+            if not isinstance(field_name, str):
+                continue
+            text_value = node.get("text")
+            select_value = node.get("name")
+            value = text_value if isinstance(text_value, str) else select_value
             if isinstance(value, str):
-                result[field["name"]] = value
+                result[field_name] = value
         return result
 
     def _run_json(self, command: Sequence[str]) -> object:
@@ -651,13 +658,22 @@ def _work_body(
 
 
 def _title(goal_text: str) -> str:
-    return next((line.strip() for line in goal_text.splitlines() if line.strip()), "Product Goal")[:120]
+    first = next(
+        (line.strip() for line in goal_text.splitlines() if line.strip()),
+        "Product Goal",
+    )
+    return first[:120]
 
 
 def _nested(raw: object, *keys: str) -> Mapping[str, object]:
-    current: object = raw
+    current = raw
     for key in keys:
         if not isinstance(current, dict):
             return {}
         current = current.get(key)
     return current if isinstance(current, dict) else {}
+
+
+def _has_next_page(value: Mapping[str, object]) -> bool:
+    page_info = value.get("pageInfo")
+    return isinstance(page_info, dict) and page_info.get("hasNextPage") is True

--- a/src/loop_engineering/v2_planning_projection.py
+++ b/src/loop_engineering/v2_planning_projection.py
@@ -1,0 +1,663 @@
+"""検証済みGoal PlanをGitHub Issue / Projectへ冪等に投影する。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from .v2_bootstrap_state import BootstrapEffect, BootstrapStateUnavailable
+from .v2_goal_planning import (
+    PlannedWork,
+    ProductDevelopmentRegistration,
+    ProjectedPlan,
+    ProjectedWork,
+    WorkPlanProposal,
+    acceptance_digest,
+    goal_marker,
+    work_marker,
+)
+
+
+class PlanningProjectionError(RuntimeError):
+    """GitHub Planning Authorityを安全に確立できない。"""
+
+
+class PlanningCommandRunner(Protocol):
+    def run(self, args: Sequence[str]) -> str: ...
+
+
+class BootstrapEffectStatePort(Protocol):
+    def ensure_intent(self, effect: BootstrapEffect) -> BootstrapEffect: ...
+
+    def get(self, idempotency_key: str) -> BootstrapEffect | None: ...
+
+    def record_outcome(self, idempotency_key: str, status: str) -> BootstrapEffect: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _Issue:
+    number: int
+    url: str
+    title: str
+    body: str
+
+
+@dataclass(frozen=True, slots=True)
+class _ProjectItem:
+    item_id: str
+    issue_url: str
+
+
+@dataclass(frozen=True, slots=True)
+class _ProjectField:
+    field_id: str
+    name: str
+    kind: str
+    options: tuple[tuple[str, str], ...] = ()
+
+
+class GitHubPlanningProjectionAdapter:
+    """bootstrap mutationを専用DB intentとreadbackで保護するGitHub adapter。"""
+
+    def __init__(self, runner: PlanningCommandRunner, state: BootstrapEffectStatePort) -> None:
+        self._runner = runner
+        self._state = state
+
+    def ensure_plan(
+        self,
+        registration: ProductDevelopmentRegistration,
+        proposal: WorkPlanProposal,
+    ) -> ProjectedPlan:
+        project_id = self._project_id(registration)
+        fields = self._project_fields(project_id)
+        digest_field = _required_field(fields, "Acceptance criteria digest", "TEXT")
+        status_field = _required_field(fields, "Status", "SINGLE_SELECT")
+        status_option = _required_option(status_field, registration.initial_project_status)
+
+        goal_issue = self._ensure_issue(
+            registration,
+            role="goal",
+            marker=goal_marker(registration),
+            title=f"Goal: {_title(registration.goal_text)}",
+            body=_goal_body(registration, proposal),
+        )
+        goal_item = self._ensure_project_item(registration, project_id, goal_issue.url, "goal")
+        self._ensure_field(
+            registration,
+            project_id,
+            goal_item.item_id,
+            status_field,
+            registration.initial_project_status,
+            option_id=status_option,
+            role="goal-status",
+        )
+
+        projected: list[ProjectedWork] = []
+        for work in proposal.works:
+            issue = self._ensure_issue(
+                registration,
+                role=f"work:{work.logical_key}",
+                marker=work_marker(registration, work.logical_key),
+                title=work.title,
+                body=_work_body(goal_issue.number, registration, work),
+            )
+            item = self._ensure_project_item(
+                registration,
+                project_id,
+                issue.url,
+                f"work:{work.logical_key}",
+            )
+            digest = acceptance_digest(work.acceptance_criteria)
+            self._ensure_field(
+                registration,
+                project_id,
+                item.item_id,
+                digest_field,
+                digest,
+                role=f"work:{work.logical_key}:acceptance",
+            )
+            self._ensure_field(
+                registration,
+                project_id,
+                item.item_id,
+                status_field,
+                registration.initial_project_status,
+                option_id=status_option,
+                role=f"work:{work.logical_key}:status",
+            )
+            projected.append(
+                ProjectedWork(
+                    logical_key=work.logical_key,
+                    issue_number=issue.number,
+                    issue_url=issue.url,
+                    project_item_id=item.item_id,
+                    acceptance_digest=digest,
+                    dependencies=work.dependencies,
+                )
+            )
+        return ProjectedPlan(
+            goal_issue_number=goal_issue.number,
+            goal_issue_url=goal_issue.url,
+            goal_project_item_id=goal_item.item_id,
+            works=tuple(projected),
+        )
+
+    def _ensure_issue(
+        self,
+        registration: ProductDevelopmentRegistration,
+        *,
+        role: str,
+        marker: str,
+        title: str,
+        body: str,
+    ) -> _Issue:
+        found = self._find_issue(registration.repository_identity, marker)
+        if found is not None:
+            return found
+        effect = self._prepare_effect(
+            registration,
+            kind="ISSUE_CREATE",
+            role=role,
+            target_identity=f"issue-marker:{marker}",
+            expected_preconditions=(("marker_count", "0"),),
+            expected_effect=(("marker", marker),),
+        )
+        if effect.status == "CONFIRMED":
+            found = self._find_issue(registration.repository_identity, marker)
+            if found is None:
+                raise PlanningProjectionError("ISSUE_CONFIRMED_BUT_MISSING")
+            return found
+        if effect.status == "UNCERTAIN":
+            found = self._find_issue(registration.repository_identity, marker)
+            if found is not None:
+                self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+                return found
+            raise PlanningProjectionError("ISSUE_CREATE_UNCERTAIN")
+        if effect.status == "NO_EFFECT":
+            effect = self._next_intent(
+                registration,
+                kind="ISSUE_CREATE",
+                role=role,
+                target_identity=f"issue-marker:{marker}",
+                expected_preconditions=(("marker_count", "0"),),
+                expected_effect=(("marker", marker),),
+            )
+
+        if self._find_issue(registration.repository_identity, marker) is not None:
+            self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+            found = self._find_issue(registration.repository_identity, marker)
+            assert found is not None
+            return found
+        try:
+            self._run_json(
+                (
+                    "gh",
+                    "api",
+                    f"repos/{registration.repository_identity}/issues",
+                    "--method",
+                    "POST",
+                    "--raw-field",
+                    f"title={title}",
+                    "--raw-field",
+                    f"body={body}",
+                )
+            )
+        except PlanningProjectionError:
+            found = self._find_issue(registration.repository_identity, marker)
+            if found is not None:
+                self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+                return found
+            self._state.record_outcome(effect.idempotency_key, "NO_EFFECT")
+            raise
+        found = self._find_issue(registration.repository_identity, marker)
+        if found is None:
+            self._state.record_outcome(effect.idempotency_key, "UNCERTAIN")
+            raise PlanningProjectionError("ISSUE_CREATE_READBACK_UNPROVEN")
+        self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+        return found
+
+    def _ensure_project_item(
+        self,
+        registration: ProductDevelopmentRegistration,
+        project_id: str,
+        issue_url: str,
+        role: str,
+    ) -> _ProjectItem:
+        existing = self._find_project_item(project_id, issue_url)
+        if existing is not None:
+            return existing
+        effect = self._prepare_effect(
+            registration,
+            kind="PROJECT_ITEM_ADD",
+            role=role,
+            target_identity=f"project:{project_id}:issue:{issue_url}",
+            expected_preconditions=(("present", "false"),),
+            expected_effect=(("issue_url", issue_url),),
+        )
+        if effect.status == "CONFIRMED":
+            existing = self._find_project_item(project_id, issue_url)
+            if existing is None:
+                raise PlanningProjectionError("PROJECT_ITEM_CONFIRMED_BUT_MISSING")
+            return existing
+        if effect.status == "UNCERTAIN":
+            existing = self._find_project_item(project_id, issue_url)
+            if existing is not None:
+                self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+                return existing
+            raise PlanningProjectionError("PROJECT_ITEM_ADD_UNCERTAIN")
+        if effect.status == "NO_EFFECT":
+            effect = self._next_intent(
+                registration,
+                kind="PROJECT_ITEM_ADD",
+                role=role,
+                target_identity=f"project:{project_id}:issue:{issue_url}",
+                expected_preconditions=(("present", "false"),),
+                expected_effect=(("issue_url", issue_url),),
+            )
+        try:
+            self._run_json(
+                (
+                    "gh",
+                    "project",
+                    "item-add",
+                    str(registration.project_number),
+                    "--owner",
+                    registration.project_owner,
+                    "--url",
+                    issue_url,
+                    "--format",
+                    "json",
+                )
+            )
+        except PlanningProjectionError:
+            existing = self._find_project_item(project_id, issue_url)
+            if existing is not None:
+                self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+                return existing
+            self._state.record_outcome(effect.idempotency_key, "NO_EFFECT")
+            raise
+        existing = self._find_project_item(project_id, issue_url)
+        if existing is None:
+            self._state.record_outcome(effect.idempotency_key, "UNCERTAIN")
+            raise PlanningProjectionError("PROJECT_ITEM_ADD_READBACK_UNPROVEN")
+        self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+        return existing
+
+    def _ensure_field(
+        self,
+        registration: ProductDevelopmentRegistration,
+        project_id: str,
+        item_id: str,
+        field: _ProjectField,
+        value: str,
+        *,
+        role: str,
+        option_id: str | None = None,
+    ) -> None:
+        observed = self._item_fields(item_id)
+        if observed.get(field.name) == value:
+            return
+        before = observed.get(field.name, "<unset>")
+        effect = self._prepare_effect(
+            registration,
+            kind="PROJECT_FIELD_UPDATE",
+            role=role,
+            target_identity=f"project-item:{item_id}:field:{field.name}",
+            expected_preconditions=(("value", before),),
+            expected_effect=(("value", value),),
+        )
+        if effect.status == "CONFIRMED":
+            if self._item_fields(item_id).get(field.name) != value:
+                raise PlanningProjectionError("PROJECT_FIELD_CONFIRMED_BUT_MISMATCH")
+            return
+        if effect.status == "UNCERTAIN":
+            if self._item_fields(item_id).get(field.name) == value:
+                self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+                return
+            raise PlanningProjectionError("PROJECT_FIELD_UPDATE_UNCERTAIN")
+        if effect.status == "NO_EFFECT":
+            effect = self._next_intent(
+                registration,
+                kind="PROJECT_FIELD_UPDATE",
+                role=role,
+                target_identity=f"project-item:{item_id}:field:{field.name}",
+                expected_preconditions=(("value", before),),
+                expected_effect=(("value", value),),
+            )
+        fresh_before = self._item_fields(item_id).get(field.name, "<unset>")
+        if fresh_before != before:
+            if fresh_before == value:
+                self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+                return
+            self._state.record_outcome(effect.idempotency_key, "NO_EFFECT")
+            raise PlanningProjectionError("PROJECT_FIELD_STALE_PRECONDITION")
+        command = [
+            "gh",
+            "project",
+            "item-edit",
+            "--id",
+            item_id,
+            "--project-id",
+            project_id,
+            "--field-id",
+            field.field_id,
+        ]
+        if field.kind == "TEXT":
+            command.extend(("--text", value))
+        elif field.kind == "SINGLE_SELECT" and option_id is not None:
+            command.extend(("--single-select-option-id", option_id))
+        else:
+            self._state.record_outcome(effect.idempotency_key, "NO_EFFECT")
+            raise PlanningProjectionError("PROJECT_FIELD_KIND_UNSUPPORTED")
+        try:
+            self._run_text(tuple(command))
+        except PlanningProjectionError:
+            if self._item_fields(item_id).get(field.name) == value:
+                self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+                return
+            self._state.record_outcome(effect.idempotency_key, "NO_EFFECT")
+            raise
+        if self._item_fields(item_id).get(field.name) != value:
+            self._state.record_outcome(effect.idempotency_key, "UNCERTAIN")
+            raise PlanningProjectionError("PROJECT_FIELD_UPDATE_READBACK_UNPROVEN")
+        self._state.record_outcome(effect.idempotency_key, "CONFIRMED")
+
+    def _prepare_effect(
+        self,
+        registration: ProductDevelopmentRegistration,
+        *,
+        kind: str,
+        role: str,
+        target_identity: str,
+        expected_preconditions: tuple[tuple[str, str], ...],
+        expected_effect: tuple[tuple[str, str], ...],
+    ) -> BootstrapEffect:
+        for generation in range(1, 65):
+            key = _effect_key(registration, kind, role, generation)
+            existing = self._state.get(key)
+            if existing is None:
+                return self._state.ensure_intent(
+                    BootstrapEffect(
+                        idempotency_key=key,
+                        product_key=registration.product_key,
+                        repository=registration.repository_identity,
+                        goal_revision=registration.goal_revision,
+                        kind=kind,
+                        target_identity=target_identity,
+                        expected_preconditions=expected_preconditions,
+                        expected_effect=expected_effect,
+                    )
+                )
+            if (
+                existing.kind != kind
+                or existing.target_identity != target_identity
+                or existing.expected_effect != expected_effect
+            ):
+                raise PlanningProjectionError("BOOTSTRAP_EFFECT_IDENTITY_CONFLICT")
+            if existing.status != "NO_EFFECT":
+                return existing
+        raise PlanningProjectionError("BOOTSTRAP_EFFECT_GENERATION_EXHAUSTED")
+
+    def _next_intent(
+        self,
+        registration: ProductDevelopmentRegistration,
+        *,
+        kind: str,
+        role: str,
+        target_identity: str,
+        expected_preconditions: tuple[tuple[str, str], ...],
+        expected_effect: tuple[tuple[str, str], ...],
+    ) -> BootstrapEffect:
+        return self._prepare_effect(
+            registration,
+            kind=kind,
+            role=role,
+            target_identity=target_identity,
+            expected_preconditions=expected_preconditions,
+            expected_effect=expected_effect,
+        )
+
+    def _find_issue(self, repository: str, marker: str) -> _Issue | None:
+        payload = self._run_json(
+            (
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                repository,
+                "--state",
+                "all",
+                "--limit",
+                "1000",
+                "--json",
+                "number,title,body,url",
+            )
+        )
+        if not isinstance(payload, list):
+            raise PlanningProjectionError("ISSUE_LIST_INVALID")
+        matches: list[_Issue] = []
+        for raw in payload:
+            if not isinstance(raw, dict) or raw.get("body") is None:
+                continue
+            body, title, url, number = raw.get("body"), raw.get("title"), raw.get("url"), raw.get("number")
+            if (
+                isinstance(body, str)
+                and marker in body
+                and isinstance(title, str)
+                and isinstance(url, str)
+                and isinstance(number, int)
+            ):
+                matches.append(_Issue(number, url, title, body))
+        if len(matches) > 1:
+            raise PlanningProjectionError("ISSUE_MARKER_CONFLICT")
+        return matches[0] if matches else None
+
+    def _project_id(self, registration: ProductDevelopmentRegistration) -> str:
+        raw = self._run_json(
+            (
+                "gh",
+                "project",
+                "view",
+                str(registration.project_number),
+                "--owner",
+                registration.project_owner,
+                "--format",
+                "json",
+            )
+        )
+        if not isinstance(raw, dict) or not isinstance(raw.get("id"), str):
+            raise PlanningProjectionError("PROJECT_ID_UNAVAILABLE")
+        return raw["id"]
+
+    def _project_fields(self, project_id: str) -> tuple[_ProjectField, ...]:
+        query = (
+            "query($project:ID!){node(id:$project){... on ProjectV2{fields(first:100){"
+            "nodes{... on ProjectV2Field{id name dataType} ... on ProjectV2SingleSelectField{"
+            "id name options{id name}}} pageInfo{hasNextPage}}}}}"
+        )
+        raw = self._run_json(
+            ("gh", "api", "graphql", "-f", f"query={query}", "-f", f"project={project_id}")
+        )
+        fields = _nested(raw, "data", "node", "fields")
+        if fields.get("pageInfo", {}).get("hasNextPage") is True:
+            raise PlanningProjectionError("PROJECT_FIELDS_PAGINATED")
+        nodes = fields.get("nodes")
+        if not isinstance(nodes, list):
+            raise PlanningProjectionError("PROJECT_FIELDS_INVALID")
+        result: list[_ProjectField] = []
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            field_id, name = node.get("id"), node.get("name")
+            if not isinstance(field_id, str) or not isinstance(name, str):
+                continue
+            options_raw = node.get("options")
+            if isinstance(options_raw, list):
+                options = tuple(
+                    (option["id"], option["name"])
+                    for option in options_raw
+                    if isinstance(option, dict)
+                    and isinstance(option.get("id"), str)
+                    and isinstance(option.get("name"), str)
+                )
+                result.append(_ProjectField(field_id, name, "SINGLE_SELECT", options))
+            else:
+                data_type = node.get("dataType")
+                result.append(_ProjectField(field_id, name, str(data_type or "UNKNOWN")))
+        return tuple(result)
+
+    def _find_project_item(self, project_id: str, issue_url: str) -> _ProjectItem | None:
+        query = (
+            "query($project:ID!){node(id:$project){... on ProjectV2{items(first:100){nodes{"
+            "id content{... on Issue{url}}} pageInfo{hasNextPage}}}}}"
+        )
+        raw = self._run_json(
+            ("gh", "api", "graphql", "-f", f"query={query}", "-f", f"project={project_id}")
+        )
+        items = _nested(raw, "data", "node", "items")
+        if items.get("pageInfo", {}).get("hasNextPage") is True:
+            raise PlanningProjectionError("PROJECT_ITEMS_PAGINATED")
+        nodes = items.get("nodes")
+        if not isinstance(nodes, list):
+            raise PlanningProjectionError("PROJECT_ITEMS_INVALID")
+        matches: list[_ProjectItem] = []
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            item_id, content = node.get("id"), node.get("content")
+            if (
+                isinstance(item_id, str)
+                and isinstance(content, dict)
+                and content.get("url") == issue_url
+            ):
+                matches.append(_ProjectItem(item_id, issue_url))
+        if len(matches) > 1:
+            raise PlanningProjectionError("PROJECT_ITEM_CONFLICT")
+        return matches[0] if matches else None
+
+    def _item_fields(self, item_id: str) -> dict[str, str]:
+        query = (
+            "query($item:ID!){node(id:$item){... on ProjectV2Item{fieldValues(first:100){nodes{"
+            "... on ProjectV2ItemFieldTextValue{text field{... on ProjectV2FieldCommon{name}}} "
+            "... on ProjectV2ItemFieldSingleSelectValue{name field{... on ProjectV2FieldCommon{name}}}"
+            "} pageInfo{hasNextPage}}}}}"
+        )
+        raw = self._run_json(
+            ("gh", "api", "graphql", "-f", f"query={query}", "-f", f"item={item_id}")
+        )
+        values = _nested(raw, "data", "node", "fieldValues")
+        if values.get("pageInfo", {}).get("hasNextPage") is True:
+            raise PlanningProjectionError("PROJECT_ITEM_FIELDS_PAGINATED")
+        nodes = values.get("nodes")
+        if not isinstance(nodes, list):
+            raise PlanningProjectionError("PROJECT_ITEM_FIELDS_INVALID")
+        result: dict[str, str] = {}
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            field = node.get("field")
+            if not isinstance(field, dict) or not isinstance(field.get("name"), str):
+                continue
+            value = node.get("text") if isinstance(node.get("text"), str) else node.get("name")
+            if isinstance(value, str):
+                result[field["name"]] = value
+        return result
+
+    def _run_json(self, command: Sequence[str]) -> object:
+        text = self._run_text(command)
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as error:
+            raise PlanningProjectionError("GITHUB_JSON_INVALID") from error
+
+    def _run_text(self, command: Sequence[str]) -> str:
+        try:
+            return self._runner.run(command)
+        except (OSError, subprocess.SubprocessError, ValueError) as error:
+            raise PlanningProjectionError("GITHUB_COMMAND_FAILED") from error
+
+
+def _required_field(
+    fields: tuple[_ProjectField, ...], name: str, kind: str
+) -> _ProjectField:
+    matches = [field for field in fields if field.name == name]
+    if len(matches) != 1 or matches[0].kind != kind:
+        raise PlanningProjectionError("PROJECT_FIELD_REQUIRED")
+    return matches[0]
+
+
+def _required_option(field: _ProjectField, name: str) -> str:
+    matches = [option_id for option_id, option_name in field.options if option_name == name]
+    if len(matches) != 1:
+        raise PlanningProjectionError("PROJECT_STATUS_OPTION_REQUIRED")
+    return matches[0]
+
+
+def _effect_key(
+    registration: ProductDevelopmentRegistration,
+    kind: str,
+    role: str,
+    generation: int,
+) -> str:
+    raw = (
+        f"{registration.repository_identity}|{registration.product_key}|"
+        f"{registration.goal_revision}|{kind}|{role}|{generation}"
+    )
+    return "bootstrap:" + hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _goal_body(
+    registration: ProductDevelopmentRegistration, proposal: WorkPlanProposal
+) -> str:
+    acceptance = "\n".join(f"- {item}" for item in registration.acceptance_criteria)
+    return (
+        f"{goal_marker(registration)}\n\n"
+        "## 目的\n\n"
+        f"{registration.goal_text}\n\n"
+        "## 受入条件\n\n"
+        f"{acceptance}\n\n"
+        "## Planning\n\n"
+        f"- Goal revision: `{registration.goal_revision}`\n"
+        f"- Proposal: `{proposal.proposal_identity}`\n"
+    )
+
+
+def _work_body(
+    goal_issue: int,
+    registration: ProductDevelopmentRegistration,
+    work: PlannedWork,
+) -> str:
+    acceptance = "\n".join(f"- [ ] {item}" for item in work.acceptance_criteria)
+    dependencies = ", ".join(f"`{item}`" for item in work.dependencies) or "なし"
+    designs = ", ".join(f"`{item}`" for item in work.canonical_design_targets) or "未指定"
+    verification = "必要" if work.human_verification_required else "不要"
+    return (
+        f"{work_marker(registration, work.logical_key)}\n\n"
+        f"Goal: #{goal_issue}\n\n"
+        "## 目的\n\n"
+        f"{work.purpose}\n\n"
+        "## 受入条件\n\n"
+        f"{acceptance}\n\n"
+        "## 設計・依存\n\n"
+        f"- Work kind: `{work.work_kind}`\n"
+        f"- logical dependencies: {dependencies}\n"
+        f"- canonical design targets: {designs}\n"
+        f"- Human Verification: {verification}\n"
+    )
+
+
+def _title(goal_text: str) -> str:
+    return next((line.strip() for line in goal_text.splitlines() if line.strip()), "Product Goal")[:120]
+
+
+def _nested(raw: object, *keys: str) -> Mapping[str, object]:
+    current: object = raw
+    for key in keys:
+        if not isinstance(current, dict):
+            return {}
+        current = current.get(key)
+    return current if isinstance(current, dict) else {}

--- a/tests/loop_engineering/test_v2_bootstrap_state.py
+++ b/tests/loop_engineering/test_v2_bootstrap_state.py
@@ -1,0 +1,84 @@
+from loop_engineering.v2_bootstrap_state import (
+    BootstrapEffect,
+    BootstrapStateUnavailable,
+    PostgreSQLBootstrapStateStore,
+)
+
+
+class ScriptedDatabase:
+    def __init__(
+        self,
+        query_results: list[list[dict[str, object]] | None],
+        execute_results: list[bool] | None = None,
+    ) -> None:
+        self.query_results = list(query_results)
+        self.execute_results = list(execute_results or [True] * 10)
+        self.executed_sql: list[str] = []
+
+    def execute_sql(self, sql: str) -> bool:
+        self.executed_sql.append(sql)
+        return self.execute_results.pop(0)
+
+    def query_json_rows(self, select_sql: str) -> list[dict[str, object]] | None:
+        self.executed_sql.append(select_sql)
+        return self.query_results.pop(0)
+
+
+def row(*, status: str = "INTENT_RECORDED", target: str = "issue-marker:x") -> dict[str, object]:
+    return {
+        "idempotency_key": "key-1",
+        "product_key": "sample",
+        "repository": "owner/sample",
+        "goal_revision": "rev-1",
+        "kind": "ISSUE_CREATE",
+        "target_identity": target,
+        "status": status,
+        "request_identity": None,
+        "expected_preconditions": {"present": "false"},
+        "expected_effect": {"marker": "x"},
+    }
+
+
+def effect() -> BootstrapEffect:
+    return BootstrapEffect(
+        idempotency_key="key-1",
+        product_key="sample",
+        repository="owner/sample",
+        goal_revision="rev-1",
+        kind="ISSUE_CREATE",
+        target_identity="issue-marker:x",
+        expected_preconditions=(("present", "false"),),
+        expected_effect=(("marker", "x"),),
+    )
+
+
+def test_ensure_intent_writes_then_reads_back_same_plan() -> None:
+    database = ScriptedDatabase([[], [row()]])
+    store = PostgreSQLBootstrapStateStore(database)
+
+    stored = store.ensure_intent(effect())
+
+    assert stored.status == "INTENT_RECORDED"
+    assert any("INSERT INTO loop_bootstrap_effects" in sql for sql in database.executed_sql)
+
+
+def test_ensure_intent_rejects_same_key_with_different_plan() -> None:
+    database = ScriptedDatabase([[row(target="issue-marker:other")]])
+    store = PostgreSQLBootstrapStateStore(database)
+
+    try:
+        store.ensure_intent(effect())
+    except BootstrapStateUnavailable as error:
+        assert str(error) == "BOOTSTRAP_EFFECT_CONFLICT"
+    else:
+        raise AssertionError("conflicting bootstrap effect was accepted")
+
+
+def test_record_outcome_confirms_intent_with_readback() -> None:
+    database = ScriptedDatabase([[row()], [row(status="CONFIRMED")]])
+    store = PostgreSQLBootstrapStateStore(database)
+
+    stored = store.record_outcome("key-1", "CONFIRMED")
+
+    assert stored.status == "CONFIRMED"
+    assert any("confirmed_at" in sql for sql in database.executed_sql)

--- a/tests/loop_engineering/test_v2_goal_planning.py
+++ b/tests/loop_engineering/test_v2_goal_planning.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+
+import pytest
+
+from loop_engineering.v2_goal_planning import (
+    PlannedWork,
+    PlanningValidationError,
+    ProductDevelopmentRegistration,
+    SingleWorkGoalPlanner,
+    WorkPlanProposal,
+    acceptance_digest,
+    proposal_identity,
+    validate_work_plan,
+)
+
+
+def registration() -> ProductDevelopmentRegistration:
+    return ProductDevelopmentRegistration(
+        product_key="sample",
+        workspace_canonical_path=Path("/tmp/sample"),
+        repository_identity="owner/sample",
+        project_owner="owner",
+        project_number=10,
+        trunk_branch="main",
+        goal_definition_identity="goal:sample",
+        goal_revision="rev-1",
+        goal_text="文字統計CLIを完成させる",
+        acceptance_criteria=("ファイル入力", "JSON出力"),
+        work_branch_template="feature/work-{issue}",
+        ci_workflow_name="Deterministic CI",
+        initial_project_status="Backlog",
+    )
+
+
+def test_single_work_goal_planner_is_deterministic() -> None:
+    target = registration()
+    planner = SingleWorkGoalPlanner()
+
+    first = planner.plan(target)
+    second = planner.plan(target)
+
+    assert first == second
+    assert first.proposal_identity.startswith("plan:")
+    assert first.works[0].logical_key == "goal-implementation"
+    assert first.works[0].acceptance_criteria == target.acceptance_criteria
+
+
+def test_validation_rejects_dependency_cycle() -> None:
+    target = registration()
+    works = (
+        PlannedWork("a", "A", "A", ("A",), dependencies=("b",)),
+        PlannedWork("b", "B", "B", ("B",), dependencies=("a",)),
+    )
+    proposal = WorkPlanProposal(
+        proposal_identity=proposal_identity(target, works),
+        goal_revision=target.goal_revision,
+        works=works,
+        completion_conditions=("done",),
+    )
+
+    with pytest.raises(PlanningValidationError, match="PLAN_DEPENDENCY_CYCLE"):
+        validate_work_plan(target, proposal)
+
+
+def test_validation_rejects_unknown_dependency() -> None:
+    target = registration()
+    works = (PlannedWork("a", "A", "A", ("A",), dependencies=("missing",)),)
+    proposal = WorkPlanProposal(
+        proposal_identity=proposal_identity(target, works),
+        goal_revision=target.goal_revision,
+        works=works,
+        completion_conditions=("done",),
+    )
+
+    with pytest.raises(PlanningValidationError, match="PLAN_DEPENDENCY_INVALID"):
+        validate_work_plan(target, proposal)
+
+
+def test_validation_rejects_duplicate_logical_key() -> None:
+    target = registration()
+    works = (
+        PlannedWork("same", "A", "A", ("A",)),
+        PlannedWork("same", "B", "B", ("B",)),
+    )
+    proposal = WorkPlanProposal(
+        proposal_identity=proposal_identity(target, works),
+        goal_revision=target.goal_revision,
+        works=works,
+        completion_conditions=("done",),
+    )
+
+    with pytest.raises(PlanningValidationError, match="PLAN_LOGICAL_KEY_INVALID"):
+        validate_work_plan(target, proposal)
+
+
+def test_acceptance_digest_is_stable_and_order_sensitive() -> None:
+    assert acceptance_digest(("a", "b")) == acceptance_digest(("a", "b"))
+    assert acceptance_digest(("a", "b")) != acceptance_digest(("b", "a"))

--- a/tests/loop_engineering/test_v2_planning_projection.py
+++ b/tests/loop_engineering/test_v2_planning_projection.py
@@ -57,7 +57,7 @@ class FakeGitHubRunner:
             body = _raw_field(command, "body")
             number = self.next_issue
             self.next_issue += 1
-            issue = {
+            issue: dict[str, object] = {
                 "number": number,
                 "title": title,
                 "body": body,
@@ -72,11 +72,12 @@ class FakeGitHubRunner:
             return json.dumps({"id": "PROJECT"})
         if command[:3] == ("gh", "project", "item-add"):
             issue_url = command[command.index("--url") + 1]
-            item = {"id": f"ITEM{self.next_item}", "issue_url": issue_url}
+            item_id = f"ITEM{self.next_item}"
+            item: dict[str, object] = {"id": item_id, "issue_url": issue_url}
             self.next_item += 1
             self.items.append(item)
-            self.item_fields[item["id"]] = {}
-            return json.dumps({"id": item["id"]})
+            self.item_fields[item_id] = {}
+            return json.dumps({"id": item_id})
         if command[:3] == ("gh", "project", "item-edit"):
             item_id = command[command.index("--id") + 1]
             field_id = command[command.index("--field-id") + 1]

--- a/tests/loop_engineering/test_v2_planning_projection.py
+++ b/tests/loop_engineering/test_v2_planning_projection.py
@@ -1,8 +1,8 @@
 import json
 import subprocess
+from collections.abc import Sequence
 from dataclasses import replace
 from pathlib import Path
-from collections.abc import Sequence
 
 import pytest
 

--- a/tests/loop_engineering/test_v2_planning_projection.py
+++ b/tests/loop_engineering/test_v2_planning_projection.py
@@ -1,0 +1,232 @@
+import json
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+from collections.abc import Sequence
+
+import pytest
+
+from loop_engineering.v2_bootstrap_state import BootstrapEffect
+from loop_engineering.v2_goal_planning import (
+    ProductDevelopmentRegistration,
+    SingleWorkGoalPlanner,
+    V2GoalBootstrapService,
+)
+from loop_engineering.v2_planning_projection import (
+    GitHubPlanningProjectionAdapter,
+    PlanningProjectionError,
+)
+
+
+class MemoryState:
+    def __init__(self) -> None:
+        self.effects: dict[str, BootstrapEffect] = {}
+
+    def ensure_intent(self, effect: BootstrapEffect) -> BootstrapEffect:
+        self.effects.setdefault(effect.idempotency_key, effect)
+        return self.effects[effect.idempotency_key]
+
+    def get(self, idempotency_key: str) -> BootstrapEffect | None:
+        return self.effects.get(idempotency_key)
+
+    def record_outcome(self, idempotency_key: str, status: str) -> BootstrapEffect:
+        current = self.effects[idempotency_key]
+        updated = replace(current, status=status)
+        self.effects[idempotency_key] = updated
+        return updated
+
+
+class FakeGitHubRunner:
+    def __init__(self, *, fail_first_issue_response: bool = False) -> None:
+        self.issues: list[dict[str, object]] = []
+        self.items: list[dict[str, object]] = []
+        self.item_fields: dict[str, dict[str, str]] = {}
+        self.next_issue = 1
+        self.next_item = 1
+        self.fail_first_issue_response = fail_first_issue_response
+        self.issue_create_calls = 0
+        self.field_mode = "complete"
+
+    def run(self, args: Sequence[str]) -> str:
+        command = tuple(args)
+        if command[:3] == ("gh", "issue", "list"):
+            return json.dumps(self.issues)
+        if command[:3] == ("gh", "api", "repos/owner/sample/issues"):
+            self.issue_create_calls += 1
+            title = _raw_field(command, "title")
+            body = _raw_field(command, "body")
+            number = self.next_issue
+            self.next_issue += 1
+            issue = {
+                "number": number,
+                "title": title,
+                "body": body,
+                "url": f"https://github.com/owner/sample/issues/{number}",
+            }
+            self.issues.append(issue)
+            if self.fail_first_issue_response:
+                self.fail_first_issue_response = False
+                raise subprocess.CalledProcessError(1, command)
+            return json.dumps(issue)
+        if command[:3] == ("gh", "project", "view"):
+            return json.dumps({"id": "PROJECT"})
+        if command[:3] == ("gh", "project", "item-add"):
+            issue_url = command[command.index("--url") + 1]
+            item = {"id": f"ITEM{self.next_item}", "issue_url": issue_url}
+            self.next_item += 1
+            self.items.append(item)
+            self.item_fields[item["id"]] = {}
+            return json.dumps({"id": item["id"]})
+        if command[:3] == ("gh", "project", "item-edit"):
+            item_id = command[command.index("--id") + 1]
+            field_id = command[command.index("--field-id") + 1]
+            if "--text" in command:
+                value = command[command.index("--text") + 1]
+                name = "Acceptance criteria digest" if field_id == "DIGEST" else field_id
+            else:
+                option = command[command.index("--single-select-option-id") + 1]
+                value = "Backlog" if option == "BACKLOG" else option
+                name = "Status" if field_id == "STATUS" else field_id
+            self.item_fields[item_id][name] = value
+            return "{}"
+        if command[:3] == ("gh", "api", "graphql"):
+            query = command[command.index("-f") + 1]
+            if "fields(first:100)" in query:
+                nodes: list[dict[str, object]] = [
+                    {
+                        "id": "STATUS",
+                        "name": "Status",
+                        "options": [{"id": "BACKLOG", "name": "Backlog"}],
+                    }
+                ]
+                if self.field_mode == "complete":
+                    nodes.append(
+                        {
+                            "id": "DIGEST",
+                            "name": "Acceptance criteria digest",
+                            "dataType": "TEXT",
+                        }
+                    )
+                return _graphql({"fields": {"nodes": nodes, "pageInfo": {"hasNextPage": False}}})
+            if "items(first:100)" in query:
+                nodes = [
+                    {"id": item["id"], "content": {"url": item["issue_url"]}}
+                    for item in self.items
+                ]
+                return _graphql({"items": {"nodes": nodes, "pageInfo": {"hasNextPage": False}}})
+            if "fieldValues(first:100)" in query:
+                item_id = command[-1].split("=", 1)[1]
+                nodes = []
+                for name, value in self.item_fields[item_id].items():
+                    if name == "Status":
+                        nodes.append({"name": value, "field": {"name": name}})
+                    else:
+                        nodes.append({"text": value, "field": {"name": name}})
+                return json.dumps(
+                    {
+                        "data": {
+                            "node": {
+                                "fieldValues": {
+                                    "nodes": nodes,
+                                    "pageInfo": {"hasNextPage": False},
+                                }
+                            }
+                        }
+                    }
+                )
+        raise AssertionError(f"unexpected command: {command}")
+
+
+def _graphql(value: dict[str, object]) -> str:
+    return json.dumps({"data": {"node": value}})
+
+
+def _raw_field(command: tuple[str, ...], key: str) -> str:
+    prefix = f"{key}="
+    for index, value in enumerate(command):
+        if value == "--raw-field" and command[index + 1].startswith(prefix):
+            return command[index + 1][len(prefix) :]
+    raise AssertionError(key)
+
+
+def registration() -> ProductDevelopmentRegistration:
+    return ProductDevelopmentRegistration(
+        product_key="sample",
+        workspace_canonical_path=Path("/tmp/sample"),
+        repository_identity="owner/sample",
+        project_owner="owner",
+        project_number=10,
+        trunk_branch="main",
+        goal_definition_identity="goal:sample",
+        goal_revision="rev-1",
+        goal_text="文字統計CLIを完成させる",
+        acceptance_criteria=("ファイル入力", "JSON出力"),
+        work_branch_template="feature/work-{issue}",
+        ci_workflow_name="Deterministic CI",
+        initial_project_status="Backlog",
+    )
+
+
+def test_bootstrap_repeated_run_converges_to_same_issues_and_items() -> None:
+    runner = FakeGitHubRunner()
+    state = MemoryState()
+    service = V2GoalBootstrapService(
+        SingleWorkGoalPlanner(), GitHubPlanningProjectionAdapter(runner, state)
+    )
+
+    first = service.bootstrap(registration())
+    second = service.bootstrap(registration())
+
+    assert first.projection == second.projection
+    assert len(runner.issues) == 2
+    assert len(runner.items) == 2
+    assert first.projection.works[0].acceptance_digest == runner.item_fields["ITEM2"][
+        "Acceptance criteria digest"
+    ]
+    assert runner.item_fields["ITEM2"]["Status"] == "Backlog"
+
+
+def test_issue_create_response_failure_is_reconciled_by_marker_readback() -> None:
+    runner = FakeGitHubRunner(fail_first_issue_response=True)
+    state = MemoryState()
+    service = V2GoalBootstrapService(
+        SingleWorkGoalPlanner(), GitHubPlanningProjectionAdapter(runner, state)
+    )
+
+    result = service.bootstrap(registration())
+
+    assert result.projection.goal_issue_number == 1
+    assert len(runner.issues) == 2
+    assert runner.issue_create_calls == 2
+    assert any(effect.status == "CONFIRMED" for effect in state.effects.values())
+
+
+def test_missing_acceptance_digest_field_fails_before_issue_mutation() -> None:
+    runner = FakeGitHubRunner()
+    runner.field_mode = "status-only"
+    state = MemoryState()
+    service = V2GoalBootstrapService(
+        SingleWorkGoalPlanner(), GitHubPlanningProjectionAdapter(runner, state)
+    )
+
+    with pytest.raises(PlanningProjectionError, match="PROJECT_FIELD_REQUIRED"):
+        service.bootstrap(registration())
+
+    assert runner.issues == []
+    assert state.effects == {}
+
+
+def test_duplicate_goal_marker_fails_closed() -> None:
+    runner = FakeGitHubRunner()
+    marker = "<!-- loop-engineering-goal:sample:rev-1 -->"
+    runner.issues = [
+        {"number": 1, "title": "A", "body": marker, "url": "https://x/1"},
+        {"number": 2, "title": "B", "body": marker, "url": "https://x/2"},
+    ]
+    state = MemoryState()
+    service = V2GoalBootstrapService(
+        SingleWorkGoalPlanner(), GitHubPlanningProjectionAdapter(runner, state)
+    )
+
+    with pytest.raises(PlanningProjectionError, match="ISSUE_MARKER_CONFLICT"):
+        service.bootstrap(registration())


### PR DESCRIPTION
## 関連Issue

Closes #83
Parent manufacturing: #81
Depends on: #82

## 設計

`docs/architecture/v2/goal_bootstrap_and_planning.md` を先行追加し、初期Goal→型付きWorkPlan→PostgreSQL bootstrap effect intent→GitHub Issue/Project projectionの境界を確定した。

## 実装

- `v2_goal_planning.py`: Registration / WorkPlan / validator / fallback planner / bootstrap service
- `v2_bootstrap_state.py`: Work Issue作成前のbootstrap effect PostgreSQL状態
- migration `0008_v2_bootstrap_effects.sql`
- `v2_planning_projection.py`: Goal/Work IssueとProject item/fieldの冪等projection
- bootstrap markerは冪等identity専用で、current Work/PR/HEAD復元には使用しない
- Issue create / Project add / field updateをDB intent→readback→最大1回mutation→readback→outcomeで保護

## 検証

- deterministic fallback Planning
- dependency cycle / unknown dependency / duplicate key拒否
- repeated bootstrap convergence
- Issue create応答失敗後のmarker readback
- Project field不足でmutation前fail-closed
- duplicate marker conflict

旧actual-host自然文current-state解析は再導入しない。