### PR TITLE
feat: V2 Codex Implementerをproposal modeへ分離する

### DIFF
--- a/docs/architecture/v2/codex_implementer_proposal_mode.md
+++ b/docs/architecture/v2/codex_implementer_proposal_mode.md
@@ -1,0 +1,180 @@
+# V2 Codex Implementer proposal mode仕様
+
+管理Issue: #85
+親Issue: #81
+依存: #84
+上位正本: `autonomous_development_completion_contract.md`
+
+## 1. 目的
+
+V2 Supervisorが決定した `DESIGN` / `IMPLEMENT` / `REPAIR` を、Codexへ安全にdispatchし、Product Workspaceへ直接Git管理effectを発生させずに変更提案を生成する。
+
+CodexはProductのファイル編集者であり、branch / commit / push / PR / review request / merge等のGitHub lifecycle ownerではない。それらは#86の信頼済みHostが担当する。
+
+## 2. 実行方式
+
+標準modeはproposal modeとする。
+
+```text
+DevelopmentTaskPacket
+→ trusted Hostがsource Workspaceをread-only検査
+→ exact base SHAから隔離Git worktreeを作成
+→ Codexを隔離worktree内で実行
+→ local diff / changed paths / checksをreadback
+→ ChangeProposalを返す
+→ 隔離worktreeを削除
+```
+
+Codex自身によるcommit / push / PR作成は許可しない。
+
+## 3. DevelopmentTaskPacket
+
+最低限:
+
+- `packet_identity`
+- `work_identity`
+- `generation`
+- `transition`: `DESIGN | IMPLEMENT | REPAIR`
+- `repository_identity`
+- `workspace_canonical_path`
+- `exact_base_sha`
+- `active_lineage_identity?`
+- `canonical_design_identities[]`
+- `canonical_design_targets[]`
+- `scope_paths[]`
+- `authority_refs[]`
+- `goal_revision`
+- `issue_revision`
+- `acceptance_checks[]`
+- `non_goals[]`
+- `safety_constraints[]`
+
+## 4. transition Gate
+
+### DESIGN
+
+- `canonical_design_targets` が1件以上必要。
+- 成功proposalでは少なくとも1つのdesign targetが変更される。
+- design target外の変更は、TaskPacketのscope内でもDESIGNでは原則拒否する。
+
+### IMPLEMENT
+
+- `canonical_design_identities` が1件以上必要。
+- 設計identityが無いIMPLEMENTはdispatch前に拒否する。
+
+### REPAIR
+
+- `active_lineage_identity` が必要。
+- `canonical_design_identities` が必要。
+- 新lineageを作らず、exact base SHA上の同一lineage修正proposalとして扱う。
+
+## 5. Workspace preflight
+
+source Workspaceについてmutation前に確認する。
+
+- absolute canonical path
+- Git repositoryである
+- `remote.origin.url` がRegistrationのrepository identityと一致
+- source Workspaceがclean
+- `exact_base_sha` がlocal Git objectとして解決可能
+- exact base SHAが40桁hex
+
+source Workspaceのbranchを切替えない。
+
+## 6. 隔離worktree
+
+trusted Hostがsource repositoryのGit metadataを用いて、Product Workspaceの親配下に一時directoryを作り、`git worktree add --detach <temp> <exact_base_sha>` する。
+
+Codexはこの一時worktreeだけを編集する。
+
+実行終了後は成功・失敗に関係なく `git worktree remove --force` を実行し、fresh readbackで登録が消えていることを確認する。
+
+隔離worktree外の削除は行わない。
+
+## 7. Credential境界
+
+Codex childへ次を渡さない。
+
+- `GH_TOKEN`
+- `GITHUB_TOKEN`
+- Reviewer API key
+- `LOOP_POSTGRES_DSN`
+- `LOOP_DATABASE_URL`
+- Trusted Reviewer socket/token
+
+Codex自身の認証に必要な非Reviewer credentialはHost設定のallowlistだけを渡す。
+
+## 8. Prompt契約
+
+Codex promptはTaskPacketから構築し、次を固定で含める。
+
+- 対象Work / transition / exact base
+- Authority refs
+- scope / non-goals / acceptance
+- 設計→実装順序
+- Git branch / commit / push / PR / merge禁止
+- GitHub mutation禁止
+- Reviewer credential利用禁止
+- Product Workspace外編集禁止
+- 人間向け文章は日本語
+
+自由文promptだけを安全境界にせず、実行後readbackでも検証する。
+
+## 9. ChangeProposal
+
+成功結果:
+
+- `packet_identity`
+- `work_identity`
+- `transition`
+- `exact_base_sha`
+- `changed_paths[]`
+- `patch_sha256`
+- `patch_text`
+- `design_targets_changed[]`
+- `diff_check_passed`
+
+成功条件:
+
+- Codex process success
+- HEADがexact baseから変化していない（commit禁止の実証）
+- detached状態を維持
+- changed pathがscope内
+- `git diff --check` PASS
+- patchが空でない
+- transition固有Gate PASS
+
+## 10. failure / cleanup
+
+Codex failure、timeout、scope逸脱、commit検出、diff-check failure等はproposalを返さない。
+
+隔離worktreeを必ずcleanupし、cleanup自体が証明できない場合は `IMPLEMENTER_CLEANUP_UNPROVEN` としてHuman/Host safety blockerへ昇格する。
+
+source Workspaceは実行前後でHEAD / branch / clean stateが変化していないことを確認する。
+
+## 11. #86との境界
+
+#85はpatchを生成するまで。
+
+#86が:
+
+1. active lineage branchを安全に作成/resolve
+2. proposal patchをtrusted Workspaceへ適用
+3. commit / push
+4. PR create/update
+5. fresh GitHub readback
+
+を担当する。
+
+## 12. 完了条件
+
+- DESIGN / IMPLEMENT / REPAIRをtypedに区別できる。
+- DESIGN未完了でIMPLEMENTを拒否できる。
+- REPAIRはactive lineage必須。
+- exact base SHAから隔離worktreeでCodexを実行する。
+- CodexがGit commit/push/PRを行っていないことをreadbackできる。
+- scope逸脱を拒否できる。
+- Reviewer/GitHub/DB credentialをCodexへ渡さない。
+- failure時に隔離worktreeを残さない。
+- source Workspaceを変更しない。
+- tests / exact-head CIがPASSする。

--- a/docs/architecture/v2/codex_implementer_proposal_mode.md
+++ b/docs/architecture/v2/codex_implementer_proposal_mode.md
@@ -134,6 +134,8 @@ Codex promptはTaskPacketから構築し、次を固定で含める。
 - `design_targets_changed[]`
 - `diff_check_passed`
 
+`patch_text` は `git diff --cached --binary --no-ext-diff HEAD` が返したraw UTF-8 textをtrim・改行正規化せず保持する。`patch_sha256` はそのraw textをUTF-8 encodeしたbyte列に対して計算する。patch本文を表示用文字列処理で変形してはならない。
+
 成功条件:
 
 - Codex process success
@@ -175,6 +177,7 @@ source Workspaceは実行前後でHEAD / branch / clean stateが変化してい�
 - CodexがGit commit/push/PRを行っていないことをreadbackできる。
 - scope逸脱を拒否できる。
 - Reviewer/GitHub/DB credentialをCodexへ渡さない。
+- ChangeProposalのraw patch本文とSHA-256 identityを無加工で一致させる。
 - failure時に隔離worktreeを残さない。
 - source Workspaceを変更しない。
 - tests / exact-head CIがPASSする。

--- a/src/loop_engineering/v2_implementer.py
+++ b/src/loop_engineering/v2_implementer.py
@@ -220,11 +220,14 @@ class CodexProposalImplementer:
         diff_check = self._run_git(worktree, ("diff", "--cached", "--check", "HEAD"))
         if not diff_check.succeeded:
             return ImplementerResult(ImplementerStatus.FAILED, "PROPOSAL_DIFF_CHECK_FAILED")
-        patch = self._git_output(
+        patch_result = self._run_git(
             worktree,
             ("diff", "--cached", "--binary", "--no-ext-diff", "HEAD"),
         )
-        if patch is None or not patch:
+        if not patch_result.succeeded:
+            return ImplementerResult(ImplementerStatus.FAILED, "PROPOSAL_PATCH_UNAVAILABLE")
+        patch = patch_result.output
+        if not patch:
             return ImplementerResult(ImplementerStatus.FAILED, "PROPOSAL_PATCH_UNAVAILABLE")
         if len(patch.encode("utf-8")) > _MAX_PATCH_BYTES:
             return ImplementerResult(ImplementerStatus.BLOCKED, "PROPOSAL_PATCH_TOO_LARGE")

--- a/src/loop_engineering/v2_implementer.py
+++ b/src/loop_engineering/v2_implementer.py
@@ -177,7 +177,10 @@ class CodexProposalImplementer:
         before_head = self._git_output(worktree, ("rev-parse", "HEAD"))
         branch = self._git_output(worktree, ("branch", "--show-current"))
         if before_head != packet.exact_base_sha or branch is None or branch.strip():
-            return ImplementerResult(ImplementerStatus.BLOCKED, "ISOLATED_WORKTREE_IDENTITY_INVALID")
+            return ImplementerResult(
+                ImplementerStatus.BLOCKED,
+                "ISOLATED_WORKTREE_IDENTITY_INVALID",
+            )
 
         codex = self._runner.run(
             (*self._codex_argv_prefix, _instruction(packet)),

--- a/src/loop_engineering/v2_implementer.py
+++ b/src/loop_engineering/v2_implementer.py
@@ -1,0 +1,426 @@
+"""V2 TaskPacketをCodex proposal modeで安全に実行する。"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path, PurePosixPath
+from typing import Protocol
+
+_SHA_RE = re.compile(r"[0-9a-f]{40}")
+_MAX_PATCH_BYTES = 2_000_000
+_BASE_ENV_NAMES = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "LANG",
+        "TERM",
+        "COLORTERM",
+        "CODEX_HOME",
+    }
+)
+
+
+class ImplementerTransition(str, Enum):
+    DESIGN = "DESIGN"
+    IMPLEMENT = "IMPLEMENT"
+    REPAIR = "REPAIR"
+
+
+class ImplementerStatus(str, Enum):
+    SUCCESS = "SUCCESS"
+    BLOCKED = "BLOCKED"
+    FAILED = "FAILED"
+
+
+class CommandResultLike(Protocol):
+    @property
+    def returncode(self) -> int: ...
+
+    @property
+    def output(self) -> str: ...
+
+    @property
+    def succeeded(self) -> bool: ...
+
+
+class ImplementerCommandRunner(Protocol):
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        environment: Mapping[str, str] | None = None,
+        timeout_seconds: int = 120,
+        capture_output: bool = True,
+    ) -> CommandResultLike: ...
+
+
+@dataclass(frozen=True, slots=True)
+class DevelopmentTaskPacket:
+    packet_identity: str
+    work_identity: str
+    generation: int
+    transition: ImplementerTransition
+    repository_identity: str
+    workspace_canonical_path: Path
+    exact_base_sha: str
+    goal_revision: str
+    issue_revision: str
+    scope_paths: tuple[str, ...]
+    acceptance_checks: tuple[str, ...]
+    canonical_design_identities: tuple[str, ...] = ()
+    canonical_design_targets: tuple[str, ...] = ()
+    active_lineage_identity: str | None = None
+    authority_refs: tuple[str, ...] = ()
+    non_goals: tuple[str, ...] = ()
+    safety_constraints: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeProposal:
+    packet_identity: str
+    work_identity: str
+    transition: ImplementerTransition
+    exact_base_sha: str
+    changed_paths: tuple[str, ...]
+    patch_sha256: str
+    patch_text: str
+    design_targets_changed: tuple[str, ...]
+    diff_check_passed: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class ImplementerResult:
+    status: ImplementerStatus
+    detail: str
+    proposal: ChangeProposal | None = None
+
+
+class CodexProposalImplementer:
+    """exact HEADの隔離worktreeでCodexを実行し、patchだけを返す。"""
+
+    def __init__(
+        self,
+        runner: ImplementerCommandRunner,
+        codex_argv_prefix: Sequence[str],
+        environment: Mapping[str, str],
+        *,
+        timeout_seconds: int = 1200,
+        environment_allowlist: Sequence[str] = (),
+    ) -> None:
+        if not codex_argv_prefix or any(not item for item in codex_argv_prefix):
+            raise ValueError("CODEX_COMMAND_INVALID")
+        if timeout_seconds < 1 or timeout_seconds > 7200:
+            raise ValueError("CODEX_TIMEOUT_INVALID")
+        self._runner = runner
+        self._codex_argv_prefix = tuple(codex_argv_prefix)
+        self._environment = _sanitized_environment(environment, environment_allowlist)
+        self._timeout_seconds = timeout_seconds
+
+    def execute(self, packet: DevelopmentTaskPacket) -> ImplementerResult:
+        validation = _validate_packet(packet)
+        if validation is not None:
+            return ImplementerResult(ImplementerStatus.BLOCKED, validation)
+
+        workspace = packet.workspace_canonical_path.resolve(strict=False)
+        source = self._inspect_source(workspace, packet)
+        if source is None:
+            return ImplementerResult(ImplementerStatus.BLOCKED, "WORKSPACE_PREFLIGHT_FAILED")
+        source_branch, source_head = source
+
+        temporary = Path(
+            tempfile.mkdtemp(prefix=".loop-codex-", dir=str(workspace.parent))
+        ).resolve(strict=False)
+        worktree_added = False
+        result: ImplementerResult
+        try:
+            added = self._run_git(
+                workspace,
+                ("worktree", "add", "--detach", str(temporary), packet.exact_base_sha),
+                timeout_seconds=180,
+            )
+            if not added.succeeded:
+                result = ImplementerResult(ImplementerStatus.FAILED, "WORKTREE_CREATE_FAILED")
+            else:
+                worktree_added = True
+                result = self._execute_in_worktree(temporary, packet)
+        finally:
+            cleanup_ok = self._cleanup_worktree(workspace, temporary, worktree_added)
+
+        source_ok = self._source_unchanged(
+            workspace,
+            expected_branch=source_branch,
+            expected_head=source_head,
+        )
+        if not cleanup_ok:
+            return ImplementerResult(ImplementerStatus.BLOCKED, "IMPLEMENTER_CLEANUP_UNPROVEN")
+        if not source_ok:
+            return ImplementerResult(ImplementerStatus.BLOCKED, "SOURCE_WORKSPACE_CHANGED")
+        return result
+
+    def _execute_in_worktree(
+        self,
+        worktree: Path,
+        packet: DevelopmentTaskPacket,
+    ) -> ImplementerResult:
+        before_head = self._git_output(worktree, ("rev-parse", "HEAD"))
+        branch = self._git_output(worktree, ("branch", "--show-current"))
+        if before_head != packet.exact_base_sha or branch is None or branch.strip():
+            return ImplementerResult(ImplementerStatus.BLOCKED, "ISOLATED_WORKTREE_IDENTITY_INVALID")
+
+        codex = self._runner.run(
+            (*self._codex_argv_prefix, _instruction(packet)),
+            cwd=worktree,
+            environment=self._environment,
+            timeout_seconds=self._timeout_seconds,
+        )
+        if not codex.succeeded:
+            return ImplementerResult(ImplementerStatus.FAILED, "CODEX_EXECUTION_FAILED")
+
+        after_head = self._git_output(worktree, ("rev-parse", "HEAD"))
+        after_branch = self._git_output(worktree, ("branch", "--show-current"))
+        if after_head != packet.exact_base_sha or after_branch is None or after_branch.strip():
+            return ImplementerResult(ImplementerStatus.BLOCKED, "CODEX_GIT_MUTATION_DETECTED")
+
+        staged = self._run_git(worktree, ("add", "-A"))
+        if not staged.succeeded:
+            return ImplementerResult(ImplementerStatus.FAILED, "PROPOSAL_STAGE_FAILED")
+        changed = self._git_output(worktree, ("diff", "--cached", "--name-only", "HEAD"))
+        if changed is None:
+            return ImplementerResult(ImplementerStatus.FAILED, "PROPOSAL_PATH_READBACK_FAILED")
+        paths = tuple(line.strip() for line in changed.splitlines() if line.strip())
+        if not paths:
+            return ImplementerResult(ImplementerStatus.FAILED, "CODEX_NO_CHANGE")
+        if any(not _path_in_scope(path, packet.scope_paths) for path in paths):
+            return ImplementerResult(ImplementerStatus.BLOCKED, "PROPOSAL_SCOPE_VIOLATION")
+
+        design_changed = tuple(
+            path
+            for path in paths
+            if _path_in_scope(path, packet.canonical_design_targets)
+        )
+        if packet.transition is ImplementerTransition.DESIGN:
+            if not design_changed or len(design_changed) != len(paths):
+                return ImplementerResult(ImplementerStatus.BLOCKED, "DESIGN_SCOPE_VIOLATION")
+
+        diff_check = self._run_git(worktree, ("diff", "--cached", "--check", "HEAD"))
+        if not diff_check.succeeded:
+            return ImplementerResult(ImplementerStatus.FAILED, "PROPOSAL_DIFF_CHECK_FAILED")
+        patch = self._git_output(
+            worktree,
+            ("diff", "--cached", "--binary", "--no-ext-diff", "HEAD"),
+        )
+        if patch is None or not patch:
+            return ImplementerResult(ImplementerStatus.FAILED, "PROPOSAL_PATCH_UNAVAILABLE")
+        if len(patch.encode("utf-8")) > _MAX_PATCH_BYTES:
+            return ImplementerResult(ImplementerStatus.BLOCKED, "PROPOSAL_PATCH_TOO_LARGE")
+
+        proposal = ChangeProposal(
+            packet_identity=packet.packet_identity,
+            work_identity=packet.work_identity,
+            transition=packet.transition,
+            exact_base_sha=packet.exact_base_sha,
+            changed_paths=paths,
+            patch_sha256=hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+            patch_text=patch,
+            design_targets_changed=design_changed,
+        )
+        return ImplementerResult(ImplementerStatus.SUCCESS, "CHANGE_PROPOSAL_READY", proposal)
+
+    def _inspect_source(
+        self,
+        workspace: Path,
+        packet: DevelopmentTaskPacket,
+    ) -> tuple[str, str] | None:
+        if not workspace.is_absolute() or not workspace.is_dir():
+            return None
+        top = self._git_output(workspace, ("rev-parse", "--show-toplevel"))
+        if top is None or Path(top).resolve(strict=False) != workspace:
+            return None
+        remote = self._git_output(workspace, ("remote", "get-url", "origin"))
+        if remote is None or not _remote_matches(remote, packet.repository_identity):
+            return None
+        status = self._git_output(workspace, ("status", "--porcelain"))
+        if status is None or status.strip():
+            return None
+        object_check = self._run_git(
+            workspace,
+            ("cat-file", "-e", f"{packet.exact_base_sha}^{{commit}}"),
+        )
+        if not object_check.succeeded:
+            return None
+        branch = self._git_output(workspace, ("branch", "--show-current"))
+        head = self._git_output(workspace, ("rev-parse", "HEAD"))
+        if branch is None or head is None:
+            return None
+        return branch, head
+
+    def _source_unchanged(
+        self,
+        workspace: Path,
+        *,
+        expected_branch: str,
+        expected_head: str,
+    ) -> bool:
+        branch = self._git_output(workspace, ("branch", "--show-current"))
+        head = self._git_output(workspace, ("rev-parse", "HEAD"))
+        status = self._git_output(workspace, ("status", "--porcelain"))
+        return branch == expected_branch and head == expected_head and status == ""
+
+    def _cleanup_worktree(
+        self,
+        workspace: Path,
+        temporary: Path,
+        worktree_added: bool,
+    ) -> bool:
+        if worktree_added:
+            removed = self._run_git(
+                workspace,
+                ("worktree", "remove", "--force", str(temporary)),
+                timeout_seconds=180,
+            )
+            if not removed.succeeded:
+                return False
+        elif temporary.exists():
+            try:
+                temporary.rmdir()
+            except OSError:
+                return False
+        listing = self._git_output(workspace, ("worktree", "list", "--porcelain"))
+        if listing is None or str(temporary) in listing:
+            return False
+        return not temporary.exists()
+
+    def _run_git(
+        self,
+        root: Path,
+        arguments: Sequence[str],
+        *,
+        timeout_seconds: int = 120,
+    ) -> CommandResultLike:
+        return self._runner.run(
+            ("git", "-C", str(root), *arguments),
+            environment=self._environment,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def _git_output(self, root: Path, arguments: Sequence[str]) -> str | None:
+        result = self._run_git(root, arguments)
+        return result.output.strip() if result.succeeded else None
+
+
+def _validate_packet(packet: DevelopmentTaskPacket) -> str | None:
+    if (
+        not packet.packet_identity
+        or not packet.work_identity
+        or packet.generation < 1
+        or "/" not in packet.repository_identity
+        or not packet.goal_revision
+        or not packet.issue_revision
+        or _SHA_RE.fullmatch(packet.exact_base_sha) is None
+    ):
+        return "TASK_PACKET_IDENTITY_INVALID"
+    if not packet.workspace_canonical_path.is_absolute():
+        return "TASK_PACKET_WORKSPACE_INVALID"
+    if not packet.scope_paths or any(not _safe_relative_path(path) for path in packet.scope_paths):
+        return "TASK_PACKET_SCOPE_INVALID"
+    if any(not _safe_relative_path(path) for path in packet.canonical_design_targets):
+        return "TASK_PACKET_DESIGN_TARGET_INVALID"
+    if not packet.acceptance_checks or any(not item.strip() for item in packet.acceptance_checks):
+        return "TASK_PACKET_ACCEPTANCE_INVALID"
+    if packet.transition is ImplementerTransition.DESIGN and not packet.canonical_design_targets:
+        return "DESIGN_TARGET_REQUIRED"
+    if packet.transition in {ImplementerTransition.IMPLEMENT, ImplementerTransition.REPAIR}:
+        if not packet.canonical_design_identities:
+            return "CANONICAL_DESIGN_REQUIRED"
+    if packet.transition is ImplementerTransition.REPAIR and not packet.active_lineage_identity:
+        return "ACTIVE_LINEAGE_REQUIRED"
+    return None
+
+
+def _safe_relative_path(value: str) -> bool:
+    if not value or value != value.strip() or "\\" in value or "\x00" in value:
+        return False
+    path = PurePosixPath(value)
+    return not path.is_absolute() and ".." not in path.parts and value not in {".", "./"}
+
+
+def _path_in_scope(path: str, scopes: tuple[str, ...]) -> bool:
+    for scope in scopes:
+        normalized = scope.rstrip("/")
+        if path == normalized or path.startswith(normalized + "/"):
+            return True
+    return False
+
+
+def _remote_matches(remote: str, repository_identity: str) -> bool:
+    expected = repository_identity.removesuffix(".git")
+    value = remote.strip().removesuffix(".git")
+    if value == expected:
+        return True
+    if value.endswith("/" + expected):
+        return True
+    return value.endswith(":" + expected)
+
+
+def _sanitized_environment(
+    environment: Mapping[str, str],
+    extra_allowlist: Sequence[str],
+) -> dict[str, str]:
+    allowed = set(_BASE_ENV_NAMES)
+    allowed.update(extra_allowlist)
+    allowed.update(name for name in environment if name.startswith("LC_"))
+    allowed.update(name for name in environment if name.startswith("XDG_"))
+    forbidden = {
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "LOOP_POSTGRES_DSN",
+        "LOOP_DATABASE_URL",
+        "OPENAI_API_KEY",
+        "OPENAI_API_KEY_REVIEWER",
+        "LOOP_TRUSTED_REVIEWER_SOCKET",
+    }
+    return {
+        name: value
+        for name, value in environment.items()
+        if name in allowed and name not in forbidden and "REVIEWER" not in name
+    }
+
+
+def _instruction(packet: DevelopmentTaskPacket) -> str:
+    authority = ", ".join(packet.authority_refs) or packet.repository_identity
+    scope = ", ".join(packet.scope_paths)
+    acceptance = "\n".join(f"- {item}" for item in packet.acceptance_checks)
+    non_goals = "\n".join(f"- {item}" for item in packet.non_goals) or "- なし"
+    safety = "\n".join(f"- {item}" for item in packet.safety_constraints) or "- 追加なし"
+    design_targets = ", ".join(packet.canonical_design_targets) or "なし"
+    return (
+        f"Loop Engineeringの{packet.transition.value}遷移を1回だけ実行してください。\n"
+        f"Work: {packet.work_identity}\n"
+        f"exact base: {packet.exact_base_sha}\n"
+        f"Authority: {authority}\n"
+        f"変更可能scope: {scope}\n"
+        f"canonical design target: {design_targets}\n"
+        "受入条件:\n"
+        f"{acceptance}\n"
+        "対象外:\n"
+        f"{non_goals}\n"
+        "追加安全条件:\n"
+        f"{safety}\n"
+        "設計→実装の順序を守り、人間向け文章は日本語で記述してください。\n"
+        "Git branch作成・切替、commit、push、rebase、force push、PR作成・更新、merge、"
+        "GitHub Issue/Projectへの書込みを行わないでください。\n"
+        "レビューワー認証情報やDB credentialを探索・利用せず、このworktree内の"
+        "ファイル編集と必要なローカル検証だけを行ってください。"
+    )

--- a/tests/loop_engineering/test_v2_implementer.py
+++ b/tests/loop_engineering/test_v2_implementer.py
@@ -1,6 +1,6 @@
 import hashlib
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from loop_engineering.v2_implementer import (
@@ -163,13 +163,8 @@ def test_design_returns_scoped_patch_and_strips_credentials(tmp_path: Path) -> N
 
 
 def test_implement_requires_canonical_design(tmp_path: Path) -> None:
-    task = packet(tmp_path, ImplementerTransition.IMPLEMENT)
-    task = DevelopmentTaskPacket(
-        **{
-            field: getattr(task, field)
-            for field in task.__dataclass_fields__
-            if field != "canonical_design_identities"
-        },
+    task = replace(
+        packet(tmp_path, ImplementerTransition.IMPLEMENT),
         canonical_design_identities=(),
     )
     runner = FakeRunner(task.workspace_canonical_path, exact_base=task.exact_base_sha)
@@ -182,13 +177,8 @@ def test_implement_requires_canonical_design(tmp_path: Path) -> None:
 
 
 def test_repair_requires_active_lineage(tmp_path: Path) -> None:
-    task = packet(tmp_path, ImplementerTransition.REPAIR)
-    task = DevelopmentTaskPacket(
-        **{
-            field: getattr(task, field)
-            for field in task.__dataclass_fields__
-            if field != "active_lineage_identity"
-        },
+    task = replace(
+        packet(tmp_path, ImplementerTransition.REPAIR),
         active_lineage_identity=None,
     )
     runner = FakeRunner(task.workspace_canonical_path, exact_base=task.exact_base_sha)

--- a/tests/loop_engineering/test_v2_implementer.py
+++ b/tests/loop_engineering/test_v2_implementer.py
@@ -1,0 +1,257 @@
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from loop_engineering.v2_implementer import (
+    CodexProposalImplementer,
+    DevelopmentTaskPacket,
+    ImplementerStatus,
+    ImplementerTransition,
+)
+
+
+@dataclass(frozen=True)
+class Result:
+    returncode: int
+    output: str = ""
+
+    @property
+    def succeeded(self) -> bool:
+        return self.returncode == 0
+
+
+class FakeRunner:
+    def __init__(
+        self,
+        source: Path,
+        *,
+        exact_base: str,
+        changed_paths: tuple[str, ...] = ("docs/design.md",),
+        patch: str = "diff --git a/docs/design.md b/docs/design.md\n+design\n",
+        codex_success: bool = True,
+        git_mutation: bool = False,
+        diff_check_success: bool = True,
+    ) -> None:
+        self.source = source
+        self.exact_base = exact_base
+        self.source_head = "f" * 40
+        self.changed_paths = changed_paths
+        self.patch = patch
+        self.codex_success = codex_success
+        self.git_mutation = git_mutation
+        self.diff_check_success = diff_check_success
+        self.codex_environment: Mapping[str, str] | None = None
+        self.codex_executed = False
+        self.temporary_paths: list[Path] = []
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        environment: Mapping[str, str] | None = None,
+        timeout_seconds: int = 120,
+        capture_output: bool = True,
+    ) -> Result:
+        del timeout_seconds, capture_output
+        values = tuple(command)
+        if values[0] != "git":
+            self.codex_executed = True
+            self.codex_environment = environment
+            assert cwd is not None
+            return Result(0 if self.codex_success else 1)
+
+        root = Path(values[2])
+        args = values[3:]
+        if root == self.source:
+            return self._source_git(args)
+        return self._isolated_git(root, args)
+
+    def _source_git(self, args: tuple[str, ...]) -> Result:
+        if args == ("rev-parse", "--show-toplevel"):
+            return Result(0, str(self.source))
+        if args == ("remote", "get-url", "origin"):
+            return Result(0, "https://github.com/owner/sample.git")
+        if args == ("status", "--porcelain"):
+            return Result(0, "")
+        if args[:2] == ("cat-file", "-e"):
+            return Result(0)
+        if args == ("branch", "--show-current"):
+            return Result(0, "main")
+        if args == ("rev-parse", "HEAD"):
+            return Result(0, self.source_head)
+        if args[:3] == ("worktree", "add", "--detach"):
+            path = Path(args[3])
+            self.temporary_paths.append(path)
+            return Result(0)
+        if args[:3] == ("worktree", "remove", "--force"):
+            path = Path(args[3])
+            if path.exists():
+                path.rmdir()
+            return Result(0)
+        if args == ("worktree", "list", "--porcelain"):
+            return Result(0, f"worktree {self.source}\nHEAD {self.source_head}\n")
+        raise AssertionError(f"unexpected source git command: {args}")
+
+    def _isolated_git(self, root: Path, args: tuple[str, ...]) -> Result:
+        assert root in self.temporary_paths
+        if args == ("rev-parse", "HEAD"):
+            if self.codex_executed and self.git_mutation:
+                return Result(0, "b" * 40)
+            return Result(0, self.exact_base)
+        if args == ("branch", "--show-current"):
+            return Result(0, "")
+        if args == ("add", "-A"):
+            return Result(0)
+        if args == ("diff", "--cached", "--name-only", "HEAD"):
+            return Result(0, "\n".join(self.changed_paths))
+        if args == ("diff", "--cached", "--check", "HEAD"):
+            return Result(0 if self.diff_check_success else 1)
+        if args == ("diff", "--cached", "--binary", "--no-ext-diff", "HEAD"):
+            return Result(0, self.patch)
+        raise AssertionError(f"unexpected isolated git command: {args}")
+
+
+def packet(tmp_path: Path, transition: ImplementerTransition) -> DevelopmentTaskPacket:
+    source = tmp_path / "product"
+    source.mkdir(exist_ok=True)
+    return DevelopmentTaskPacket(
+        packet_identity="packet:1",
+        work_identity="work:owner/sample:1",
+        generation=1,
+        transition=transition,
+        repository_identity="owner/sample",
+        workspace_canonical_path=source,
+        exact_base_sha="a" * 40,
+        goal_revision="goal-1",
+        issue_revision="issue-1",
+        scope_paths=("docs", "src"),
+        acceptance_checks=("設計と実装が一致する",),
+        canonical_design_identities=("design:abc",),
+        canonical_design_targets=("docs/design.md",),
+        active_lineage_identity="lineage:1",
+        authority_refs=("Issue #1",),
+    )
+
+
+def implementer(runner: FakeRunner) -> CodexProposalImplementer:
+    environment = {
+        "PATH": "/usr/bin",
+        "HOME": "/tmp/home",
+        "GH_TOKEN": "forbidden",
+        "OPENAI_API_KEY_REVIEWER": "forbidden",
+        "LOOP_POSTGRES_DSN": "forbidden",
+        "LOOP_TRUSTED_REVIEWER_SOCKET": "forbidden",
+    }
+    return CodexProposalImplementer(runner, ("codex", "exec"), environment)
+
+
+def test_design_returns_scoped_patch_and_strips_credentials(tmp_path: Path) -> None:
+    task = packet(tmp_path, ImplementerTransition.DESIGN)
+    runner = FakeRunner(task.workspace_canonical_path, exact_base=task.exact_base_sha)
+
+    result = implementer(runner).execute(task)
+
+    assert result.status is ImplementerStatus.SUCCESS
+    assert result.proposal is not None
+    assert result.proposal.changed_paths == ("docs/design.md",)
+    assert result.proposal.design_targets_changed == ("docs/design.md",)
+    assert result.proposal.patch_sha256 == hashlib.sha256(runner.patch.encode()).hexdigest()
+    assert runner.codex_environment == {"PATH": "/usr/bin", "HOME": "/tmp/home"}
+    assert all(not path.exists() for path in runner.temporary_paths)
+
+
+def test_implement_requires_canonical_design(tmp_path: Path) -> None:
+    task = packet(tmp_path, ImplementerTransition.IMPLEMENT)
+    task = DevelopmentTaskPacket(
+        **{
+            field: getattr(task, field)
+            for field in task.__dataclass_fields__
+            if field != "canonical_design_identities"
+        },
+        canonical_design_identities=(),
+    )
+    runner = FakeRunner(task.workspace_canonical_path, exact_base=task.exact_base_sha)
+
+    result = implementer(runner).execute(task)
+
+    assert result.status is ImplementerStatus.BLOCKED
+    assert result.detail == "CANONICAL_DESIGN_REQUIRED"
+    assert runner.codex_executed is False
+
+
+def test_repair_requires_active_lineage(tmp_path: Path) -> None:
+    task = packet(tmp_path, ImplementerTransition.REPAIR)
+    task = DevelopmentTaskPacket(
+        **{
+            field: getattr(task, field)
+            for field in task.__dataclass_fields__
+            if field != "active_lineage_identity"
+        },
+        active_lineage_identity=None,
+    )
+    runner = FakeRunner(task.workspace_canonical_path, exact_base=task.exact_base_sha)
+
+    result = implementer(runner).execute(task)
+
+    assert result.status is ImplementerStatus.BLOCKED
+    assert result.detail == "ACTIVE_LINEAGE_REQUIRED"
+
+
+def test_scope_violation_is_rejected_and_worktree_is_removed(tmp_path: Path) -> None:
+    task = packet(tmp_path, ImplementerTransition.IMPLEMENT)
+    runner = FakeRunner(
+        task.workspace_canonical_path,
+        exact_base=task.exact_base_sha,
+        changed_paths=("outside.txt",),
+    )
+
+    result = implementer(runner).execute(task)
+
+    assert result.status is ImplementerStatus.BLOCKED
+    assert result.detail == "PROPOSAL_SCOPE_VIOLATION"
+    assert all(not path.exists() for path in runner.temporary_paths)
+
+
+def test_codex_commit_is_detected(tmp_path: Path) -> None:
+    task = packet(tmp_path, ImplementerTransition.IMPLEMENT)
+    runner = FakeRunner(
+        task.workspace_canonical_path,
+        exact_base=task.exact_base_sha,
+        git_mutation=True,
+    )
+
+    result = implementer(runner).execute(task)
+
+    assert result.status is ImplementerStatus.BLOCKED
+    assert result.detail == "CODEX_GIT_MUTATION_DETECTED"
+
+
+def test_codex_failure_still_removes_isolated_worktree(tmp_path: Path) -> None:
+    task = packet(tmp_path, ImplementerTransition.IMPLEMENT)
+    runner = FakeRunner(
+        task.workspace_canonical_path,
+        exact_base=task.exact_base_sha,
+        codex_success=False,
+    )
+
+    result = implementer(runner).execute(task)
+
+    assert result.status is ImplementerStatus.FAILED
+    assert result.detail == "CODEX_EXECUTION_FAILED"
+    assert all(not path.exists() for path in runner.temporary_paths)
+
+
+def test_design_cannot_modify_implementation_files(tmp_path: Path) -> None:
+    task = packet(tmp_path, ImplementerTransition.DESIGN)
+    runner = FakeRunner(
+        task.workspace_canonical_path,
+        exact_base=task.exact_base_sha,
+        changed_paths=("docs/design.md", "src/app.py"),
+    )
+
+    result = implementer(runner).execute(task)
+
+    assert result.status is ImplementerStatus.BLOCKED
+    assert result.detail == "DESIGN_SCOPE_VIOLATION"


### PR DESCRIPTION
## 関連Issue

Closes #85
Parent manufacturing: #81
Depends on: #84

## 設計

`docs/architecture/v2/codex_implementer_proposal_mode.md` を先行追加し、CodexをGitHub lifecycle ownerから分離した。

## 実装

- exact base SHAから隔離Git worktreeを作成
- Codexは隔離worktree内のファイル編集だけを担当
- DESIGN / IMPLEMENT / REPAIRをtyped TaskPacketで分離
- DESIGN未完了のIMPLEMENT拒否
- REPAIRはactive lineage必須
- Codex childからGitHub / Reviewer / PostgreSQL credentialを除外
- 実行後にHEAD不変、detached維持、scope、diff-check、patch hashをfresh readback
- 成功時はChangeProposalだけを返し、branch/commit/push/PRは#86へ委譲
- success/failureに関係なく隔離worktreeを除去しsource Workspace不変を確認

## 検証

- DESIGN proposal success
- credential stripping
- canonical design未設定IMPLEMENT拒否
- active lineage無しREPAIR拒否
- scope逸脱拒否
- Codex commit検出
- Codex failure cleanup
- DESIGN中の実装file変更拒否

旧`TrustedWorktree`のGitHub lifecycle一体化は本経路では使用しない。