### PR TITLE
feat: V2 exact-head evidenceと修正ループを完成する

### DIFF
--- a/docs/architecture/v2/evidence_review_human_verification.md
+++ b/docs/architecture/v2/evidence_review_human_verification.md
@@ -1,0 +1,166 @@
+# V2 CI・Review・Human Verification Evidence仕様
+
+管理Issue: #87
+親Issue: #81
+依存: #85, #86
+上位正本: `autonomous_development_completion_contract.md`, `review_pipeline.md`
+
+## 1. 目的
+
+Product Workのcurrent exact HEADに対するCI、Independent Review、Human Verificationをtyped evidenceへ正規化し、V2 Supervisorが`VERIFY / REVIEW / HUMAN_VERIFY / REPAIR / INTEGRATE`を安全に判断できるようにする。
+
+## 2. Evidence target
+
+全evidenceは次の`EvidenceTarget`へbindする。
+
+- repository identity
+- Work identity / Issue number
+- PR number
+- exact head SHA
+- base branch
+- canonical design identities
+- acceptance digest
+
+old HEADのevidenceをcurrent HEADへ流用しない。
+
+## 3. CI
+
+GitHub Actions adapterは指定workflowのrunをexact `head_sha`でfresh取得する。
+
+正規化:
+
+- run無し → `NOT_RUN`
+- queued / in_progress / pending → `PENDING`
+- completed success → `PASS`
+- completed failure/cancelled/timed_out等 → `FAIL`
+
+runの`head_sha`がtargetと一致しない結果は採用しない。
+
+CI failureはHuman Interventionではなく、Supervisorのsame-lineage `REPAIR`へ戻す。
+
+## 4. ReviewRequestKey
+
+次のcanonical値からSHA-256で生成する。
+
+- reviewer policy identity
+- repository
+- work identity
+- exact head SHA
+- base branch
+- canonical design identities
+- acceptance digest
+- CI evidence identity
+
+同じkeyは1回だけcanonical reviewを要求する。
+
+## 5. Trusted Reviewer Broker
+
+Reviewer credentialはProduct WorkspaceやImplementerへ渡さず、Host側broker processだけが保持する。
+
+初期production adapterは`TrustedReviewerBrokerAdapter`とし、Hostが設定したargvをshellなしで実行する。
+
+```text
+Host
+→ sanitized ReviewRequest JSON file
+→ trusted reviewer broker command
+→ sanitized ReviewResult JSON stdout
+```
+
+Product側のdiff/Issue内容はuntrusted dataとしてrequestへ含めるが、Host commandへ展開しない。
+
+Broker出力:
+
+- `request_key`
+- `target_head_sha`
+- `verdict`: `PASS | REQUEST_CHANGES | ESCALATE | NOT_RUN`
+- `findings[]`
+- `reviewer_identity`
+
+schema / target echo / size / enumをHost側で再検証する。
+
+## 6. Review persistence
+
+PostgreSQLへ`ReviewRequestKey`単位で保存する。
+
+状態:
+
+- `REQUESTED`
+- `PASS`
+- `REQUEST_CHANGES`
+- `ESCALATE`
+- `NOT_RUN`
+
+same keyがterminalならproviderを再呼出ししない。
+
+`REQUESTED`のままbroker結果が不明な場合、restart時に無条件再callせず`NOT_RUN`/safe retry policyへ移す。provider二重課金・二重reviewを防ぐ。
+
+## 7. Review stale guard
+
+Broker call前後でGitHub current PR headをfresh確認する。
+
+- before != target HEAD → requestしない
+- broker result target != target HEAD → stale rejection
+- after != target HEAD → resultをcurrent PASSへ昇格しない
+
+HEADが変われば新ReviewRequestKeyを生成する。
+
+## 8. Human Verification
+
+Human Verificationは自動検証不能なWorkだけが要求する。
+
+人間の確認結果はIssue commentの自由文ではなく、exact HEADにbindしたmachine markerだけを機械evidenceとして読む。
+
+```text
+<!-- loop-engineering-human-verification:v1 -->
+```json
+{"work_identity":"...","head_sha":"40hex","result":"PASS"}
+```
+```
+
+resultは`PASS | FAIL`のみ。
+
+comment本文のその他自然文はcurrent-state Authorityにしない。
+
+HEAD変更後、古いHuman Verification PASSはstaleになる。
+
+## 9. EvidenceBundle
+
+`EvidenceBundle`:
+
+- target
+- CI state / identity
+- Review state / identity
+- Human Verification state / identity
+
+`V2WorkObservation`へ投影し、既存`V2Supervisor.derive_transition`へ渡す。
+
+## 10. Repair semantics
+
+- CI `FAIL` → `REPAIR`
+- Review `REQUEST_CHANGES` → `REPAIR`
+- Human Verification `FAIL` → `REPAIR`
+- new HEAD後はCI / Review / Human evidenceを再取得
+- pending evidenceだけでMissionをHuman STOPへしない
+- independent actionable WorkがあればSchedulerが継続
+
+## 11. Integration Gate
+
+`INTEGRATE`へ進める条件:
+
+- current exact HEADのCI `PASS`
+- current exact HEADのReview `PASS`
+- Human Verification requiredならcurrent exact HEADの`PASS`
+- unresolved conflictなし
+
+## 12. 完了条件
+
+- exact-head CIをtyped evidenceへ変換できる。
+- stale CIをcurrent PASSへしない。
+- ReviewRequestKeyがdeterministicである。
+- same exact reviewを二重broker callしない。
+- REQUEST_CHANGESをREPAIRへ投影できる。
+- broker result前後のHEAD変化をstale rejectできる。
+- Human Verificationをexact HEAD markerからtyped readできる。
+- old-head Human PASSを流用しない。
+- pending evidenceをHuman Interventionへ誤分類しない。
+- tests / exact-head CIがPASSする。

--- a/src/loop_engineering/migrations/0009_v2_review_evidence.sql
+++ b/src/loop_engineering/migrations/0009_v2_review_evidence.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS loop_review_evidence (
+    request_key TEXT PRIMARY KEY,
+    work_identity TEXT NOT NULL REFERENCES loop_work_records(identity),
+    head_sha TEXT NOT NULL,
+    status TEXT NOT NULL,
+    reviewer_identity TEXT,
+    findings JSONB NOT NULL DEFAULT '[]'::jsonb,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS loop_review_evidence_work_head_index
+    ON loop_review_evidence (work_identity, head_sha, updated_at DESC);

--- a/src/loop_engineering/v2_evidence.py
+++ b/src/loop_engineering/v2_evidence.py
@@ -1,0 +1,565 @@
+"""exact HEADに結び付くCI・Review・Human Verification evidenceを提供する。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Protocol
+
+from .v2_supervisor import EvidenceState, V2WorkObservation
+
+_SHA_RE = re.compile(r"[0-9a-f]{40}")
+_HUMAN_MARKER = "<!-- loop-engineering-human-verification:v1 -->"
+_REVIEW_TERMINAL = frozenset({"PASS", "REQUEST_CHANGES", "ESCALATE", "NOT_RUN"})
+
+
+class CommandResultLike(Protocol):
+    @property
+    def returncode(self) -> int: ...
+
+    @property
+    def output(self) -> str: ...
+
+    @property
+    def succeeded(self) -> bool: ...
+
+
+class EvidenceCommandRunner(Protocol):
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        environment: Mapping[str, str] | None = None,
+        timeout_seconds: int = 120,
+        capture_output: bool = True,
+    ) -> CommandResultLike: ...
+
+
+class ReviewEvidenceDatabase(Protocol):
+    def execute_sql(self, sql: str) -> bool: ...
+
+    def query_json_rows(self, select_sql: str) -> list[dict[str, object]] | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceTarget:
+    repository: str
+    work_identity: str
+    issue_number: int
+    pr_number: int
+    head_sha: str
+    base_branch: str
+    canonical_design_identities: tuple[str, ...]
+    acceptance_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class MachineEvidence:
+    state: EvidenceState
+    identity: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewRequest:
+    request_key: str
+    target: EvidenceTarget
+    ci_identity: str
+    reviewer_policy_identity: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewResult:
+    request_key: str
+    target_head_sha: str
+    verdict: str
+    findings: tuple[str, ...]
+    reviewer_identity: str
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceBundle:
+    target: EvidenceTarget
+    ci: MachineEvidence
+    review: MachineEvidence
+    human: MachineEvidence
+    review_escalated: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class StoredReview:
+    request_key: str
+    work_identity: str
+    head_sha: str
+    status: str
+    reviewer_identity: str | None
+    findings: tuple[str, ...]
+
+
+class PostgreSQLReviewEvidenceStore:
+    def __init__(self, database: ReviewEvidenceDatabase) -> None:
+        self._database = database
+
+    def get(self, request_key: str) -> StoredReview | None:
+        rows = self._database.query_json_rows(
+            "SELECT request_key, work_identity, head_sha, status, reviewer_identity, findings "
+            "FROM loop_review_evidence "
+            f"WHERE request_key = {_literal(request_key)} LIMIT 1"
+        )
+        if rows is None:
+            raise RuntimeError("REVIEW_EVIDENCE_READ_FAILED")
+        if not rows:
+            return None
+        row = rows[0]
+        findings = row.get("findings")
+        if not isinstance(findings, list) or not all(isinstance(item, str) for item in findings):
+            raise RuntimeError("REVIEW_EVIDENCE_ROW_INVALID")
+        return StoredReview(
+            _required_string(row, "request_key"),
+            _required_string(row, "work_identity"),
+            _required_string(row, "head_sha"),
+            _required_string(row, "status"),
+            _optional_string(row, "reviewer_identity"),
+            tuple(findings),
+        )
+
+    def mark_requested(self, request: ReviewRequest) -> bool:
+        sql = (
+            "INSERT INTO loop_review_evidence "
+            "(request_key, work_identity, head_sha, status) VALUES ("
+            f"{_literal(request.request_key)}, {_literal(request.target.work_identity)}, "
+            f"{_literal(request.target.head_sha)}, 'REQUESTED') "
+            "ON CONFLICT (request_key) DO NOTHING"
+        )
+        return self._database.execute_sql(sql)
+
+    def save_result(self, result: ReviewResult, work_identity: str) -> None:
+        if result.verdict not in _REVIEW_TERMINAL:
+            raise RuntimeError("REVIEW_RESULT_INVALID")
+        findings_json = _literal(
+            json.dumps(result.findings, ensure_ascii=False, separators=(",", ":"))
+        )
+        sql = (
+            "UPDATE loop_review_evidence SET "
+            f"status = {_literal(result.verdict)}, "
+            f"reviewer_identity = {_literal(result.reviewer_identity)}, "
+            f"findings = {findings_json}::jsonb, updated_at = now() "
+            f"WHERE request_key = {_literal(result.request_key)} "
+            f"AND work_identity = {_literal(work_identity)}"
+        )
+        if not self._database.execute_sql(sql):
+            raise RuntimeError("REVIEW_EVIDENCE_WRITE_FAILED")
+
+
+class GitHubExactHeadCIAdapter:
+    def __init__(self, runner: EvidenceCommandRunner, environment: Mapping[str, str]) -> None:
+        self._runner = runner
+        self._environment = dict(environment)
+
+    def read(self, target: EvidenceTarget, workflow_name: str) -> MachineEvidence:
+        if not workflow_name.strip() or not _valid_target(target):
+            return MachineEvidence(EvidenceState.NOT_RUN, None)
+        result = self._run(
+            (
+                "gh",
+                "api",
+                f"repos/{target.repository}/actions/runs?head_sha={target.head_sha}&per_page=100",
+            )
+        )
+        if not result.succeeded:
+            return MachineEvidence(EvidenceState.PENDING, None)
+        try:
+            payload = json.loads(result.output)
+        except json.JSONDecodeError:
+            return MachineEvidence(EvidenceState.PENDING, None)
+        if not isinstance(payload, dict) or not isinstance(payload.get("workflow_runs"), list):
+            return MachineEvidence(EvidenceState.PENDING, None)
+        candidates: list[dict[str, object]] = []
+        for raw in payload["workflow_runs"]:
+            if not isinstance(raw, dict):
+                continue
+            if raw.get("name") != workflow_name or raw.get("head_sha") != target.head_sha:
+                continue
+            if not isinstance(raw.get("id"), int):
+                continue
+            candidates.append(raw)
+        if not candidates:
+            return MachineEvidence(EvidenceState.NOT_RUN, None)
+        latest = max(candidates, key=lambda item: int(item["id"]))
+        run_id = latest["id"]
+        identity = f"ci:{run_id}:{target.head_sha}"
+        if latest.get("status") != "completed":
+            return MachineEvidence(EvidenceState.PENDING, identity)
+        conclusion = latest.get("conclusion")
+        if conclusion == "success":
+            return MachineEvidence(EvidenceState.PASS, identity)
+        return MachineEvidence(EvidenceState.FAIL, identity)
+
+    def _run(self, command: Sequence[str]) -> CommandResultLike:
+        try:
+            return self._runner.run(command, environment=self._environment)
+        except (OSError, subprocess.SubprocessError):
+            return _FailedResult()
+
+
+class TrustedReviewerBrokerAdapter:
+    """reviewer credentialをHost broker側だけに閉じ込めるcommand adapter。"""
+
+    def __init__(
+        self,
+        runner: EvidenceCommandRunner,
+        argv_prefix: Sequence[str],
+        environment: Mapping[str, str],
+        *,
+        timeout_seconds: int = 1200,
+    ) -> None:
+        if not argv_prefix or any(not item for item in argv_prefix):
+            raise ValueError("REVIEWER_COMMAND_INVALID")
+        self._runner = runner
+        self._argv_prefix = tuple(argv_prefix)
+        self._environment = dict(environment)
+        self._timeout_seconds = timeout_seconds
+
+    def request(self, request: ReviewRequest) -> ReviewResult | None:
+        payload = {
+            "request_key": request.request_key,
+            "repository": request.target.repository,
+            "work_identity": request.target.work_identity,
+            "issue_number": request.target.issue_number,
+            "pr_number": request.target.pr_number,
+            "head_sha": request.target.head_sha,
+            "base_branch": request.target.base_branch,
+            "canonical_design_identities": list(request.target.canonical_design_identities),
+            "acceptance_digest": request.target.acceptance_digest,
+            "ci_identity": request.ci_identity,
+            "reviewer_policy_identity": request.reviewer_policy_identity,
+        }
+        path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                delete=False,
+                prefix="loop-review-",
+                suffix=".json",
+            ) as stream:
+                json.dump(payload, stream, ensure_ascii=False, sort_keys=True)
+                path = Path(stream.name)
+            result = self._runner.run(
+                (*self._argv_prefix, "--request", str(path)),
+                environment=self._environment,
+                timeout_seconds=self._timeout_seconds,
+            )
+            if not result.succeeded:
+                return None
+            return _review_result(result.output, request)
+        except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError):
+            return None
+        finally:
+            if path is not None:
+                path.unlink(missing_ok=True)
+
+
+class GitHubTargetReader:
+    def __init__(self, runner: EvidenceCommandRunner, environment: Mapping[str, str]) -> None:
+        self._runner = runner
+        self._environment = dict(environment)
+
+    def current_head(self, target: EvidenceTarget) -> str | None:
+        try:
+            result = self._runner.run(
+                (
+                    "gh",
+                    "pr",
+                    "view",
+                    str(target.pr_number),
+                    "--repo",
+                    target.repository,
+                    "--json",
+                    "number,headRefOid,baseRefName",
+                ),
+                environment=self._environment,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if not result.succeeded:
+            return None
+        try:
+            payload = json.loads(result.output)
+        except json.JSONDecodeError:
+            return None
+        if (
+            not isinstance(payload, dict)
+            or payload.get("number") != target.pr_number
+            or payload.get("baseRefName") != target.base_branch
+        ):
+            return None
+        head = payload.get("headRefOid")
+        return head if isinstance(head, str) else None
+
+
+class ReviewCoordinator:
+    def __init__(
+        self,
+        store: PostgreSQLReviewEvidenceStore,
+        broker: TrustedReviewerBrokerAdapter,
+        target_reader: GitHubTargetReader,
+        reviewer_policy_identity: str,
+    ) -> None:
+        if not reviewer_policy_identity.strip():
+            raise ValueError("REVIEWER_POLICY_INVALID")
+        self._store = store
+        self._broker = broker
+        self._target_reader = target_reader
+        self._policy = reviewer_policy_identity
+
+    def ensure_review(self, target: EvidenceTarget, ci: MachineEvidence) -> MachineEvidence:
+        if ci.state is not EvidenceState.PASS or ci.identity is None:
+            return MachineEvidence(EvidenceState.NOT_RUN, None)
+        key = review_request_key(target, ci.identity, self._policy)
+        stored = self._store.get(key)
+        if stored is not None:
+            return _stored_evidence(stored)
+        if self._target_reader.current_head(target) != target.head_sha:
+            return MachineEvidence(EvidenceState.NOT_RUN, f"stale:{key}")
+        request = ReviewRequest(key, target, ci.identity, self._policy)
+        if not self._store.mark_requested(request):
+            return MachineEvidence(EvidenceState.PENDING, key)
+        result = self._broker.request(request)
+        if result is None:
+            return MachineEvidence(EvidenceState.PENDING, key)
+        if self._target_reader.current_head(target) != target.head_sha:
+            stale = ReviewResult(key, target.head_sha, "NOT_RUN", (), result.reviewer_identity)
+            self._store.save_result(stale, target.work_identity)
+            return MachineEvidence(EvidenceState.NOT_RUN, f"stale:{key}")
+        self._store.save_result(result, target.work_identity)
+        return _result_evidence(result)
+
+
+class GitHubHumanVerificationAdapter:
+    def __init__(self, runner: EvidenceCommandRunner, environment: Mapping[str, str]) -> None:
+        self._runner = runner
+        self._environment = dict(environment)
+
+    def read(self, target: EvidenceTarget, required: bool) -> MachineEvidence:
+        if not required:
+            return MachineEvidence(EvidenceState.NOT_REQUIRED, None)
+        try:
+            result = self._runner.run(
+                (
+                    "gh",
+                    "api",
+                    "--paginate",
+                    "--slurp",
+                    f"repos/{target.repository}/issues/{target.issue_number}/comments?per_page=100",
+                ),
+                environment=self._environment,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return MachineEvidence(EvidenceState.PENDING, None)
+        if not result.succeeded:
+            return MachineEvidence(EvidenceState.PENDING, None)
+        records = _human_records(result.output)
+        matches = [
+            record
+            for record in records
+            if record.get("work_identity") == target.work_identity
+            and record.get("head_sha") == target.head_sha
+        ]
+        if not matches:
+            return MachineEvidence(EvidenceState.PENDING, None)
+        latest = matches[-1]
+        value = latest.get("result")
+        identity = "human:" + hashlib.sha256(
+            json.dumps(latest, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        if value == "PASS":
+            return MachineEvidence(EvidenceState.PASS, identity)
+        if value == "FAIL":
+            return MachineEvidence(EvidenceState.FAIL, identity)
+        return MachineEvidence(EvidenceState.PENDING, None)
+
+
+class V2EvidenceCoordinator:
+    def __init__(
+        self,
+        ci: GitHubExactHeadCIAdapter,
+        review: ReviewCoordinator,
+        human: GitHubHumanVerificationAdapter,
+        workflow_name: str,
+    ) -> None:
+        self._ci = ci
+        self._review = review
+        self._human = human
+        self._workflow_name = workflow_name
+
+    def observe(self, target: EvidenceTarget, human_required: bool) -> EvidenceBundle:
+        ci = self._ci.read(target, self._workflow_name)
+        review = self._review.ensure_review(target, ci)
+        human = self._human.read(target, human_required)
+        escalated = review.identity is not None and review.identity.startswith("escalate:")
+        return EvidenceBundle(target, ci, review, human, escalated)
+
+
+def apply_evidence(work: V2WorkObservation, bundle: EvidenceBundle) -> V2WorkObservation:
+    if work.work_identity != bundle.target.work_identity:
+        raise ValueError("EVIDENCE_WORK_MISMATCH")
+    if work.exact_head_sha != bundle.target.head_sha:
+        raise ValueError("EVIDENCE_HEAD_MISMATCH")
+    return replace(
+        work,
+        verification_state=bundle.ci.state,
+        verification_identity=bundle.ci.identity,
+        review_state=bundle.review.state,
+        review_identity=bundle.review.identity,
+        human_verification_state=bundle.human.state,
+        human_verification_identity=bundle.human.identity,
+        unresolved_conflict=work.unresolved_conflict or bundle.review_escalated,
+    )
+
+
+def review_request_key(target: EvidenceTarget, ci_identity: str, policy: str) -> str:
+    payload = {
+        "policy": policy,
+        "repository": target.repository,
+        "work_identity": target.work_identity,
+        "head_sha": target.head_sha,
+        "base_branch": target.base_branch,
+        "canonical_design_identities": target.canonical_design_identities,
+        "acceptance_digest": target.acceptance_digest,
+        "ci_identity": ci_identity,
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return "review:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _stored_evidence(stored: StoredReview) -> MachineEvidence:
+    identity = f"review:{stored.request_key}:{stored.head_sha}"
+    if stored.status == "PASS":
+        return MachineEvidence(EvidenceState.PASS, identity)
+    if stored.status == "REQUEST_CHANGES":
+        return MachineEvidence(EvidenceState.REQUEST_CHANGES, identity)
+    if stored.status == "ESCALATE":
+        return MachineEvidence(EvidenceState.FAIL, "escalate:" + identity)
+    if stored.status == "NOT_RUN":
+        return MachineEvidence(EvidenceState.NOT_RUN, identity)
+    return MachineEvidence(EvidenceState.PENDING, identity)
+
+
+def _result_evidence(result: ReviewResult) -> MachineEvidence:
+    stored = StoredReview(
+        result.request_key,
+        "",
+        result.target_head_sha,
+        result.verdict,
+        result.reviewer_identity,
+        result.findings,
+    )
+    return _stored_evidence(stored)
+
+
+def _review_result(raw: str, request: ReviewRequest) -> ReviewResult | None:
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        return None
+    key = payload.get("request_key")
+    head = payload.get("target_head_sha")
+    verdict = payload.get("verdict")
+    reviewer = payload.get("reviewer_identity")
+    findings = payload.get("findings")
+    if (
+        key != request.request_key
+        or head != request.target.head_sha
+        or verdict not in _REVIEW_TERMINAL
+        or not isinstance(reviewer, str)
+        or not reviewer.strip()
+        or not isinstance(findings, list)
+        or len(findings) > 64
+        or not all(isinstance(item, str) and len(item) <= 1000 for item in findings)
+    ):
+        return None
+    return ReviewResult(key, head, verdict, tuple(findings), reviewer)
+
+
+def _human_records(raw: str) -> tuple[dict[str, object], ...]:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return ()
+    pages = payload if isinstance(payload, list) else []
+    comments: list[Mapping[str, object]] = []
+    for page in pages:
+        if isinstance(page, list):
+            comments.extend(item for item in page if isinstance(item, dict))
+        elif isinstance(page, dict):
+            comments.append(page)
+    records: list[dict[str, object]] = []
+    for comment in comments:
+        body = comment.get("body")
+        if not isinstance(body, str) or _HUMAN_MARKER not in body:
+            continue
+        after = body.split(_HUMAN_MARKER, 1)[1].strip()
+        try:
+            record = json.loads(after)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        if (
+            isinstance(record.get("work_identity"), str)
+            and isinstance(record.get("head_sha"), str)
+            and _SHA_RE.fullmatch(str(record["head_sha"])) is not None
+            and record.get("result") in {"PASS", "FAIL"}
+        ):
+            records.append(record)
+    return tuple(records)
+
+
+def _valid_target(target: EvidenceTarget) -> bool:
+    return (
+        target.repository.count("/") == 1
+        and bool(target.work_identity)
+        and target.issue_number > 0
+        and target.pr_number > 0
+        and _SHA_RE.fullmatch(target.head_sha) is not None
+        and bool(target.base_branch)
+        and bool(target.acceptance_digest)
+    )
+
+
+def _literal(value: str) -> str:
+    if "\x00" in value or len(value) > 4096:
+        raise RuntimeError("REVIEW_EVIDENCE_VALUE_INVALID")
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _required_string(row: Mapping[str, object], key: str) -> str:
+    value = row.get(key)
+    if not isinstance(value, str):
+        raise RuntimeError("REVIEW_EVIDENCE_ROW_INVALID")
+    return value
+
+
+def _optional_string(row: Mapping[str, object], key: str) -> str | None:
+    value = row.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise RuntimeError("REVIEW_EVIDENCE_ROW_INVALID")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class _FailedResult:
+    returncode: int = 127
+    output: str = ""
+
+    @property
+    def succeeded(self) -> bool:
+        return False

--- a/src/loop_engineering/v2_evidence.py
+++ b/src/loop_engineering/v2_evidence.py
@@ -191,8 +191,8 @@ class GitHubExactHeadCIAdapter:
             candidates.append(raw)
         if not candidates:
             return MachineEvidence(EvidenceState.NOT_RUN, None)
-        latest = max(candidates, key=lambda item: int(item["id"]))
-        run_id = latest["id"]
+        latest = max(candidates, key=_ci_run_id)
+        run_id = _ci_run_id(latest)
         identity = f"ci:{run_id}:{target.head_sha}"
         if latest.get("status") != "completed":
             return MachineEvidence(EvidenceState.PENDING, identity)
@@ -531,6 +531,13 @@ def _valid_target(target: EvidenceTarget) -> bool:
         and bool(target.base_branch)
         and bool(target.acceptance_digest)
     )
+
+
+def _ci_run_id(item: Mapping[str, object]) -> int:
+    value = item.get("id")
+    if not isinstance(value, int):
+        raise RuntimeError("CI_EVIDENCE_ROW_INVALID")
+    return value
 
 
 def _literal(value: str) -> str:

--- a/tests/loop_engineering/test_v2_evidence.py
+++ b/tests/loop_engineering/test_v2_evidence.py
@@ -1,0 +1,339 @@
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from loop_engineering.v2_evidence import (
+    EvidenceTarget,
+    GitHubExactHeadCIAdapter,
+    GitHubHumanVerificationAdapter,
+    GitHubTargetReader,
+    MachineEvidence,
+    PostgreSQLReviewEvidenceStore,
+    ReviewCoordinator,
+    TrustedReviewerBrokerAdapter,
+    apply_evidence,
+    review_request_key,
+)
+from loop_engineering.v2_supervisor import (
+    EvidenceState,
+    V2Transition,
+    V2WorkObservation,
+    derive_transition,
+)
+
+
+@dataclass(frozen=True)
+class Result:
+    returncode: int = 0
+    output: str = ""
+
+    @property
+    def succeeded(self) -> bool:
+        return self.returncode == 0
+
+
+class FakeDatabase:
+    def __init__(self) -> None:
+        self.rows: dict[str, dict[str, object]] = {}
+
+    def execute_sql(self, sql: str) -> bool:
+        if sql.startswith("INSERT INTO loop_review_evidence"):
+            key = _sql_value(sql, "VALUES ('", "', '")
+            values = _quoted_values(sql)
+            self.rows.setdefault(
+                key,
+                {
+                    "request_key": values[0],
+                    "work_identity": values[1],
+                    "head_sha": values[2],
+                    "status": "REQUESTED",
+                    "reviewer_identity": None,
+                    "findings": [],
+                },
+            )
+            return True
+        if sql.startswith("UPDATE loop_review_evidence SET"):
+            values = _quoted_values(sql)
+            status, reviewer, findings_json, key, work_identity = values
+            row = self.rows[key]
+            assert row["work_identity"] == work_identity
+            row["status"] = status
+            row["reviewer_identity"] = reviewer
+            row["findings"] = json.loads(findings_json)
+            return True
+        raise AssertionError(sql)
+
+    def query_json_rows(self, select_sql: str) -> list[dict[str, object]] | None:
+        key = select_sql.split("request_key = '", 1)[1].split("'", 1)[0]
+        row = self.rows.get(key)
+        return [] if row is None else [dict(row)]
+
+
+class EvidenceRunner:
+    def __init__(self, target: EvidenceTarget) -> None:
+        self.target = target
+        self.current_head = target.head_sha
+        self.ci_runs: list[dict[str, object]] = []
+        self.comments: list[dict[str, object]] = []
+        self.broker_calls = 0
+        self.broker_verdict = "PASS"
+        self.move_head_after_review = False
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        environment: Mapping[str, str] | None = None,
+        timeout_seconds: int = 120,
+        capture_output: bool = True,
+    ) -> Result:
+        del cwd, environment, timeout_seconds, capture_output
+        values = tuple(command)
+        if values[:2] == ("gh", "api") and "actions/runs?" in values[-1]:
+            return Result(output=json.dumps({"workflow_runs": self.ci_runs}))
+        if values[:3] == ("gh", "pr", "view"):
+            return Result(
+                output=json.dumps(
+                    {
+                        "number": self.target.pr_number,
+                        "headRefOid": self.current_head,
+                        "baseRefName": self.target.base_branch,
+                    }
+                )
+            )
+        if values[:3] == ("gh", "api", "--paginate"):
+            return Result(output=json.dumps([self.comments]))
+        if values[0] == "reviewer-broker":
+            self.broker_calls += 1
+            request_path = Path(values[-1])
+            request = json.loads(request_path.read_text(encoding="utf-8"))
+            output = json.dumps(
+                {
+                    "request_key": request["request_key"],
+                    "target_head_sha": request["head_sha"],
+                    "verdict": self.broker_verdict,
+                    "findings": ["修正が必要"] if self.broker_verdict == "REQUEST_CHANGES" else [],
+                    "reviewer_identity": "independent-reviewer",
+                }
+            )
+            if self.move_head_after_review:
+                self.current_head = "c" * 40
+            return Result(output=output)
+        raise AssertionError(values)
+
+
+def target() -> EvidenceTarget:
+    return EvidenceTarget(
+        repository="owner/sample",
+        work_identity="work:owner/sample:1",
+        issue_number=1,
+        pr_number=7,
+        head_sha="a" * 40,
+        base_branch="main",
+        canonical_design_identities=("design:1",),
+        acceptance_digest="digest-1",
+    )
+
+
+def work() -> V2WorkObservation:
+    return V2WorkObservation(
+        work_identity="work:owner/sample:1",
+        issue_number=1,
+        issue_revision="issue-rev",
+        issue_state="OPEN",
+        lifecycle="RUNNING",
+        project_status="In progress",
+        priority="P1",
+        dependency_states=(),
+        acceptance_digest="digest-1",
+        canonical_design_identities=("design:1",),
+        active_lineage_identity="lineage:1",
+        exact_head_sha="a" * 40,
+    )
+
+
+def ci_success(run_id: int = 10, head: str = "a" * 40) -> dict[str, object]:
+    return {
+        "id": run_id,
+        "name": "CI",
+        "head_sha": head,
+        "status": "completed",
+        "conclusion": "success",
+    }
+
+
+def review_components(runner: EvidenceRunner, database: FakeDatabase) -> ReviewCoordinator:
+    store = PostgreSQLReviewEvidenceStore(database)
+    broker = TrustedReviewerBrokerAdapter(runner, ("reviewer-broker",), {})
+    reader = GitHubTargetReader(runner, {})
+    return ReviewCoordinator(store, broker, reader, "policy-v1")
+
+
+def test_ci_uses_only_exact_head() -> None:
+    item = target()
+    runner = EvidenceRunner(item)
+    runner.ci_runs = [ci_success(11, "b" * 40), ci_success(10, item.head_sha)]
+
+    evidence = GitHubExactHeadCIAdapter(runner, {}).read(item, "CI")
+
+    assert evidence.state is EvidenceState.PASS
+    assert evidence.identity == f"ci:10:{item.head_sha}"
+
+
+def test_review_request_key_changes_with_head() -> None:
+    item = target()
+    first = review_request_key(item, "ci:1", "policy-v1")
+    second = review_request_key(
+        EvidenceTarget(**{**item.__dict__, "head_sha": "b" * 40}),
+        "ci:1",
+        "policy-v1",
+    )
+    assert first != second
+
+
+def test_same_exact_review_is_not_called_twice() -> None:
+    item = target()
+    runner = EvidenceRunner(item)
+    database = FakeDatabase()
+    coordinator = review_components(runner, database)
+    ci = MachineEvidence(EvidenceState.PASS, "ci:10")
+
+    first = coordinator.ensure_review(item, ci)
+    second = coordinator.ensure_review(item, ci)
+
+    assert first.state is EvidenceState.PASS
+    assert second.state is EvidenceState.PASS
+    assert runner.broker_calls == 1
+
+
+def test_request_changes_returns_supervisor_to_repair() -> None:
+    item = target()
+    runner = EvidenceRunner(item)
+    runner.broker_verdict = "REQUEST_CHANGES"
+    coordinator = review_components(runner, FakeDatabase())
+    ci = MachineEvidence(EvidenceState.PASS, "ci:10")
+    review = coordinator.ensure_review(item, ci)
+    observation = work()
+    observation = V2WorkObservation(
+        **{
+            **observation.__dict__,
+            "verification_state": EvidenceState.PASS,
+            "verification_identity": "ci:10",
+            "review_state": review.state,
+            "review_identity": review.identity,
+        }
+    )
+
+    assert review.state is EvidenceState.REQUEST_CHANGES
+    assert derive_transition(observation) is V2Transition.REPAIR
+
+
+def test_review_result_is_stale_when_head_moves_during_call() -> None:
+    item = target()
+    runner = EvidenceRunner(item)
+    runner.move_head_after_review = True
+    coordinator = review_components(runner, FakeDatabase())
+
+    result = coordinator.ensure_review(item, MachineEvidence(EvidenceState.PASS, "ci:10"))
+
+    assert result.state is EvidenceState.NOT_RUN
+    assert result.identity is not None and result.identity.startswith("stale:")
+
+
+def test_human_verification_is_exact_head_bound() -> None:
+    item = target()
+    runner = EvidenceRunner(item)
+    runner.comments = [
+        {
+            "body": "<!-- loop-engineering-human-verification:v1 -->\n"
+            + json.dumps(
+                {
+                    "work_identity": item.work_identity,
+                    "head_sha": "b" * 40,
+                    "result": "PASS",
+                }
+            )
+        },
+        {
+            "body": "<!-- loop-engineering-human-verification:v1 -->\n"
+            + json.dumps(
+                {
+                    "work_identity": item.work_identity,
+                    "head_sha": item.head_sha,
+                    "result": "PASS",
+                }
+            )
+        },
+    ]
+
+    evidence = GitHubHumanVerificationAdapter(runner, {}).read(item, True)
+
+    assert evidence.state is EvidenceState.PASS
+    assert evidence.identity is not None
+
+
+def test_old_head_human_pass_is_not_current_pass() -> None:
+    item = target()
+    runner = EvidenceRunner(item)
+    runner.comments = [
+        {
+            "body": "<!-- loop-engineering-human-verification:v1 -->\n"
+            + json.dumps(
+                {
+                    "work_identity": item.work_identity,
+                    "head_sha": "b" * 40,
+                    "result": "PASS",
+                }
+            )
+        }
+    ]
+
+    evidence = GitHubHumanVerificationAdapter(runner, {}).read(item, True)
+
+    assert evidence.state is EvidenceState.PENDING
+
+
+def test_apply_evidence_requires_same_head() -> None:
+    item = target()
+    bundle_ci = MachineEvidence(EvidenceState.PASS, "ci")
+    from loop_engineering.v2_evidence import EvidenceBundle
+
+    bundle = EvidenceBundle(
+        item,
+        bundle_ci,
+        MachineEvidence(EvidenceState.PASS, "review"),
+        MachineEvidence(EvidenceState.NOT_REQUIRED, None),
+    )
+    updated = apply_evidence(work(), bundle)
+
+    assert updated.verification_state is EvidenceState.PASS
+    assert updated.review_state is EvidenceState.PASS
+
+
+def _quoted_values(sql: str) -> list[str]:
+    values: list[str] = []
+    index = 0
+    while index < len(sql):
+        if sql[index] != "'":
+            index += 1
+            continue
+        index += 1
+        current = []
+        while index < len(sql):
+            if sql[index] == "'" and index + 1 < len(sql) and sql[index + 1] == "'":
+                current.append("'")
+                index += 2
+                continue
+            if sql[index] == "'":
+                index += 1
+                break
+            current.append(sql[index])
+            index += 1
+        values.append("".join(current))
+    return values
+
+
+def _sql_value(sql: str, start: str, end: str) -> str:
+    return sql.split(start, 1)[1].split(end, 1)[0]

--- a/tests/loop_engineering/test_v2_evidence.py
+++ b/tests/loop_engineering/test_v2_evidence.py
@@ -1,9 +1,10 @@
 import json
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from loop_engineering.v2_evidence import (
+    EvidenceBundle,
     EvidenceTarget,
     GitHubExactHeadCIAdapter,
     GitHubHumanVerificationAdapter,
@@ -39,8 +40,8 @@ class FakeDatabase:
 
     def execute_sql(self, sql: str) -> bool:
         if sql.startswith("INSERT INTO loop_review_evidence"):
-            key = _sql_value(sql, "VALUES ('", "', '")
             values = _quoted_values(sql)
+            key = values[0]
             self.rows.setdefault(
                 key,
                 {
@@ -186,7 +187,7 @@ def test_review_request_key_changes_with_head() -> None:
     item = target()
     first = review_request_key(item, "ci:1", "policy-v1")
     second = review_request_key(
-        EvidenceTarget(**{**item.__dict__, "head_sha": "b" * 40}),
+        replace(item, head_sha="b" * 40),
         "ci:1",
         "policy-v1",
     )
@@ -215,15 +216,12 @@ def test_request_changes_returns_supervisor_to_repair() -> None:
     coordinator = review_components(runner, FakeDatabase())
     ci = MachineEvidence(EvidenceState.PASS, "ci:10")
     review = coordinator.ensure_review(item, ci)
-    observation = work()
-    observation = V2WorkObservation(
-        **{
-            **observation.__dict__,
-            "verification_state": EvidenceState.PASS,
-            "verification_identity": "ci:10",
-            "review_state": review.state,
-            "review_identity": review.identity,
-        }
+    observation = replace(
+        work(),
+        verification_state=EvidenceState.PASS,
+        verification_identity="ci:10",
+        review_state=review.state,
+        review_identity=review.identity,
     )
 
     assert review.state is EvidenceState.REQUEST_CHANGES
@@ -297,12 +295,9 @@ def test_old_head_human_pass_is_not_current_pass() -> None:
 
 def test_apply_evidence_requires_same_head() -> None:
     item = target()
-    bundle_ci = MachineEvidence(EvidenceState.PASS, "ci")
-    from loop_engineering.v2_evidence import EvidenceBundle
-
     bundle = EvidenceBundle(
         item,
-        bundle_ci,
+        MachineEvidence(EvidenceState.PASS, "ci"),
         MachineEvidence(EvidenceState.PASS, "review"),
         MachineEvidence(EvidenceState.NOT_REQUIRED, None),
     )
@@ -320,7 +315,7 @@ def _quoted_values(sql: str) -> list[str]:
             index += 1
             continue
         index += 1
-        current = []
+        current: list[str] = []
         while index < len(sql):
             if sql[index] == "'" and index + 1 < len(sql) and sql[index + 1] == "'":
                 current.append("'")
@@ -333,7 +328,3 @@ def _quoted_values(sql: str) -> list[str]:
             index += 1
         values.append("".join(current))
     return values
-
-
-def _sql_value(sql: str, start: str, end: str) -> str:
-    return sql.split(start, 1)[1].split(end, 1)[0]


### PR DESCRIPTION
## 関連Issue

Closes #87
Parent manufacturing: #81
Depends on: #85, #86

## 設計

`docs/architecture/v2/evidence_review_human_verification.md` を先行追加し、CI / Independent Review / Human Verificationをexact HEADへbindする契約を確定した。

## 実装

- GitHub Actions exact-head CI evidence
- deterministic ReviewRequestKey
- PostgreSQL review request/result persistence (`0009_v2_review_evidence.sql`)
- Host-side trusted reviewer broker command adapter
- review call前後のPR HEAD stale guard
- REQUEST_CHANGESをSupervisor REPAIRへ投影
- Human Verificationはexact HEAD付きmachine markerだけを読取
- old-head CI/review/Human PASSの流用禁止
- EvidenceBundleをV2WorkObservationへ投影

## 検証

- exact-head CIのみ採用
- HEAD変更でReviewRequestKey変更
- same exact reviewのbroker重複call抑止
- REQUEST_CHANGES→REPAIR
- review中HEAD移動のstale reject
- Human Verification exact-head binding
- old-head Human PASS拒否
