### PR TITLE
feat: V2 GitHub開発lineage effectを完成する

### DIFF
--- a/docs/architecture/v2/development_lineage_effects.md
+++ b/docs/architecture/v2/development_lineage_effects.md
@@ -1,0 +1,190 @@
+# V2 GitHub開発lineage effect仕様
+
+管理Issue: #86
+親Issue: #81
+依存: #84, #85
+上位正本: `autonomous_development_completion_contract.md`
+
+## 1. 目的
+
+#85の`ChangeProposal`を信頼済みHostがProductの1つのactive implementation lineageへ反映し、branch / push / PR等のGitHub開発effectをV2のDB intent・readback契約で冪等に管理する。
+
+不変条件は `1 Work = 1 active implementation lineage` とする。
+
+## 2. 責務分離
+
+```text
+ChangeProposal
+→ TrustedProposalMaterializer
+   → exact baseから隔離worktree
+   → raw patch identity検証
+   → patch apply/check
+   → trusted commit
+   → candidate commit SHA
+→ GitHubDevelopmentLineageEffects
+   → DB intent
+   → remote target readback
+   → Write Gate相当precondition
+   → 最大1回effect
+   → fresh readback
+   → DB outcome
+```
+
+Codexはこの工程へGitHub credentialを持ち込まない。
+
+## 3. Lineage identity
+
+Workごとに次を固定する。
+
+- `work_identity`
+- `issue_number`
+- `branch_name`
+- `base_branch`
+- `active_pr_number?`
+- `current_head_sha`
+
+branch名はProduct Registration / Project Profileの安全なtemplateから生成する。
+
+同一Workに別branchまたは別open PRが複数見つかった場合は`COMPETING_LINEAGE`としてfail-closedし、historical PRを推測採用しない。
+
+## 4. Proposal materialization
+
+入力:
+
+- Product workspace canonical path
+- repository identity
+- ChangeProposal
+- expected lineage branch
+- commit message
+
+手順:
+
+1. source WorkspaceがGit root / repository identity / cleanであることを確認。
+2. proposalの`patch_sha256`をraw `patch_text`から再計算。
+3. `exact_base_sha`がlocal commit objectとして存在することを確認。
+4. exact baseからdetached隔離worktreeを作る。
+5. raw patchをHost管理の一時fileへ書く。
+6. `git apply --check` → `git apply --index`。
+7. staged pathがproposal.changed_pathsと完全一致することを確認。
+8. `git diff --cached --check`。
+9. trusted Hostがcommitする。
+10. candidate commit SHAを取得。
+11. 隔離worktreeと一時patchをcleanupし、source Workspace不変を確認。
+
+candidate commitはまだremote effect truthではない。
+
+## 5. Remote branch effect
+
+remote branchのfresh stateで分類する。
+
+### branch不存在
+
+- effect kind: `BRANCH_CREATE`
+- expected before: `head=<absent>`
+- expected after: `head=<candidate_sha>`
+- command: normal `git push origin <candidate_sha>:refs/heads/<branch>`
+
+### branch存在・head == proposal.exact_base_sha
+
+- effect kind: `PUSH`
+- expected before: `head=<exact_base_sha>`
+- expected after: `head=<candidate_sha>`
+
+### branch存在・headがそれ以外
+
+`STALE_TARGET`。pushしない。
+
+force pushは禁止する。
+
+## 6. PR create effect
+
+branch反映後、open PRを`head branch + base branch`でfresh検索する。
+
+- 0件: `PR_CREATE` intentをDB確定後にdraft PRを1回だけ作成する。
+- 1件: head/base/Work identityが一致すれば既存active PRへ収束する。
+- 2件以上: `COMPETING_LINEAGE`。
+
+PR create commandが失敗・timeoutしても即再送せず、同じhead/baseをreadbackする。存在を証明できればCONFIRMED、不存在を証明できればNO_EFFECT、判定不能はUNCERTAIN。
+
+historical closed/merged PRはactive PRへ昇格しない。
+
+## 7. READY / REVIEW_REQUEST / MERGE / ISSUE_UPDATE
+
+既存V2 effect契約を維持し、開発lineage identityを必須preconditionへ加える。
+
+- `READY`: exact PR/headを確認してdraft→ready。
+- `REVIEW_REQUEST`: exact HEADごとのReviewRequestKeyで重複抑止。詳細判定は#87。
+- `MERGE`: expected exact HEAD固定・merge commit方式。
+- `ISSUE_UPDATE`: merge readback後のWork完了など、許可fieldだけ。
+
+## 8. Effect state
+
+既存`loop_effect_attempts`を使用する。
+
+各effectは最低限:
+
+- `idempotency_key`
+- `work_identity`
+- `packet_generation`
+- `kind`
+- `target_identity`
+- `status`
+- `expected_preconditions`
+- `expected_effect`
+
+statusは既存V2契約の`INTENT_RECORDED / CONFIRMED / NO_EFFECT / UNCERTAIN`を維持する。
+
+## 9. Readback
+
+remote branch:
+
+- ref不存在 → `<absent>`
+- ref存在 → exact SHA
+
+PR:
+
+- active検索ではopenのみを対象
+- PR number / headRefName / headRefOid / baseRefName / draft / stateをfresh取得
+- target限定readbackで対象を証明する
+
+command exit codeだけでCONFIRMEDにしない。
+
+## 10. Crash/restart
+
+各remote effectは必ずintentをDBへ先に記録する。
+
+```text
+INTENT_RECORDED
+→ crash possible
+→ restart
+→ target readback
+→ already afterならCONFIRMED
+→ definitely beforeならeffect候補
+→ 判定不能ならUNCERTAIN（再送禁止）
+```
+
+local materializationはremote effectではなく、失敗時に隔離worktreeを破棄して再生成可能とする。remote branchへ反映された後はDB/readbackを正とする。
+
+## 11. Safety
+
+- main/trunkへ直接pushしない。
+- force pushしない。
+- stale branch headへpushしない。
+- open competing PRを作らない。
+- historical/HOLD PRをcurrentとして推測しない。
+- proposal exact baseとremote current headを一致確認する。
+- source Workspaceを直接編集・branch切替しない。
+- create系effectをcommand失敗だけで再送しない。
+
+## 12. 完了条件
+
+- ChangeProposalをtrusted commitへmaterializeできる。
+- raw patch identity mismatchを拒否できる。
+- branch不存在をBRANCH_CREATEとして冪等に処理できる。
+- existing exact base branchをPUSHとして更新できる。
+- stale remote headを拒否できる。
+- PR_CREATEをreadback付きで冪等に処理できる。
+- competing active lineageを拒否できる。
+- crash/restart後にcreate/pushを二重送信しない契約がテストされる。
+- trunk direct push / force pushを生成しない。
+- exact-head CIがPASSする。

--- a/src/loop_engineering/v2_development_lineage.py
+++ b/src/loop_engineering/v2_development_lineage.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Protocol
-from urllib.parse import quote
 
 from .v2_implementer import ChangeProposal
 from .work_state import EffectAttempt, RecoveredWork
@@ -123,7 +122,8 @@ class TrustedProposalMaterializer:
             or _SHA_RE.fullmatch(proposal.exact_base_sha) is None
         ):
             return None
-        if hashlib.sha256(proposal.patch_text.encode("utf-8")).hexdigest() != proposal.patch_sha256:
+        raw_digest = hashlib.sha256(proposal.patch_text.encode("utf-8")).hexdigest()
+        if raw_digest != proposal.patch_sha256:
             return None
         source = self._source_identity(root, repository, proposal.exact_base_sha)
         if source is None:
@@ -133,13 +133,21 @@ class TrustedProposalMaterializer:
         worktree = Path(
             tempfile.mkdtemp(prefix=".loop-lineage-", dir=str(root.parent))
         ).resolve(strict=False)
-        patch_path = Path(
-            tempfile.mkstemp(prefix=".loop-proposal-", suffix=".patch", dir=str(root.parent))[1]
-        ).resolve(strict=False)
+        patch_path: Path | None = None
         added = False
         result: MaterializedProposal | None = None
         try:
-            patch_path.write_text(proposal.patch_text, encoding="utf-8", newline="")
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                newline="",
+                delete=False,
+                prefix=".loop-proposal-",
+                suffix=".patch",
+                dir=str(root.parent),
+            ) as stream:
+                stream.write(proposal.patch_text)
+                patch_path = Path(stream.name).resolve(strict=False)
             create = self._git(
                 root,
                 ("worktree", "add", "--detach", str(worktree), proposal.exact_base_sha),
@@ -239,7 +247,7 @@ class TrustedProposalMaterializer:
         self,
         root: Path,
         worktree: Path,
-        patch_path: Path,
+        patch_path: Path | None,
         added: bool,
     ) -> bool:
         if added:
@@ -255,16 +263,17 @@ class TrustedProposalMaterializer:
                 worktree.rmdir()
             except OSError:
                 return False
-        try:
-            patch_path.unlink(missing_ok=True)
-        except OSError:
-            return False
+        if patch_path is not None:
+            try:
+                patch_path.unlink(missing_ok=True)
+            except OSError:
+                return False
         listing = self._git_output(root, ("worktree", "list", "--porcelain"))
         return (
             listing is not None
             and str(worktree) not in listing
             and not worktree.exists()
-            and not patch_path.exists()
+            and (patch_path is None or not patch_path.exists())
         )
 
     def _git(

--- a/src/loop_engineering/v2_development_lineage.py
+++ b/src/loop_engineering/v2_development_lineage.py
@@ -1,0 +1,576 @@
+"""ChangeProposalを1つのGitHub開発lineageへ安全に反映する。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import quote
+
+from .v2_implementer import ChangeProposal
+from .work_state import EffectAttempt, RecoveredWork
+
+_SHA_RE = re.compile(r"[0-9a-f]{40}")
+
+
+class LineageStatus(str, Enum):
+    CONFIRMED = "CONFIRMED"
+    BLOCKED = "BLOCKED"
+    FAILED = "FAILED"
+    UNCERTAIN = "UNCERTAIN"
+
+
+class CommandResultLike(Protocol):
+    @property
+    def returncode(self) -> int: ...
+
+    @property
+    def output(self) -> str: ...
+
+    @property
+    def succeeded(self) -> bool: ...
+
+
+class LineageCommandRunner(Protocol):
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        environment: Mapping[str, str] | None = None,
+        timeout_seconds: int = 120,
+        capture_output: bool = True,
+    ) -> CommandResultLike: ...
+
+
+class DevelopmentEffectStatePort(Protocol):
+    def recover(self, work_identity: str) -> RecoveredWork | None: ...
+
+    def record_effect_intent(self, attempt: EffectAttempt) -> bool: ...
+
+    def record_effect_outcome(self, idempotency_key: str, status: str) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializedProposal:
+    work_identity: str
+    exact_base_sha: str
+    candidate_sha: str
+    changed_paths: tuple[str, ...]
+    patch_sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class LineageIdentity:
+    repository: str
+    work_identity: str
+    issue_number: int
+    branch_name: str
+    base_branch: str
+    packet_generation: int
+
+
+@dataclass(frozen=True, slots=True)
+class PullRequestIdentity:
+    number: int
+    url: str
+    head_sha: str
+    head_branch: str
+    base_branch: str
+    draft: bool
+
+
+@dataclass(frozen=True, slots=True)
+class LineageResult:
+    status: LineageStatus
+    detail: str
+    head_sha: str | None = None
+    pull_request: PullRequestIdentity | None = None
+
+
+class TrustedProposalMaterializer:
+    """raw patchを隔離worktreeへ適用し、信頼済みcommitだけを生成する。"""
+
+    def __init__(
+        self,
+        runner: LineageCommandRunner,
+        environment: Mapping[str, str],
+    ) -> None:
+        self._runner = runner
+        self._environment = dict(environment)
+
+    def materialize(
+        self,
+        *,
+        workspace: Path,
+        repository: str,
+        proposal: ChangeProposal,
+        commit_message: str,
+    ) -> MaterializedProposal | None:
+        root = workspace.resolve(strict=False)
+        if (
+            not root.is_absolute()
+            or not root.is_dir()
+            or not commit_message.strip()
+            or not _valid_repository(repository)
+            or _SHA_RE.fullmatch(proposal.exact_base_sha) is None
+        ):
+            return None
+        if hashlib.sha256(proposal.patch_text.encode("utf-8")).hexdigest() != proposal.patch_sha256:
+            return None
+        source = self._source_identity(root, repository, proposal.exact_base_sha)
+        if source is None:
+            return None
+        source_branch, source_head = source
+
+        worktree = Path(
+            tempfile.mkdtemp(prefix=".loop-lineage-", dir=str(root.parent))
+        ).resolve(strict=False)
+        patch_path = Path(
+            tempfile.mkstemp(prefix=".loop-proposal-", suffix=".patch", dir=str(root.parent))[1]
+        ).resolve(strict=False)
+        added = False
+        result: MaterializedProposal | None = None
+        try:
+            patch_path.write_text(proposal.patch_text, encoding="utf-8", newline="")
+            create = self._git(
+                root,
+                ("worktree", "add", "--detach", str(worktree), proposal.exact_base_sha),
+                timeout_seconds=180,
+            )
+            if create.succeeded:
+                added = True
+                result = self._materialize_in_worktree(
+                    worktree,
+                    patch_path,
+                    proposal,
+                    commit_message,
+                )
+        except (OSError, UnicodeError):
+            result = None
+        finally:
+            cleanup = self._cleanup(root, worktree, patch_path, added)
+
+        if not cleanup:
+            return None
+        if not self._source_unchanged(root, source_branch, source_head):
+            return None
+        return result
+
+    def _materialize_in_worktree(
+        self,
+        worktree: Path,
+        patch_path: Path,
+        proposal: ChangeProposal,
+        commit_message: str,
+    ) -> MaterializedProposal | None:
+        if self._git_output(worktree, ("rev-parse", "HEAD")) != proposal.exact_base_sha:
+            return None
+        if not self._git(worktree, ("apply", "--check", str(patch_path))).succeeded:
+            return None
+        if not self._git(worktree, ("apply", "--index", str(patch_path))).succeeded:
+            return None
+        changed = self._git_output(worktree, ("diff", "--cached", "--name-only", "HEAD"))
+        if changed is None:
+            return None
+        changed_paths = tuple(line for line in changed.splitlines() if line)
+        if changed_paths != proposal.changed_paths:
+            return None
+        if not self._git(worktree, ("diff", "--cached", "--check", "HEAD")).succeeded:
+            return None
+        if not self._git(
+            worktree,
+            ("commit", "-m", commit_message),
+            timeout_seconds=180,
+        ).succeeded:
+            return None
+        candidate = self._git_output(worktree, ("rev-parse", "HEAD"))
+        if candidate is None or _SHA_RE.fullmatch(candidate) is None:
+            return None
+        return MaterializedProposal(
+            proposal.work_identity,
+            proposal.exact_base_sha,
+            candidate,
+            changed_paths,
+            proposal.patch_sha256,
+        )
+
+    def _source_identity(
+        self,
+        root: Path,
+        repository: str,
+        exact_base: str,
+    ) -> tuple[str, str] | None:
+        top = self._git_output(root, ("rev-parse", "--show-toplevel"))
+        remote = self._git_output(root, ("remote", "get-url", "origin"))
+        status = self._git_output(root, ("status", "--porcelain"))
+        branch = self._git_output(root, ("branch", "--show-current"))
+        head = self._git_output(root, ("rev-parse", "HEAD"))
+        exists = self._git(root, ("cat-file", "-e", f"{exact_base}^{{commit}}"))
+        if (
+            top is None
+            or Path(top).resolve(strict=False) != root
+            or remote is None
+            or not _remote_matches(remote, repository)
+            or status is None
+            or status
+            or branch is None
+            or head is None
+            or not exists.succeeded
+        ):
+            return None
+        return branch, head
+
+    def _source_unchanged(self, root: Path, branch: str, head: str) -> bool:
+        return (
+            self._git_output(root, ("branch", "--show-current")) == branch
+            and self._git_output(root, ("rev-parse", "HEAD")) == head
+            and self._git_output(root, ("status", "--porcelain")) == ""
+        )
+
+    def _cleanup(
+        self,
+        root: Path,
+        worktree: Path,
+        patch_path: Path,
+        added: bool,
+    ) -> bool:
+        if added:
+            removed = self._git(
+                root,
+                ("worktree", "remove", "--force", str(worktree)),
+                timeout_seconds=180,
+            )
+            if not removed.succeeded:
+                return False
+        elif worktree.exists():
+            try:
+                worktree.rmdir()
+            except OSError:
+                return False
+        try:
+            patch_path.unlink(missing_ok=True)
+        except OSError:
+            return False
+        listing = self._git_output(root, ("worktree", "list", "--porcelain"))
+        return (
+            listing is not None
+            and str(worktree) not in listing
+            and not worktree.exists()
+            and not patch_path.exists()
+        )
+
+    def _git(
+        self,
+        root: Path,
+        args: Sequence[str],
+        *,
+        timeout_seconds: int = 120,
+    ) -> CommandResultLike:
+        return self._runner.run(
+            ("git", "-C", str(root), *args),
+            environment=self._environment,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def _git_output(self, root: Path, args: Sequence[str]) -> str | None:
+        result = self._git(root, args)
+        return result.output.strip() if result.succeeded else None
+
+
+class GitHubDevelopmentLineageEffects:
+    """remote branchとPRをDB intent→readbackで1回だけ確定する。"""
+
+    def __init__(
+        self,
+        runner: LineageCommandRunner,
+        state: DevelopmentEffectStatePort,
+        workspace: Path,
+        environment: Mapping[str, str],
+    ) -> None:
+        self._runner = runner
+        self._state = state
+        self._workspace = workspace.resolve(strict=False)
+        self._environment = dict(environment)
+
+    def publish(
+        self,
+        lineage: LineageIdentity,
+        materialized: MaterializedProposal,
+    ) -> LineageResult:
+        if not _valid_lineage(lineage, materialized):
+            return LineageResult(LineageStatus.BLOCKED, "LINEAGE_INPUT_INVALID")
+        branch_result = self._ensure_branch(lineage, materialized)
+        if branch_result.status is not LineageStatus.CONFIRMED:
+            return branch_result
+        pr = self._ensure_pull_request(lineage, materialized.candidate_sha)
+        if isinstance(pr, LineageResult):
+            return pr
+        return LineageResult(
+            LineageStatus.CONFIRMED,
+            "LINEAGE_PUBLISHED",
+            materialized.candidate_sha,
+            pr,
+        )
+
+    def _ensure_branch(
+        self,
+        lineage: LineageIdentity,
+        materialized: MaterializedProposal,
+    ) -> LineageResult:
+        observed = self._remote_branch_head(lineage.branch_name)
+        if observed == materialized.candidate_sha:
+            return LineageResult(LineageStatus.CONFIRMED, "BRANCH_ALREADY_CURRENT", observed)
+        if observed not in {None, materialized.exact_base_sha}:
+            return LineageResult(LineageStatus.BLOCKED, "STALE_REMOTE_BRANCH", observed)
+        kind = "BRANCH_CREATE" if observed is None else "PUSH"
+        before_head = "<absent>" if observed is None else observed
+        key = _effect_key(lineage, kind, materialized.candidate_sha)
+        pending = self._pending_effect(key, lineage.work_identity)
+        if pending == "UNCERTAIN":
+            return LineageResult(LineageStatus.UNCERTAIN, "BRANCH_EFFECT_UNCERTAIN", observed)
+        attempt = EffectAttempt(
+            idempotency_key=key,
+            work_identity=lineage.work_identity,
+            kind=kind,
+            target_identity=f"branch:{lineage.branch_name}",
+            status="INTENT_RECORDED",
+            packet_generation=lineage.packet_generation,
+            expected_preconditions=(("head", before_head),),
+            expected_effect=(("head", materialized.candidate_sha),),
+        )
+        if not self._state.record_effect_intent(attempt):
+            fresh = self._remote_branch_head(lineage.branch_name)
+            if fresh == materialized.candidate_sha:
+                return LineageResult(LineageStatus.CONFIRMED, "BRANCH_EFFECT_CONFIRMED", fresh)
+            return LineageResult(LineageStatus.BLOCKED, "BRANCH_EFFECT_STATE_CONFLICT", fresh)
+        fresh_before = self._remote_branch_head(lineage.branch_name)
+        if fresh_before != observed:
+            self._state.record_effect_outcome(key, "NO_EFFECT")
+            return LineageResult(LineageStatus.BLOCKED, "BRANCH_PRECONDITION_CHANGED", fresh_before)
+        push = self._run(
+            (
+                "git",
+                "push",
+                "origin",
+                f"{materialized.candidate_sha}:refs/heads/{lineage.branch_name}",
+            ),
+            timeout_seconds=300,
+        )
+        fresh = self._remote_branch_head(lineage.branch_name)
+        if fresh == materialized.candidate_sha:
+            self._state.record_effect_outcome(key, "CONFIRMED")
+            return LineageResult(LineageStatus.CONFIRMED, "BRANCH_EFFECT_CONFIRMED", fresh)
+        if push.succeeded and fresh == observed:
+            self._state.record_effect_outcome(key, "NO_EFFECT")
+            return LineageResult(LineageStatus.FAILED, "BRANCH_EFFECT_NO_EFFECT", fresh)
+        self._state.record_effect_outcome(key, "UNCERTAIN")
+        return LineageResult(LineageStatus.UNCERTAIN, "BRANCH_EFFECT_READBACK_UNPROVEN", fresh)
+
+    def _ensure_pull_request(
+        self,
+        lineage: LineageIdentity,
+        head_sha: str,
+    ) -> PullRequestIdentity | LineageResult:
+        pulls = self._open_pulls(lineage)
+        if pulls is None:
+            return LineageResult(LineageStatus.UNCERTAIN, "PR_READBACK_UNAVAILABLE", head_sha)
+        if len(pulls) > 1:
+            return LineageResult(LineageStatus.BLOCKED, "COMPETING_LINEAGE", head_sha)
+        if pulls:
+            pull = pulls[0]
+            if pull.head_sha != head_sha:
+                return LineageResult(LineageStatus.BLOCKED, "PR_HEAD_STALE", pull.head_sha)
+            return pull
+
+        key = _effect_key(lineage, "PR_CREATE", head_sha)
+        pending = self._pending_effect(key, lineage.work_identity)
+        if pending == "UNCERTAIN":
+            return LineageResult(LineageStatus.UNCERTAIN, "PR_CREATE_UNCERTAIN", head_sha)
+        attempt = EffectAttempt(
+            idempotency_key=key,
+            work_identity=lineage.work_identity,
+            kind="PR_CREATE",
+            target_identity=f"pr-lineage:{lineage.branch_name}:{lineage.base_branch}",
+            status="INTENT_RECORDED",
+            packet_generation=lineage.packet_generation,
+            expected_preconditions=(("count", "0"), ("head", head_sha)),
+            expected_effect=(("count", "1"), ("head", head_sha)),
+        )
+        if not self._state.record_effect_intent(attempt):
+            fresh = self._open_pulls(lineage)
+            if fresh is not None and len(fresh) == 1 and fresh[0].head_sha == head_sha:
+                return fresh[0]
+            return LineageResult(LineageStatus.BLOCKED, "PR_CREATE_STATE_CONFLICT", head_sha)
+        if self._open_pulls(lineage) != ():
+            self._state.record_effect_outcome(key, "NO_EFFECT")
+            return LineageResult(LineageStatus.BLOCKED, "PR_CREATE_PRECONDITION_CHANGED", head_sha)
+        created = self._run(
+            (
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                lineage.repository,
+                "--base",
+                lineage.base_branch,
+                "--head",
+                lineage.branch_name,
+                "--draft",
+                "--title",
+                f"#{lineage.issue_number} の実装",
+                "--body",
+                f"Issue #{lineage.issue_number} のLoop Engineering管理lineageです。",
+            ),
+            timeout_seconds=120,
+        )
+        fresh = self._open_pulls(lineage)
+        if fresh is not None and len(fresh) == 1 and fresh[0].head_sha == head_sha:
+            self._state.record_effect_outcome(key, "CONFIRMED")
+            return fresh[0]
+        if created.succeeded and fresh == ():
+            self._state.record_effect_outcome(key, "NO_EFFECT")
+            return LineageResult(LineageStatus.FAILED, "PR_CREATE_NO_EFFECT", head_sha)
+        self._state.record_effect_outcome(key, "UNCERTAIN")
+        return LineageResult(LineageStatus.UNCERTAIN, "PR_CREATE_READBACK_UNPROVEN", head_sha)
+
+    def _remote_branch_head(self, branch: str) -> str | None:
+        result = self._run(
+            ("git", "ls-remote", "--heads", "origin", f"refs/heads/{branch}"),
+        )
+        if not result.succeeded:
+            return None
+        lines = [line for line in result.output.splitlines() if line.strip()]
+        if not lines:
+            return None
+        if len(lines) != 1:
+            return "<ambiguous>"
+        sha = lines[0].split(maxsplit=1)[0]
+        return sha if _SHA_RE.fullmatch(sha) is not None else "<ambiguous>"
+
+    def _open_pulls(self, lineage: LineageIdentity) -> tuple[PullRequestIdentity, ...] | None:
+        result = self._run(
+            (
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                lineage.repository,
+                "--state",
+                "open",
+                "--head",
+                lineage.branch_name,
+                "--base",
+                lineage.base_branch,
+                "--json",
+                "number,url,headRefOid,headRefName,baseRefName,isDraft",
+            )
+        )
+        if not result.succeeded:
+            return None
+        try:
+            payload = json.loads(result.output)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(payload, list):
+            return None
+        pulls: list[PullRequestIdentity] = []
+        for raw in payload:
+            if not isinstance(raw, dict):
+                return None
+            number = raw.get("number")
+            url = raw.get("url")
+            head = raw.get("headRefOid")
+            head_branch = raw.get("headRefName")
+            base = raw.get("baseRefName")
+            draft = raw.get("isDraft")
+            if (
+                not isinstance(number, int)
+                or not isinstance(url, str)
+                or not isinstance(head, str)
+                or not isinstance(head_branch, str)
+                or not isinstance(base, str)
+                or not isinstance(draft, bool)
+            ):
+                return None
+            pulls.append(PullRequestIdentity(number, url, head, head_branch, base, draft))
+        return tuple(pulls)
+
+    def _pending_effect(self, key: str, work_identity: str) -> str | None:
+        recovered = self._state.recover(work_identity)
+        if recovered is None:
+            return None
+        for effect in recovered.pending_effects:
+            if effect.idempotency_key == key:
+                return effect.status
+        return None
+
+    def _run(
+        self,
+        command: Sequence[str],
+        *,
+        timeout_seconds: int = 120,
+    ) -> CommandResultLike:
+        try:
+            return self._runner.run(
+                command,
+                cwd=self._workspace,
+                environment=self._environment,
+                timeout_seconds=timeout_seconds,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return _FailedResult()
+
+
+@dataclass(frozen=True, slots=True)
+class _FailedResult:
+    returncode: int = 127
+    output: str = ""
+
+    @property
+    def succeeded(self) -> bool:
+        return False
+
+
+def _valid_lineage(lineage: LineageIdentity, proposal: MaterializedProposal) -> bool:
+    return (
+        _valid_repository(lineage.repository)
+        and lineage.work_identity == proposal.work_identity
+        and lineage.issue_number > 0
+        and lineage.packet_generation > 0
+        and bool(lineage.branch_name)
+        and bool(lineage.base_branch)
+        and lineage.branch_name != lineage.base_branch
+        and lineage.branch_name not in {"main", "master"}
+        and _SHA_RE.fullmatch(proposal.exact_base_sha) is not None
+        and _SHA_RE.fullmatch(proposal.candidate_sha) is not None
+        and proposal.exact_base_sha != proposal.candidate_sha
+    )
+
+
+def _valid_repository(repository: str) -> bool:
+    if repository.count("/") != 1 or "\x00" in repository:
+        return False
+    owner, name = repository.split("/", 1)
+    return bool(owner and name and owner.strip() == owner and name.strip() == name)
+
+
+def _remote_matches(remote: str, repository: str) -> bool:
+    expected = repository.removesuffix(".git")
+    value = remote.strip().removesuffix(".git")
+    return value == expected or value.endswith("/" + expected) or value.endswith(":" + expected)
+
+
+def _effect_key(lineage: LineageIdentity, kind: str, head: str) -> str:
+    payload = (
+        f"{lineage.repository}|{lineage.work_identity}|{lineage.packet_generation}|"
+        f"{kind}|{lineage.branch_name}|{lineage.base_branch}|{head}"
+    )
+    return "dev-effect:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/tests/loop_engineering/test_v2_development_lineage.py
+++ b/tests/loop_engineering/test_v2_development_lineage.py
@@ -1,0 +1,274 @@
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from loop_engineering.v2_development_lineage import (
+    GitHubDevelopmentLineageEffects,
+    LineageIdentity,
+    LineageStatus,
+    MaterializedProposal,
+    TrustedProposalMaterializer,
+)
+from loop_engineering.v2_implementer import ChangeProposal, ImplementerTransition
+from loop_engineering.work_state import EffectAttempt, RecoveredWork, WorkRecord
+
+
+@dataclass(frozen=True)
+class Result:
+    returncode: int = 0
+    output: str = ""
+
+    @property
+    def succeeded(self) -> bool:
+        return self.returncode == 0
+
+
+class MemoryState:
+    def __init__(self, work_identity: str) -> None:
+        self.work_identity = work_identity
+        self.effects: dict[str, EffectAttempt] = {}
+        self.outcomes: dict[str, str] = {}
+
+    def recover(self, work_identity: str) -> RecoveredWork | None:
+        if work_identity != self.work_identity:
+            return None
+        pending = tuple(
+            replace(effect, status=self.outcomes.get(key, effect.status))
+            for key, effect in self.effects.items()
+            if self.outcomes.get(key, effect.status) in {"INTENT_RECORDED", "UNCERTAIN"}
+        )
+        record = WorkRecord(
+            identity=work_identity,
+            repository="owner/sample",
+            issue_number=1,
+            issue_revision="rev",
+            lifecycle="RUNNING",
+        )
+        return RecoveredWork(record, None, None, pending)
+
+    def record_effect_intent(self, attempt: EffectAttempt) -> bool:
+        existing = self.effects.get(attempt.idempotency_key)
+        if existing is None:
+            self.effects[attempt.idempotency_key] = attempt
+            return True
+        return self.outcomes.get(attempt.idempotency_key, existing.status) == "INTENT_RECORDED"
+
+    def record_effect_outcome(self, idempotency_key: str, status: str) -> None:
+        self.outcomes[idempotency_key] = status
+
+
+class RemoteRunner:
+    def __init__(self) -> None:
+        self.branch_head: str | None = None
+        self.pulls: list[dict[str, object]] = []
+        self.commands: list[tuple[str, ...]] = []
+        self.fail_push_after_effect = False
+        self.fail_pr_after_effect = False
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        environment: Mapping[str, str] | None = None,
+        timeout_seconds: int = 120,
+        capture_output: bool = True,
+    ) -> Result:
+        del cwd, environment, timeout_seconds, capture_output
+        values = tuple(command)
+        self.commands.append(values)
+        if values[:3] == ("git", "ls-remote", "--heads"):
+            if self.branch_head is None:
+                return Result()
+            return Result(output=f"{self.branch_head}\trefs/heads/feature/work-1\n")
+        if values[:2] == ("git", "push"):
+            spec = values[-1]
+            self.branch_head = spec.split(":", 1)[0]
+            return Result(returncode=1 if self.fail_push_after_effect else 0)
+        if values[:3] == ("gh", "pr", "list"):
+            return Result(output=json.dumps(self.pulls))
+        if values[:3] == ("gh", "pr", "create"):
+            assert self.branch_head is not None
+            self.pulls.append(
+                {
+                    "number": 7,
+                    "url": "https://github.com/owner/sample/pull/7",
+                    "headRefOid": self.branch_head,
+                    "headRefName": "feature/work-1",
+                    "baseRefName": "main",
+                    "isDraft": True,
+                }
+            )
+            return Result(returncode=1 if self.fail_pr_after_effect else 0)
+        raise AssertionError(values)
+
+
+class NoCommandRunner:
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        environment: Mapping[str, str] | None = None,
+        timeout_seconds: int = 120,
+        capture_output: bool = True,
+    ) -> Result:
+        del command, cwd, environment, timeout_seconds, capture_output
+        raise AssertionError("command must not run")
+
+
+def lineage() -> LineageIdentity:
+    return LineageIdentity(
+        repository="owner/sample",
+        work_identity="work:owner/sample:1",
+        issue_number=1,
+        branch_name="feature/work-1",
+        base_branch="main",
+        packet_generation=1,
+    )
+
+
+def materialized(base: str = "a" * 40, candidate: str = "b" * 40) -> MaterializedProposal:
+    return MaterializedProposal(
+        work_identity="work:owner/sample:1",
+        exact_base_sha=base,
+        candidate_sha=candidate,
+        changed_paths=("src/app.py",),
+        patch_sha256="patch",
+    )
+
+
+def service(runner: RemoteRunner, state: MemoryState) -> GitHubDevelopmentLineageEffects:
+    return GitHubDevelopmentLineageEffects(
+        runner,
+        state,
+        Path("/tmp/product"),
+        {"PATH": "/usr/bin"},
+    )
+
+
+def test_new_branch_and_pr_are_created_once() -> None:
+    runner = RemoteRunner()
+    state = MemoryState(lineage().work_identity)
+
+    first = service(runner, state).publish(lineage(), materialized())
+    second = service(runner, state).publish(lineage(), materialized())
+
+    assert first.status is LineageStatus.CONFIRMED
+    assert second.status is LineageStatus.CONFIRMED
+    assert runner.branch_head == "b" * 40
+    assert len(runner.pulls) == 1
+    assert sum(command[:2] == ("git", "push") for command in runner.commands) == 1
+    assert sum(command[:3] == ("gh", "pr", "create") for command in runner.commands) == 1
+
+
+def test_existing_exact_base_branch_is_normal_push() -> None:
+    runner = RemoteRunner()
+    runner.branch_head = "a" * 40
+    state = MemoryState(lineage().work_identity)
+
+    result = service(runner, state).publish(lineage(), materialized())
+
+    assert result.status is LineageStatus.CONFIRMED
+    kinds = {effect.kind for effect in state.effects.values()}
+    assert "PUSH" in kinds
+    assert "BRANCH_CREATE" not in kinds
+
+
+def test_stale_remote_branch_is_blocked_without_push() -> None:
+    runner = RemoteRunner()
+    runner.branch_head = "c" * 40
+    state = MemoryState(lineage().work_identity)
+
+    result = service(runner, state).publish(lineage(), materialized())
+
+    assert result.status is LineageStatus.BLOCKED
+    assert result.detail == "STALE_REMOTE_BRANCH"
+    assert not any(command[:2] == ("git", "push") for command in runner.commands)
+
+
+def test_push_failure_after_remote_effect_is_confirmed_by_readback() -> None:
+    runner = RemoteRunner()
+    runner.fail_push_after_effect = True
+    state = MemoryState(lineage().work_identity)
+
+    result = service(runner, state).publish(lineage(), materialized())
+
+    assert result.status is LineageStatus.CONFIRMED
+    assert state.outcomes
+    assert "CONFIRMED" in state.outcomes.values()
+
+
+def test_pr_create_failure_after_effect_is_confirmed_by_readback() -> None:
+    runner = RemoteRunner()
+    runner.fail_pr_after_effect = True
+    state = MemoryState(lineage().work_identity)
+
+    result = service(runner, state).publish(lineage(), materialized())
+
+    assert result.status is LineageStatus.CONFIRMED
+    assert result.pull_request is not None
+    assert result.pull_request.number == 7
+
+
+def test_competing_open_prs_are_blocked() -> None:
+    runner = RemoteRunner()
+    runner.branch_head = "b" * 40
+    pull = {
+        "number": 7,
+        "url": "https://github.com/owner/sample/pull/7",
+        "headRefOid": "b" * 40,
+        "headRefName": "feature/work-1",
+        "baseRefName": "main",
+        "isDraft": True,
+    }
+    runner.pulls = [pull, {**pull, "number": 8, "url": "https://github.com/x/8"}]
+    state = MemoryState(lineage().work_identity)
+
+    result = service(runner, state).publish(lineage(), materialized())
+
+    assert result.status is LineageStatus.BLOCKED
+    assert result.detail == "COMPETING_LINEAGE"
+
+
+def test_uncertain_branch_effect_is_not_resent() -> None:
+    runner = RemoteRunner()
+    state = MemoryState(lineage().work_identity)
+    first = service(runner, state).publish(lineage(), materialized())
+    assert first.status is LineageStatus.CONFIRMED
+    key = next(key for key, effect in state.effects.items() if effect.kind == "BRANCH_CREATE")
+    state.outcomes[key] = "UNCERTAIN"
+    runner.branch_head = None
+    before = len(runner.commands)
+
+    result = service(runner, state).publish(lineage(), materialized())
+
+    assert result.status is LineageStatus.UNCERTAIN
+    assert not any(command[:2] == ("git", "push") for command in runner.commands[before:])
+
+
+def test_materializer_rejects_raw_patch_hash_mismatch_before_git(tmp_path: Path) -> None:
+    workspace = tmp_path / "product"
+    workspace.mkdir()
+    patch = "diff --git a/src/app.py b/src/app.py\n+ok\n"
+    proposal = ChangeProposal(
+        packet_identity="packet:1",
+        work_identity="work:owner/sample:1",
+        transition=ImplementerTransition.IMPLEMENT,
+        exact_base_sha="a" * 40,
+        changed_paths=("src/app.py",),
+        patch_sha256=hashlib.sha256(b"different").hexdigest(),
+        patch_text=patch,
+        design_targets_changed=(),
+    )
+
+    result = TrustedProposalMaterializer(NoCommandRunner(), {}).materialize(
+        workspace=workspace,
+        repository="owner/sample",
+        proposal=proposal,
+        commit_message="feat: test",
+    )
+
+    assert result is None


### PR DESCRIPTION
## 関連Issue

Closes #86
Parent manufacturing: #81
Depends on: #84, #85

## 設計

`docs/architecture/v2/development_lineage_effects.md` を先行追加し、proposal materializationとremote GitHub effectを分離した。

## 実装

- #85 ChangeProposalのraw patch hashを再検証
- exact baseから隔離worktreeを作りtrusted Hostだけがpatch apply/commit
- source Workspaceは変更しない
- remote branch不存在は`BRANCH_CREATE`、exact-base branchは`PUSH`
- stale branch headではfail-closed
- `PR_CREATE`をopen head/base readbackで冪等化
- `loop_effect_attempts`へintentを先に記録し、command後fresh readbackでCONFIRMED/NO_EFFECT/UNCERTAINを確定
- UNCERTAIN effectは再送禁止
- competing open PRはfail-closed
- trunk direct push / force pushは生成しない

## 検証

- new branch + PRの再実行収束
- existing branch PUSH
- stale branch拒否
- push command failure後のremote readback confirmed
- PR create command failure後のreadback confirmed
- competing PR拒否
- UNCERTAIN再送禁止
- raw patch hash mismatchをGit操作前に拒否
