### PR TITLE
feat: V2 SupervisorとSchedulerをDB状態へ接続する

### DIFF
--- a/docs/architecture/v2/supervisor_scheduler_state_machine.md
+++ b/docs/architecture/v2/supervisor_scheduler_state_machine.md
@@ -1,0 +1,126 @@
+# V2 Supervisor / Scheduler 状態機械
+
+管理Issue: #84
+親Issue: #81
+依存: #83
+上位正本: `autonomous_development_completion_contract.md`
+
+状態: 製造仕様
+
+## 1. 目的
+
+Goal bootstrapでGitHubへ確立したWork群と、PostgreSQLのV2実行状態を入力に、current Workと次の安全なtransitionを自然文解析なしで決定する。
+
+## 2. Authority
+
+- Work目的・受入条件・依存・Project状態: GitHub Issue / Project
+- current selected Work・packet・checkpoint・pending effect: PostgreSQL
+- branch / PR / HEAD: GitHub live（#86で接続）
+- CI / review / Human Verification evidence: exact target evidence（#87で接続）
+
+bootstrap markerはGoal配下Workのplanning discoveryにだけ使用し、current Workやnext transitionの復元には使わない。
+
+## 3. Work observation
+
+Supervisorへ渡すprovider非依存snapshotを`V2WorkObservation`とする。
+
+最低限:
+
+- work identity / issue number / revision
+- issue open/closed
+- project status / priority
+- dependency states
+- acceptance digest
+- canonical design identities
+- active lineage identity
+- exact head
+- verification state
+- review state
+- Human Verification requirement/state
+- merged state
+- unresolved conflict
+
+#84ではGitHub planning discoveryとDB current stateを接続し、branch/CI/review等の値は後続adapterが追加できる型として先に固定する。
+
+## 4. 導出transition
+
+優先順:
+
+1. unresolved conflict → `BLOCKED`
+2. dependency未完了 → wait-only
+3. Workがterminal → `COMPLETE_WORK`
+4. canonical designなし → `DESIGN`
+5. implementation headなし → `IMPLEMENT`
+6. verification failure → `REPAIR`
+7. verification未実行 → `VERIFY`
+8. verification pending → wait-only
+9. review changes/failure → `REPAIR`
+10. review未実行 → `REVIEW`
+11. review pending → wait-only
+12. Human Verification必要かつ未要求 → `HUMAN_VERIFY`
+13. Human Verification pending → wait-only
+14. Human Verification failure → `REPAIR`
+15. required evidence PASS → `INTEGRATE`
+
+後続#86/#87はこの状態機械を迂回せずevidenceを追加する。
+
+## 5. Selection
+
+1. PostgreSQL current Workがsafe/actionableなら継続。
+2. current Workがwait-onlyなら、dependency-readyな別actionable Workを選ぶ。
+3. priorityはP0→P1→P2→P3→未指定。
+4.同順位はProject Statusの作業中を優先し、最後にissue numberで安定tie-breakする。
+5. competing lineage / conflict Workはcandidateから除外し、他に進めるWorkが無ければ`INTERVENTION_REQUIRED`。
+
+## 6. duplicate suppression
+
+`V2ScheduleKey`は次をhashする。
+
+- Goal revision
+- Work identity / Issue revision
+- Project status / priority
+- dependency evidence
+- canonical design identities
+- active lineage / head
+- verification/review/HV evidence identity
+- DB checkpoint / packet identity
+- next transition
+
+同じkeyが既にin-flight/confirmedなら同一dispatchを再発行しない。
+
+## 7. WorkRecord同期
+
+bootstrap後のWork Issueを初めて観測したとき、typed Issue/Project snapshotから`PLANNED` WorkRecordを作成しV2へmigrateする。
+
+Issue commentやCheckpoint文からrevision・PR・HEAD・次transitionを復元しない。
+
+GitHub WorkがclosedなのにDBが未完了等の矛盾は静かに上書きせずtyped conflictとする。
+
+## 8. Goal completion候補
+
+`actionable Workなし`だけではGoal完了にしない。
+
+- 全Work terminal
+- pending/uncertain effectなし
+- active lineageなし
+- required Human Verification pendingなし
+- Goal acceptance evidence complete
+
+をfresh evidenceで満たす場合だけ`COMPLETE_GOAL`候補を返す。
+
+## 9. 実装
+
+- `v2_supervisor.py`: pure state derivation / selection / ScheduleKey
+- `v2_work_queue.py`: GitHub planning discovery / typed snapshot / WorkRecord migration
+- `v2_work_definition.py`: typed snapshot readをpublic adapter contractへ昇格
+- tests: continuity / wait中別Work / dependency / conflict / duplicate / restart / goal completion
+
+## 10. 完了条件
+
+- current WorkをIssue commentから解析しない。
+- dependency-ready/actionableを決定論的に選択する。
+- wait-only Workが独立Workを止めない。
+- 同じexact state/transitionを重複dispatchしない。
+- bootstrap Workをtyped snapshotからV2 WorkRecordへ同期できる。
+- conflictでfail-closedする。
+- Work完了後に次WorkまたはGoal completion候補へ進む。

--- a/src/loop_engineering/v2_supervisor.py
+++ b/src/loop_engineering/v2_supervisor.py
@@ -1,0 +1,261 @@
+"""V2のtyped observationからcurrent Workと次transitionを決定する。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+
+_PRIORITY = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+
+
+class EvidenceState(str, Enum):
+    NOT_RUN = "NOT_RUN"
+    PENDING = "PENDING"
+    PASS = "PASS"
+    FAIL = "FAIL"
+    REQUEST_CHANGES = "REQUEST_CHANGES"
+    NOT_REQUIRED = "NOT_REQUIRED"
+
+
+class V2Transition(str, Enum):
+    DESIGN = "DESIGN"
+    IMPLEMENT = "IMPLEMENT"
+    VERIFY = "VERIFY"
+    REVIEW = "REVIEW"
+    HUMAN_VERIFY = "HUMAN_VERIFY"
+    REPAIR = "REPAIR"
+    INTEGRATE = "INTEGRATE"
+    COMPLETE_WORK = "COMPLETE_WORK"
+
+
+class V2SupervisorDisposition(str, Enum):
+    CONTINUE = "CONTINUE"
+    YIELD_EXTERNAL = "YIELD_EXTERNAL"
+    INTERVENTION_REQUIRED = "INTERVENTION_REQUIRED"
+    COMPLETE_GOAL = "COMPLETE_GOAL"
+
+
+@dataclass(frozen=True, slots=True)
+class V2WorkObservation:
+    work_identity: str
+    issue_number: int
+    issue_revision: str
+    issue_state: str
+    project_status: str | None
+    priority: str | None
+    dependency_states: tuple[str, ...]
+    acceptance_digest: str | None
+    canonical_design_identities: tuple[str, ...] = ()
+    active_lineage_identity: str | None = None
+    exact_head_sha: str | None = None
+    verification_state: EvidenceState = EvidenceState.NOT_RUN
+    verification_identity: str | None = None
+    review_state: EvidenceState = EvidenceState.NOT_RUN
+    review_identity: str | None = None
+    human_verification_required: bool = False
+    human_verification_state: EvidenceState = EvidenceState.NOT_REQUIRED
+    human_verification_identity: str | None = None
+    merged: bool = False
+    unresolved_conflict: bool = False
+    latest_packet_identity: str | None = None
+    latest_checkpoint_identity: str | None = None
+
+    @property
+    def dependency_ready(self) -> bool:
+        return all(state == "CLOSED" for state in self.dependency_states)
+
+    @property
+    def terminal(self) -> bool:
+        return self.issue_state == "CLOSED" or self.merged
+
+
+@dataclass(frozen=True, slots=True)
+class V2SupervisorDecision:
+    disposition: V2SupervisorDisposition
+    work_identity: str | None
+    transition: V2Transition | None
+    schedule_key: str | None
+    detail: str
+
+
+class V2Supervisor:
+    """provider通信を持たないV2 selection / transition decision。"""
+
+    def decide(
+        self,
+        *,
+        goal_revision: str,
+        works: tuple[V2WorkObservation, ...],
+        current_work_identity: str | None = None,
+        dispatched_schedule_keys: frozenset[str] = frozenset(),
+        pending_effect: bool = False,
+        goal_acceptance_complete: bool = False,
+    ) -> V2SupervisorDecision:
+        if not goal_revision:
+            return V2SupervisorDecision(
+                V2SupervisorDisposition.INTERVENTION_REQUIRED,
+                None,
+                None,
+                None,
+                "GOAL_REVISION_INVALID",
+            )
+        if len({work.work_identity for work in works}) != len(works):
+            return V2SupervisorDecision(
+                V2SupervisorDisposition.INTERVENTION_REQUIRED,
+                None,
+                None,
+                None,
+                "WORK_IDENTITY_CONFLICT",
+            )
+
+        decisions = {work.work_identity: derive_transition(work) for work in works}
+        selected = self._select(works, decisions, current_work_identity)
+        if selected is not None:
+            transition = decisions[selected.work_identity]
+            assert transition is not None
+            key = schedule_key(goal_revision, selected, transition)
+            if key in dispatched_schedule_keys:
+                return V2SupervisorDecision(
+                    V2SupervisorDisposition.YIELD_EXTERNAL,
+                    selected.work_identity,
+                    transition,
+                    key,
+                    "DUPLICATE_SCHEDULE_SUPPRESSED",
+                )
+            return V2SupervisorDecision(
+                V2SupervisorDisposition.CONTINUE,
+                selected.work_identity,
+                transition,
+                key,
+                "ACTIONABLE_WORK_SELECTED",
+            )
+
+        conflicts = [work for work in works if work.unresolved_conflict]
+        if conflicts:
+            return V2SupervisorDecision(
+                V2SupervisorDisposition.INTERVENTION_REQUIRED,
+                None,
+                None,
+                None,
+                "UNRESOLVED_WORK_CONFLICT",
+            )
+        if (
+            works
+            and all(work.terminal for work in works)
+            and not pending_effect
+            and goal_acceptance_complete
+        ):
+            return V2SupervisorDecision(
+                V2SupervisorDisposition.COMPLETE_GOAL,
+                None,
+                None,
+                None,
+                "GOAL_COMPLETION_EVIDENCE_COMPLETE",
+            )
+        return V2SupervisorDecision(
+            V2SupervisorDisposition.YIELD_EXTERNAL,
+            None,
+            None,
+            None,
+            "NO_ACTIONABLE_WORK",
+        )
+
+    def _select(
+        self,
+        works: tuple[V2WorkObservation, ...],
+        decisions: dict[str, V2Transition | None],
+        current_work_identity: str | None,
+    ) -> V2WorkObservation | None:
+        current = next(
+            (work for work in works if work.work_identity == current_work_identity),
+            None,
+        )
+        if current is not None and decisions[current.work_identity] is not None:
+            return current
+        candidates = [
+            work
+            for work in works
+            if decisions[work.work_identity] is not None and not work.unresolved_conflict
+        ]
+        if not candidates:
+            return None
+        return min(candidates, key=_selection_key)
+
+
+def derive_transition(work: V2WorkObservation) -> V2Transition | None:
+    """1 Workのtyped stateから次actionable transitionだけを導出する。"""
+    if work.unresolved_conflict or not work.dependency_ready:
+        return None
+    if work.terminal:
+        return V2Transition.COMPLETE_WORK if work.issue_state != "CLOSED" else None
+    if not work.acceptance_digest:
+        return None
+    if not work.canonical_design_identities:
+        return V2Transition.DESIGN
+    if work.exact_head_sha is None:
+        return V2Transition.IMPLEMENT
+    if work.verification_state is EvidenceState.FAIL:
+        return V2Transition.REPAIR
+    if work.verification_state is EvidenceState.NOT_RUN:
+        return V2Transition.VERIFY
+    if work.verification_state is EvidenceState.PENDING:
+        return None
+    if work.verification_state is not EvidenceState.PASS:
+        return V2Transition.REPAIR
+    if work.review_state in {EvidenceState.FAIL, EvidenceState.REQUEST_CHANGES}:
+        return V2Transition.REPAIR
+    if work.review_state is EvidenceState.NOT_RUN:
+        return V2Transition.REVIEW
+    if work.review_state is EvidenceState.PENDING:
+        return None
+    if work.review_state is not EvidenceState.PASS:
+        return V2Transition.REPAIR
+    if work.human_verification_required:
+        if work.human_verification_state in {
+            EvidenceState.NOT_RUN,
+            EvidenceState.NOT_REQUIRED,
+        }:
+            return V2Transition.HUMAN_VERIFY
+        if work.human_verification_state is EvidenceState.PENDING:
+            return None
+        if work.human_verification_state is not EvidenceState.PASS:
+            return V2Transition.REPAIR
+    return V2Transition.INTEGRATE
+
+
+def schedule_key(
+    goal_revision: str,
+    work: V2WorkObservation,
+    transition: V2Transition,
+) -> str:
+    state = {
+        "goal_revision": goal_revision,
+        "work_identity": work.work_identity,
+        "issue_revision": work.issue_revision,
+        "project_status": work.project_status,
+        "priority": work.priority,
+        "dependency_states": work.dependency_states,
+        "acceptance_digest": work.acceptance_digest,
+        "canonical_design_identities": work.canonical_design_identities,
+        "active_lineage_identity": work.active_lineage_identity,
+        "exact_head_sha": work.exact_head_sha,
+        "verification": (work.verification_state.value, work.verification_identity),
+        "review": (work.review_state.value, work.review_identity),
+        "human_verification": (
+            work.human_verification_state.value,
+            work.human_verification_identity,
+        ),
+        "latest_packet_identity": work.latest_packet_identity,
+        "latest_checkpoint_identity": work.latest_checkpoint_identity,
+        "transition": transition.value,
+    }
+    encoded = json.dumps(state, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return "schedule:" + hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _selection_key(work: V2WorkObservation) -> tuple[int, int, int]:
+    priority = _PRIORITY.get(work.priority or "", 4)
+    in_progress = 0 if work.project_status == "In progress" else 1
+    return priority, in_progress, work.issue_number

--- a/src/loop_engineering/v2_supervisor.py
+++ b/src/loop_engineering/v2_supervisor.py
@@ -43,6 +43,7 @@ class V2WorkObservation:
     issue_number: int
     issue_revision: str
     issue_state: str
+    lifecycle: str
     project_status: str | None
     priority: str | None
     dependency_states: tuple[str, ...]
@@ -68,7 +69,7 @@ class V2WorkObservation:
 
     @property
     def terminal(self) -> bool:
-        return self.issue_state == "CLOSED" or self.merged
+        return self.lifecycle == "COMPLETED" and self.issue_state == "CLOSED"
 
 
 @dataclass(frozen=True, slots=True)
@@ -189,7 +190,11 @@ def derive_transition(work: V2WorkObservation) -> V2Transition | None:
     if work.unresolved_conflict or not work.dependency_ready:
         return None
     if work.terminal:
-        return V2Transition.COMPLETE_WORK if work.issue_state != "CLOSED" else None
+        return None
+    if work.merged:
+        return V2Transition.COMPLETE_WORK
+    if work.lifecycle == "COMPLETED" or work.issue_state == "CLOSED":
+        return None
     if not work.acceptance_digest:
         return None
     if not work.canonical_design_identities:
@@ -234,6 +239,8 @@ def schedule_key(
         "goal_revision": goal_revision,
         "work_identity": work.work_identity,
         "issue_revision": work.issue_revision,
+        "issue_state": work.issue_state,
+        "lifecycle": work.lifecycle,
         "project_status": work.project_status,
         "priority": work.priority,
         "dependency_states": work.dependency_states,

--- a/src/loop_engineering/v2_work_definition.py
+++ b/src/loop_engineering/v2_work_definition.py
@@ -65,8 +65,12 @@ class GitHubWorkDefinitionAdapter:
         self._runner = runner
         self._project_number = project_number
 
+    def snapshot(self, repository: str, issue_number: int) -> WorkDefinitionSnapshot | None:
+        """本文自然文を解析せず、Issue / Projectのtyped definitionを返す。"""
+        return self._snapshot(repository, issue_number)
+
     def synchronize(self, current: WorkRecord) -> WorkDefinitionResult:
-        snapshot = self._snapshot(current.repository, current.issue_number)
+        snapshot = self.snapshot(current.repository, current.issue_number)
         if snapshot is None:
             return WorkDefinitionResult(WorkDefinitionStatus.UNAVAILABLE)
         if snapshot.issue_state == "CLOSED" and current.lifecycle != "COMPLETED":
@@ -195,20 +199,21 @@ def _dependencies(issue: Mapping[str, object]) -> tuple[tuple[str, ...], tuple[s
     blocked_value = issue.get("blockedBy")
     if not isinstance(blocked_value, dict):
         return None
-    blocked_by = blocked_value
-    page_info = blocked_by.get("pageInfo")
-    nodes = blocked_by.get("nodes")
+    page_info = blocked_value.get("pageInfo")
+    nodes = blocked_value.get("nodes")
     if not isinstance(page_info, dict) or not isinstance(page_info.get("hasNextPage"), bool):
         return None
     if page_info["hasNextPage"]:
         return None
     if not isinstance(nodes, list):
         return None
-    candidates = [node for node in nodes if isinstance(node, dict)]
     identities: list[str] = []
     states: list[str] = []
-    for candidate in candidates:
-        number, state = candidate.get("number"), candidate.get("state")
+    for candidate in nodes:
+        if not isinstance(candidate, dict):
+            continue
+        number = candidate.get("number")
+        state = candidate.get("state")
         dependency_repository = _mapping(candidate, "repository").get("nameWithOwner")
         if isinstance(number, int) and isinstance(state, str):
             identities.append(

--- a/src/loop_engineering/v2_work_queue.py
+++ b/src/loop_engineering/v2_work_queue.py
@@ -9,11 +9,10 @@ from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from typing import Protocol
 
-from .v2_execution_state import V2ExecutionStateStore
 from .v2_goal_planning import ProductDevelopmentRegistration
 from .v2_supervisor import EvidenceState, V2WorkObservation
-from .v2_work_definition import GitHubWorkDefinitionAdapter, WorkDefinitionSnapshot
-from .work_state import PostgreSQLWorkStateStore, WorkRecord, WorkStateUnavailable
+from .v2_work_definition import WorkDefinitionSnapshot
+from .work_state import RecoveredWork, WorkRecord
 
 
 class WorkQueueUnavailable(RuntimeError):
@@ -22,6 +21,22 @@ class WorkQueueUnavailable(RuntimeError):
 
 class WorkQueueCommandRunner(Protocol):
     def run(self, args: Sequence[str]) -> str: ...
+
+
+class WorkDefinitionReaderPort(Protocol):
+    def snapshot(self, repository: str, issue_number: int) -> WorkDefinitionSnapshot | None: ...
+
+
+class ExecutionStatePort(Protocol):
+    def work_record(self, work_identity: str) -> WorkRecord | None: ...
+
+    def migrate_candidate(self, record: WorkRecord) -> bool: ...
+
+
+class WorkStatePort(Protocol):
+    def upsert_work(self, record: WorkRecord) -> None: ...
+
+    def recover(self, work_identity: str) -> RecoveredWork | None: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,9 +52,9 @@ class GitHubV2WorkQueue:
     def __init__(
         self,
         runner: WorkQueueCommandRunner,
-        definitions: GitHubWorkDefinitionAdapter,
-        execution_state: V2ExecutionStateStore,
-        work_state: PostgreSQLWorkStateStore,
+        definitions: WorkDefinitionReaderPort,
+        execution_state: ExecutionStatePort,
+        work_state: WorkStatePort,
     ) -> None:
         self._runner = runner
         self._definitions = definitions
@@ -52,7 +67,7 @@ class GitHubV2WorkQueue:
         current: list[str] = []
         pending_effect = False
 
-        for logical_key, issue_number in issue_keys:
+        for _, issue_number in issue_keys:
             definition = self._definitions.snapshot(
                 registration.repository_identity,
                 issue_number,
@@ -92,7 +107,6 @@ class GitHubV2WorkQueue:
 
             observations.append(
                 _observation(
-                    logical_key=logical_key,
                     definition=definition,
                     record=record,
                     canonical_design_identities=(
@@ -171,13 +185,11 @@ class GitHubV2WorkQueue:
 
 def _observation(
     *,
-    logical_key: str,
     definition: WorkDefinitionSnapshot,
     record: WorkRecord,
     canonical_design_identities: tuple[str, ...],
     unresolved_conflict: bool,
 ) -> V2WorkObservation:
-    del logical_key
     return V2WorkObservation(
         work_identity=record.identity,
         issue_number=record.issue_number,

--- a/src/loop_engineering/v2_work_queue.py
+++ b/src/loop_engineering/v2_work_queue.py
@@ -1,0 +1,199 @@
+"""Goal配下のGitHub Workをtyped snapshotで列挙し、V2 DB状態へ同期する。"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Protocol
+
+from .v2_execution_state import V2ExecutionStateStore
+from .v2_goal_planning import ProductDevelopmentRegistration
+from .v2_supervisor import EvidenceState, V2WorkObservation
+from .v2_work_definition import GitHubWorkDefinitionAdapter, WorkDefinitionSnapshot
+from .work_state import PostgreSQLWorkStateStore, WorkRecord, WorkStateUnavailable
+
+
+class WorkQueueUnavailable(RuntimeError):
+    """Work Queueを安全に観測・同期できない。"""
+
+
+class WorkQueueCommandRunner(Protocol):
+    def run(self, args: Sequence[str]) -> str: ...
+
+
+@dataclass(frozen=True, slots=True)
+class V2WorkQueueSnapshot:
+    works: tuple[V2WorkObservation, ...]
+    current_work_identity: str | None
+    pending_effect: bool
+
+
+class GitHubV2WorkQueue:
+    """bootstrap markerでGoal配下Issueだけを発見し、typed Project定義を読む。"""
+
+    def __init__(
+        self,
+        runner: WorkQueueCommandRunner,
+        definitions: GitHubWorkDefinitionAdapter,
+        execution_state: V2ExecutionStateStore,
+        work_state: PostgreSQLWorkStateStore,
+    ) -> None:
+        self._runner = runner
+        self._definitions = definitions
+        self._execution_state = execution_state
+        self._work_state = work_state
+
+    def synchronize(self, registration: ProductDevelopmentRegistration) -> V2WorkQueueSnapshot:
+        issue_keys = self._discover(registration)
+        observations: list[V2WorkObservation] = []
+        current: list[str] = []
+        pending_effect = False
+
+        for logical_key, issue_number in issue_keys:
+            definition = self._definitions.snapshot(
+                registration.repository_identity,
+                issue_number,
+            )
+            if definition is None:
+                raise WorkQueueUnavailable("WORK_DEFINITION_UNAVAILABLE")
+            if definition.issue_state != "CLOSED" and not definition.acceptance_criteria_digest:
+                raise WorkQueueUnavailable("WORK_ACCEPTANCE_CRITERIA_MISSING")
+            work_identity = f"work:{registration.repository_identity}:{issue_number}"
+            record = self._execution_state.work_record(work_identity)
+            if record is None:
+                candidate = WorkRecord(
+                    identity=work_identity,
+                    repository=registration.repository_identity,
+                    issue_number=issue_number,
+                    issue_revision=definition.revision,
+                    lifecycle="PLANNED",
+                )
+                if not self._execution_state.migrate_candidate(candidate):
+                    raise WorkQueueUnavailable("WORK_MIGRATION_FAILED")
+                record = self._execution_state.work_record(work_identity)
+                if record is None:
+                    raise WorkQueueUnavailable("WORK_MIGRATION_READBACK_FAILED")
+            elif record.issue_revision != definition.revision:
+                updated = replace(record, issue_revision=definition.revision)
+                self._work_state.upsert_work(updated)
+                record = updated
+
+            recovered = self._work_state.recover(work_identity)
+            if recovered is None:
+                raise WorkQueueUnavailable("WORK_STATE_RECOVERY_FAILED")
+            record = recovered.record
+            if record.lifecycle in {"SELECTED", "RUNNING"}:
+                current.append(record.identity)
+            if recovered.pending_effects:
+                pending_effect = True
+
+            observations.append(
+                _observation(
+                    logical_key=logical_key,
+                    definition=definition,
+                    record=record,
+                    canonical_design_identities=(
+                        recovered.task_packet.canonical_design_identities
+                        if recovered.task_packet is not None
+                        else ()
+                    ),
+                    unresolved_conflict=(
+                        definition.issue_state == "CLOSED"
+                        and record.lifecycle != "COMPLETED"
+                    ),
+                )
+            )
+
+        if len(current) > 1:
+            raise WorkQueueUnavailable("MULTIPLE_CURRENT_WORKS")
+        return V2WorkQueueSnapshot(
+            works=tuple(sorted(observations, key=lambda item: item.issue_number)),
+            current_work_identity=current[0] if current else None,
+            pending_effect=pending_effect,
+        )
+
+    def _discover(
+        self,
+        registration: ProductDevelopmentRegistration,
+    ) -> tuple[tuple[str, int], ...]:
+        marker = re.compile(
+            r"<!-- loop-engineering-work:"
+            + re.escape(registration.product_key)
+            + r":"
+            + re.escape(registration.goal_revision)
+            + r":([a-z0-9][a-z0-9-]{0,62}) -->"
+        )
+        try:
+            raw = self._runner.run(
+                (
+                    "gh",
+                    "issue",
+                    "list",
+                    "--repo",
+                    registration.repository_identity,
+                    "--state",
+                    "all",
+                    "--limit",
+                    "1000",
+                    "--json",
+                    "number,body",
+                )
+            )
+            payload = json.loads(raw)
+        except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError) as error:
+            raise WorkQueueUnavailable("WORK_DISCOVERY_FAILED") from error
+        if not isinstance(payload, list):
+            raise WorkQueueUnavailable("WORK_DISCOVERY_INVALID")
+        found: dict[str, int] = {}
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            body = item.get("body")
+            number = item.get("number")
+            if not isinstance(body, str) or not isinstance(number, int):
+                continue
+            matches = marker.findall(body)
+            if len(matches) > 1:
+                raise WorkQueueUnavailable("WORK_MARKER_INVALID")
+            if not matches:
+                continue
+            logical_key = matches[0]
+            if logical_key in found:
+                raise WorkQueueUnavailable("WORK_LOGICAL_IDENTITY_CONFLICT")
+            found[logical_key] = number
+        if not found:
+            raise WorkQueueUnavailable("GOAL_WORKS_NOT_FOUND")
+        return tuple(sorted(found.items(), key=lambda item: item[1]))
+
+
+def _observation(
+    *,
+    logical_key: str,
+    definition: WorkDefinitionSnapshot,
+    record: WorkRecord,
+    canonical_design_identities: tuple[str, ...],
+    unresolved_conflict: bool,
+) -> V2WorkObservation:
+    del logical_key
+    return V2WorkObservation(
+        work_identity=record.identity,
+        issue_number=record.issue_number,
+        issue_revision=definition.revision,
+        issue_state=definition.issue_state,
+        lifecycle=record.lifecycle,
+        project_status=definition.project_status,
+        priority=definition.priority,
+        dependency_states=definition.dependency_states,
+        acceptance_digest=definition.acceptance_criteria_digest,
+        canonical_design_identities=canonical_design_identities,
+        active_lineage_identity=record.active_lineage_identity,
+        latest_packet_identity=record.latest_task_packet_identity,
+        latest_checkpoint_identity=record.latest_checkpoint_identity,
+        verification_state=EvidenceState.NOT_RUN,
+        review_state=EvidenceState.NOT_RUN,
+        human_verification_state=EvidenceState.NOT_REQUIRED,
+        unresolved_conflict=unresolved_conflict,
+    )

--- a/tests/loop_engineering/test_v2_supervisor.py
+++ b/tests/loop_engineering/test_v2_supervisor.py
@@ -1,0 +1,134 @@
+from dataclasses import replace
+
+from loop_engineering.v2_supervisor import (
+    EvidenceState,
+    V2Supervisor,
+    V2SupervisorDisposition,
+    V2Transition,
+    V2WorkObservation,
+    derive_transition,
+    schedule_key,
+)
+
+
+def work(issue: int, **overrides: object) -> V2WorkObservation:
+    base = V2WorkObservation(
+        work_identity=f"work:owner/repo:{issue}",
+        issue_number=issue,
+        issue_revision=f"definition:{issue}",
+        issue_state="OPEN",
+        lifecycle="PLANNED",
+        project_status="Backlog",
+        priority="P1",
+        dependency_states=(),
+        acceptance_digest=f"digest:{issue}",
+    )
+    return replace(base, **overrides)
+
+
+def test_missing_design_selects_design_transition() -> None:
+    target = work(1)
+
+    decision = V2Supervisor().decide(goal_revision="rev-1", works=(target,))
+
+    assert decision.disposition is V2SupervisorDisposition.CONTINUE
+    assert decision.work_identity == target.work_identity
+    assert decision.transition is V2Transition.DESIGN
+
+
+def test_wait_only_current_work_does_not_block_other_actionable_work() -> None:
+    waiting = work(
+        1,
+        canonical_design_identities=("design:a",),
+        exact_head_sha="a" * 40,
+        verification_state=EvidenceState.PENDING,
+        project_status="In progress",
+        priority="P0",
+        lifecycle="RUNNING",
+    )
+    actionable = work(2, priority="P2")
+
+    decision = V2Supervisor().decide(
+        goal_revision="rev-1",
+        works=(waiting, actionable),
+        current_work_identity=waiting.work_identity,
+    )
+
+    assert decision.work_identity == actionable.work_identity
+    assert decision.transition is V2Transition.DESIGN
+
+
+def test_dependency_pending_is_wait_only() -> None:
+    target = work(1, dependency_states=("OPEN",))
+
+    decision = V2Supervisor().decide(goal_revision="rev-1", works=(target,))
+
+    assert decision.disposition is V2SupervisorDisposition.YIELD_EXTERNAL
+    assert decision.work_identity is None
+
+
+def test_review_request_changes_returns_same_work_to_repair() -> None:
+    target = work(
+        1,
+        canonical_design_identities=("design:a",),
+        exact_head_sha="a" * 40,
+        verification_state=EvidenceState.PASS,
+        review_state=EvidenceState.REQUEST_CHANGES,
+    )
+
+    assert derive_transition(target) is V2Transition.REPAIR
+
+
+def test_human_verification_is_required_before_integrate() -> None:
+    target = work(
+        1,
+        canonical_design_identities=("design:a",),
+        exact_head_sha="a" * 40,
+        verification_state=EvidenceState.PASS,
+        review_state=EvidenceState.PASS,
+        human_verification_required=True,
+        human_verification_state=EvidenceState.NOT_RUN,
+    )
+
+    assert derive_transition(target) is V2Transition.HUMAN_VERIFY
+
+
+def test_duplicate_schedule_is_suppressed() -> None:
+    target = work(1)
+    key = schedule_key("rev-1", target, V2Transition.DESIGN)
+
+    decision = V2Supervisor().decide(
+        goal_revision="rev-1",
+        works=(target,),
+        dispatched_schedule_keys=frozenset({key}),
+    )
+
+    assert decision.disposition is V2SupervisorDisposition.YIELD_EXTERNAL
+    assert decision.detail == "DUPLICATE_SCHEDULE_SUPPRESSED"
+
+
+def test_unresolved_conflict_requires_intervention_when_nothing_else_is_actionable() -> None:
+    target = work(1, unresolved_conflict=True)
+
+    decision = V2Supervisor().decide(goal_revision="rev-1", works=(target,))
+
+    assert decision.disposition is V2SupervisorDisposition.INTERVENTION_REQUIRED
+    assert decision.detail == "UNRESOLVED_WORK_CONFLICT"
+
+
+def test_goal_completion_requires_terminal_work_and_acceptance_evidence() -> None:
+    target = work(1, issue_state="CLOSED", lifecycle="COMPLETED")
+
+    incomplete = V2Supervisor().decide(
+        goal_revision="rev-1",
+        works=(target,),
+        goal_acceptance_complete=False,
+    )
+    complete = V2Supervisor().decide(
+        goal_revision="rev-1",
+        works=(target,),
+        goal_acceptance_complete=True,
+    )
+
+    assert incomplete.disposition is V2SupervisorDisposition.YIELD_EXTERNAL
+    assert complete.disposition is V2SupervisorDisposition.COMPLETE_GOAL

--- a/tests/loop_engineering/test_v2_supervisor.py
+++ b/tests/loop_engineering/test_v2_supervisor.py
@@ -1,5 +1,3 @@
-from dataclasses import replace
-
 from loop_engineering.v2_supervisor import (
     EvidenceState,
     V2Supervisor,
@@ -11,19 +9,40 @@ from loop_engineering.v2_supervisor import (
 )
 
 
-def work(issue: int, **overrides: object) -> V2WorkObservation:
-    base = V2WorkObservation(
+def work(
+    issue: int,
+    *,
+    issue_state: str = "OPEN",
+    lifecycle: str = "PLANNED",
+    project_status: str | None = "Backlog",
+    priority: str | None = "P1",
+    dependency_states: tuple[str, ...] = (),
+    canonical_design_identities: tuple[str, ...] = (),
+    exact_head_sha: str | None = None,
+    verification_state: EvidenceState = EvidenceState.NOT_RUN,
+    review_state: EvidenceState = EvidenceState.NOT_RUN,
+    human_verification_required: bool = False,
+    human_verification_state: EvidenceState = EvidenceState.NOT_REQUIRED,
+    unresolved_conflict: bool = False,
+) -> V2WorkObservation:
+    return V2WorkObservation(
         work_identity=f"work:owner/repo:{issue}",
         issue_number=issue,
         issue_revision=f"definition:{issue}",
-        issue_state="OPEN",
-        lifecycle="PLANNED",
-        project_status="Backlog",
-        priority="P1",
-        dependency_states=(),
+        issue_state=issue_state,
+        lifecycle=lifecycle,
+        project_status=project_status,
+        priority=priority,
+        dependency_states=dependency_states,
         acceptance_digest=f"digest:{issue}",
+        canonical_design_identities=canonical_design_identities,
+        exact_head_sha=exact_head_sha,
+        verification_state=verification_state,
+        review_state=review_state,
+        human_verification_required=human_verification_required,
+        human_verification_state=human_verification_state,
+        unresolved_conflict=unresolved_conflict,
     )
-    return replace(base, **overrides)
 
 
 def test_missing_design_selects_design_transition() -> None:

--- a/tests/loop_engineering/test_v2_work_queue.py
+++ b/tests/loop_engineering/test_v2_work_queue.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
@@ -13,8 +14,9 @@ class FakeRunner:
     def __init__(self, issues: list[dict[str, object]]) -> None:
         self.issues = issues
 
-    def run(self, args: tuple[str, ...]) -> str:
-        assert args[:3] == ("gh", "issue", "list")
+    def run(self, args: Sequence[str]) -> str:
+        command = tuple(args)
+        assert command[:3] == ("gh", "issue", "list")
         return json.dumps(self.issues)
 
 

--- a/tests/loop_engineering/test_v2_work_queue.py
+++ b/tests/loop_engineering/test_v2_work_queue.py
@@ -1,0 +1,188 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from loop_engineering.v2_goal_planning import ProductDevelopmentRegistration
+from loop_engineering.v2_work_definition import WorkDefinitionSnapshot
+from loop_engineering.v2_work_queue import GitHubV2WorkQueue, WorkQueueUnavailable
+from loop_engineering.work_state import RecoveredWork, WorkRecord
+
+
+class FakeRunner:
+    def __init__(self, issues: list[dict[str, object]]) -> None:
+        self.issues = issues
+
+    def run(self, args: tuple[str, ...]) -> str:
+        assert args[:3] == ("gh", "issue", "list")
+        return json.dumps(self.issues)
+
+
+class FakeDefinitions:
+    def __init__(self, definitions: dict[int, WorkDefinitionSnapshot]) -> None:
+        self.definitions = definitions
+
+    def snapshot(self, repository: str, issue_number: int) -> WorkDefinitionSnapshot | None:
+        result = self.definitions.get(issue_number)
+        if result is not None:
+            assert result.repository == repository
+        return result
+
+
+class FakeExecutionState:
+    def __init__(self) -> None:
+        self.records: dict[str, WorkRecord] = {}
+
+    def work_record(self, work_identity: str) -> WorkRecord | None:
+        return self.records.get(work_identity)
+
+    def migrate_candidate(self, record: WorkRecord) -> bool:
+        self.records.setdefault(record.identity, record)
+        return True
+
+
+class FakeWorkState:
+    def __init__(self, execution: FakeExecutionState) -> None:
+        self.execution = execution
+
+    def upsert_work(self, record: WorkRecord) -> None:
+        self.execution.records[record.identity] = record
+
+    def recover(self, work_identity: str) -> RecoveredWork | None:
+        record = self.execution.records.get(work_identity)
+        return RecoveredWork(record, None, None, ()) if record is not None else None
+
+
+def registration() -> ProductDevelopmentRegistration:
+    return ProductDevelopmentRegistration(
+        product_key="sample",
+        workspace_canonical_path=Path("/tmp/sample"),
+        repository_identity="owner/sample",
+        project_owner="owner",
+        project_number=10,
+        trunk_branch="main",
+        goal_definition_identity="goal:sample",
+        goal_revision="rev-1",
+        goal_text="Sample Goal",
+        acceptance_criteria=("done",),
+        work_branch_template="feature/work-{issue}",
+        ci_workflow_name="CI",
+        initial_project_status="Backlog",
+    )
+
+
+def definition(
+    issue: int,
+    *,
+    state: str = "OPEN",
+    dependencies: tuple[str, ...] = (),
+    dependency_states: tuple[str, ...] = (),
+) -> WorkDefinitionSnapshot:
+    return WorkDefinitionSnapshot(
+        repository="owner/sample",
+        issue_number=issue,
+        issue_state=state,
+        acceptance_criteria_digest=f"digest-{issue}" if state == "OPEN" else None,
+        dependency_identities=dependencies,
+        dependency_states=dependency_states,
+        project_status="Backlog",
+        priority="P1",
+        start_date=None,
+        target_date=None,
+    )
+
+
+def test_synchronize_discovers_bootstrap_works_and_creates_work_records() -> None:
+    marker1 = "<!-- loop-engineering-work:sample:rev-1:first -->"
+    marker2 = "<!-- loop-engineering-work:sample:rev-1:second -->"
+    runner = FakeRunner(
+        [
+            {"number": 1, "body": marker1},
+            {"number": 2, "body": marker2},
+            {"number": 3, "body": "unrelated"},
+        ]
+    )
+    execution = FakeExecutionState()
+    queue = GitHubV2WorkQueue(
+        runner,
+        FakeDefinitions({1: definition(1), 2: definition(2)}),
+        execution,
+        FakeWorkState(execution),
+    )
+
+    snapshot = queue.synchronize(registration())
+
+    assert [item.issue_number for item in snapshot.works] == [1, 2]
+    assert snapshot.current_work_identity is None
+    assert set(execution.records) == {"work:owner/sample:1", "work:owner/sample:2"}
+
+
+def test_synchronize_preserves_current_work_and_updates_issue_revision() -> None:
+    marker = "<!-- loop-engineering-work:sample:rev-1:first -->"
+    execution = FakeExecutionState()
+    execution.records["work:owner/sample:1"] = WorkRecord(
+        identity="work:owner/sample:1",
+        repository="owner/sample",
+        issue_number=1,
+        issue_revision="old",
+        lifecycle="RUNNING",
+    )
+    queue = GitHubV2WorkQueue(
+        FakeRunner([{"number": 1, "body": marker}]),
+        FakeDefinitions({1: definition(1)}),
+        execution,
+        FakeWorkState(execution),
+    )
+
+    snapshot = queue.synchronize(registration())
+
+    assert snapshot.current_work_identity == "work:owner/sample:1"
+    assert execution.records["work:owner/sample:1"].issue_revision == definition(1).revision
+
+
+def test_multiple_current_works_fail_closed() -> None:
+    execution = FakeExecutionState()
+    for issue in (1, 2):
+        execution.records[f"work:owner/sample:{issue}"] = WorkRecord(
+            identity=f"work:owner/sample:{issue}",
+            repository="owner/sample",
+            issue_number=issue,
+            issue_revision=f"old-{issue}",
+            lifecycle="RUNNING",
+        )
+    queue = GitHubV2WorkQueue(
+        FakeRunner(
+            [
+                {"number": 1, "body": "<!-- loop-engineering-work:sample:rev-1:first -->"},
+                {"number": 2, "body": "<!-- loop-engineering-work:sample:rev-1:second -->"},
+            ]
+        ),
+        FakeDefinitions({1: definition(1), 2: definition(2)}),
+        execution,
+        FakeWorkState(execution),
+    )
+
+    with pytest.raises(WorkQueueUnavailable, match="MULTIPLE_CURRENT_WORKS"):
+        queue.synchronize(registration())
+
+
+def test_closed_issue_with_noncompleted_db_state_is_conflict() -> None:
+    marker = "<!-- loop-engineering-work:sample:rev-1:first -->"
+    execution = FakeExecutionState()
+    execution.records["work:owner/sample:1"] = WorkRecord(
+        identity="work:owner/sample:1",
+        repository="owner/sample",
+        issue_number=1,
+        issue_revision="old",
+        lifecycle="RUNNING",
+    )
+    queue = GitHubV2WorkQueue(
+        FakeRunner([{"number": 1, "body": marker}]),
+        FakeDefinitions({1: definition(1, state="CLOSED")}),
+        execution,
+        FakeWorkState(execution),
+    )
+
+    snapshot = queue.synchronize(registration())
+
+    assert snapshot.works[0].unresolved_conflict is True


### PR DESCRIPTION
## 関連Issue

Closes #84
Parent manufacturing: #81
Depends on: #83

## 設計

`docs/architecture/v2/supervisor_scheduler_state_machine.md` を先行追加し、GitHub planning AuthorityとPostgreSQL execution stateからcurrent Work / next transitionを自然文解析なしで決定する契約を確定した。

## 実装

- `v2_work_definition.py`: typed snapshotをpublic read契約へ昇格
- `v2_work_queue.py`: bootstrap Work discovery、WorkRecord初期化、revision同期、current Work/pending effect復元
- `v2_supervisor.py`: dependency-ready/actionable分離、current continuity、priority selection、transition導出、ScheduleKey、Goal completion候補
- Issue closedとDB lifecycle completedを別Authorityとして扱い、不一致は競合にする

## 検証

- DESIGN選択
- wait-only currentから別Workへ継続
- dependency pending
- REQUEST_CHANGES→REPAIR
- Human Verification gate
- duplicate schedule抑止
- unresolved conflict
- Goal completion
- bootstrap Work→WorkRecord同期
- revision更新/current Work復元
- multiple current Work fail-closed
- closed Issue / noncompleted DB conflict

旧Issue comment current-state解析は使用しない。