### PR TITLE
feat: V2自律Runnerと停止復元を完成する

### DIFF
--- a/docs/architecture/v2/autonomous_runner_recovery.md
+++ b/docs/architecture/v2/autonomous_runner_recovery.md
@@ -1,0 +1,242 @@
+# V2 Autonomous Runner / Recovery仕様
+
+管理Issue: #88
+親Issue: #81
+依存: #83, #84, #85, #86, #87
+上位正本: `autonomous_development_completion_contract.md`
+
+## 1. 目的
+
+Goal bootstrap / Planning / Work Queue / Supervisor / Codex Implementer / GitHub development lineage / exact-head evidence / Integrationを、1つのV2 Application Runnerへ接続する。
+
+人間がWorkごとのTaskPacketやeffectを逐次発行しなくても、初期Product RegistrationとGoal DefinitionからGoal完了まで有用な遷移を継続できることを目的とする。
+
+旧actual-host continuous loopを復活させない。Issue本文・Issueコメント・PR本文の自然文をcurrent stateやresume Authorityにしない。
+
+## 2. Authority
+
+- Requirement / acceptance / dependency / planning field: GitHub Issue / Project
+- current Work / transition / checkpoint / dispatch / effect intent / review request: PostgreSQL
+- branch / PR / exact HEAD / CI / review / merge: live provider readback
+- Goal / Profile: Host Product Registrationで固定したtrusted source
+
+restart時も同じAuthorityを使用する。
+
+## 3. Runner iteration
+
+1回のiterationは次の順序とする。
+
+```text
+PREFLIGHT
+→ BOOTSTRAP / PLAN (必要な場合のみ)
+→ QUEUE SYNCHRONIZE
+→ LINEAGE OBSERVE
+→ EVIDENCE OBSERVE
+→ SUPERVISOR DECIDE
+→ DISPATCH INTENT RECORD
+→ TRANSITION EXECUTE または SAFE YIELD
+→ FRESH READBACK
+→ RUNTIME CHECKPOINT
+```
+
+1 iterationに複数の外部mutationを無制限に詰め込まない。外部effectを持つtransitionは既存のDB intent/readback契約を使用する。
+
+## 4. AutonomousRuntimeState
+
+PostgreSQLへProduct/Goal単位のrunner状態を保持する。
+
+- `runtime_identity`
+- `product_key`
+- `repository`
+- `goal_revision`
+- `status`: `ACTIVE | WAITING | INTERVENTION_REQUIRED | COMPLETED`
+- `current_work_identity?`
+- `last_schedule_key?`
+- `last_progress_fingerprint?`
+- `no_progress_count`
+- `last_detail`
+- `completed_at?`
+
+さらにdispatch journalを保持する。
+
+- `schedule_key`
+- `runtime_identity`
+- `work_identity`
+- `transition`
+- `status`: `DISPATCHED | COMPLETED | WAITING | FAILED | SUPERSEDED`
+
+同じexact observationから生成された同じScheduleKeyを、restart後に無条件再dispatchしない。
+
+## 5. Progress fingerprint
+
+Runnerはiteration開始/終了時にtyped stateからfingerprintを生成する。
+
+入力:
+
+- goal revision
+- current Work identity
+- Work observation identities/revisions
+- exact HEAD
+- CI/review/Human evidence identities
+- latest packet/checkpoint identities
+- pending effect有無
+- Supervisor decision
+
+同じfingerprintで同じScheduleKeyを繰り返す場合、provider再送を行わない。
+
+bounded `no_progress_count` を超えた場合:
+
+- 外部待ちの根拠がある: `WAITING`
+- provider/DB conflictや安全証明不能: `INTERVENTION_REQUIRED`
+- repair可能なCI/review failure: REPAIRへ戻す
+
+## 6. Lineage observation
+
+#84 Queueのtyped WorkDefinitionに、live GitHub development lineageを重ねる。
+
+branchはHost Registrationの`work_branch_template`からWork Issue番号を使って決定する。
+
+観測:
+
+- remote branch存在/HEAD
+- open PR head/base/draft
+- competing open PR
+- merged state
+
+0件なら未実装Work、1件ならactive lineage、複数競合ならfail-closed。
+
+historical closed PRをcurrent PRとして採用しない。
+
+## 7. Evidence observation
+
+active PRが存在するWorkだけ #87 EvidenceCoordinatorへ渡す。
+
+- CI PENDING / NOT_RUN: safe wait
+- CI FAIL: REPAIR
+- CI PASS: independent reviewをexact HEADでensure
+- Review REQUEST_CHANGES: REPAIR
+- Review PASS: Human Verification policy確認
+- Human pending: safe wait
+- all PASS: INTEGRATE
+
+old-head evidenceは採用しない。
+
+## 8. Transition execution
+
+### DESIGN / IMPLEMENT / REPAIR
+
+- Supervisor decisionから`DevelopmentTaskPacket`を組み立てる。
+- #85 proposal modeを呼ぶ。
+- proposalを#86 trusted materializerへ渡す。
+- active lineageを#86 remote effectへpublishする。
+- fresh PR/head readbackを行う。
+
+DESIGN成功後は変更されたcanonical design targetのidentityを新HEADへbindし、次iterationでIMPLEMENT可能にする。
+
+### VERIFY / REVIEW / HUMAN_VERIFY
+
+これらはevidence observerが外部状態を確認する段階であり、pending状態でmutationを作らない。
+
+必要なprovider requestは#87 ReviewCoordinatorのrequest-key契約だけで行う。
+
+### INTEGRATE
+
+- exact current HEAD
+- CI PASS
+- review PASS
+- required Human PASS
+- competing lineageなし
+- pending/UNCERTAIN effectなし
+
+をfresh確認後、既存V2 MERGE effectのintent/readback契約でmergeする。
+
+### COMPLETE_WORK
+
+merge readback後、DB lifecycleを`COMPLETED`へ進め、Product Issueをcloseし、Project StatusをDoneへ投影する。Issue close/Project updateもtarget限定readbackを持つ。
+
+## 9. WaitingとHuman Intervention
+
+`WAITING`:
+
+- CI pending
+- review provider pending
+- Human Verification pending
+- dependency pending
+- lease held
+- provider eventual consistency
+
+`INTERVENTION_REQUIRED`:
+
+- duplicate/competing current lineage
+- target identity conflict
+- unresolved UNCERTAIN effect
+- DB corruption/unavailable
+- trusted cleanup証明不能
+- required provider credential/config欠落
+- policyで人間判断が必須なreview escalation
+
+repair可能なtest/CI/review failureをHuman Interventionへ送らない。
+
+## 10. Restart / crash recovery
+
+起動時にPostgreSQLからruntime/work/effect状態を読む。
+
+- pending `INTENT_RECORDED` / `UNCERTAIN` effectはfresh readback優先
+- CONFIRMED済みeffectを再送しない
+- active WorkはQueue/live lineageから再構成
+- last ScheduleKeyと同一stateならduplicate dispatchを抑止
+- Issueコメント自然文をparseしてresumeしない
+
+crash window:
+
+- dispatch intent前: 再decide可
+- dispatch intent後 / provider call前: journalにより同一ScheduleKey再送を抑止し、transition固有readbackでreconcile
+- provider call後 / outcome確定前: provider/live stateをreadback
+- outcome後 / checkpoint前: DB terminal stateからcheckpointを再構成
+
+## 11. Goal completion
+
+Goal完了は次をすべてfreshに満たす場合のみ。
+
+- 全planned Work lifecycle `COMPLETED`
+- 全Work Issue/Project planning stateが完了条件と整合
+- pending/UNCERTAIN effectなし
+- current Workなし
+- Goal acceptance evaluator PASS
+
+完了後runtimeを`COMPLETED`へ確定し、自律dispatchを停止する。
+
+## 12. Platform self-improvement境界
+
+Product側の修正で解消できないPlatform contract/safety/provider/recovery不具合はSelfImprovementPortへtyped reportを渡す。
+
+Product Work IssueへPlatform内部の実装詳細を混ぜない。SelfImprovement target未設定時に別Repositoryへ勝手に書き込まない。
+
+## 13. Runner API
+
+```text
+V2AutonomousRunner.run(registration, max_iterations=N)
+→ AutonomousRunResult
+```
+
+status:
+
+- `GOAL_COMPLETED`
+- `PROGRESSED`
+- `WAITING`
+- `INTERVENTION_REQUIRED`
+- `ITERATION_LIMIT`
+
+`run()`はbounded iterationを必須とし、無限whileをCore APIに埋め込まない。常駐processは上位launcherがbounded runを繰り返す。
+
+## 14. 完了条件
+
+- bootstrap済み/未bootstrap両方から開始できる。
+- Workを人間が逐次選択しない。
+- wait-only Workが別のdependency-ready Workを塞がない。
+- restart後にDB/live readbackから継続できる。
+- pending/UNCERTAIN effectを盲目的再送しない。
+- same ScheduleKeyの無限dispatchを防ぐ。
+- Work完了後に次Workへ進む。
+- fresh evidenceからGoal完了を確定する。
+- tests / exact-head CIを通過する。

--- a/src/loop_engineering/migrations/0010_v2_autonomous_runtime.sql
+++ b/src/loop_engineering/migrations/0010_v2_autonomous_runtime.sql
@@ -15,6 +15,14 @@ CREATE TABLE IF NOT EXISTS loop_autonomous_runtimes (
     UNIQUE (product_key, repository, goal_revision)
 );
 
+CREATE TABLE IF NOT EXISTS loop_goal_plans (
+    runtime_identity TEXT PRIMARY KEY REFERENCES loop_autonomous_runtimes(runtime_identity),
+    proposal_identity TEXT NOT NULL,
+    proposal_json JSONB NOT NULL,
+    projection_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
 CREATE TABLE IF NOT EXISTS loop_autonomous_dispatches (
     schedule_key TEXT PRIMARY KEY,
     runtime_identity TEXT NOT NULL REFERENCES loop_autonomous_runtimes(runtime_identity),

--- a/src/loop_engineering/migrations/0010_v2_autonomous_runtime.sql
+++ b/src/loop_engineering/migrations/0010_v2_autonomous_runtime.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS loop_autonomous_runtimes (
+    runtime_identity TEXT PRIMARY KEY,
+    product_key TEXT NOT NULL,
+    repository TEXT NOT NULL,
+    goal_revision TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('ACTIVE', 'WAITING', 'INTERVENTION_REQUIRED', 'COMPLETED')),
+    current_work_identity TEXT NULL,
+    last_schedule_key TEXT NULL,
+    last_progress_fingerprint TEXT NULL,
+    no_progress_count INTEGER NOT NULL DEFAULT 0 CHECK (no_progress_count >= 0),
+    last_detail TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at TIMESTAMPTZ NULL,
+    UNIQUE (product_key, repository, goal_revision)
+);
+
+CREATE TABLE IF NOT EXISTS loop_autonomous_dispatches (
+    schedule_key TEXT PRIMARY KEY,
+    runtime_identity TEXT NOT NULL REFERENCES loop_autonomous_runtimes(runtime_identity),
+    work_identity TEXT NOT NULL,
+    transition TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('DISPATCHED', 'COMPLETED', 'WAITING', 'FAILED', 'SUPERSEDED')),
+    detail TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS loop_autonomous_dispatches_runtime_idx
+    ON loop_autonomous_dispatches (runtime_identity, created_at);

--- a/src/loop_engineering/v2_autonomous_runner.py
+++ b/src/loop_engineering/v2_autonomous_runner.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 import subprocess
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
@@ -13,7 +12,6 @@ from typing import Protocol
 
 from .v2_autonomous_runtime import (
     AutonomousDispatch,
-    AutonomousRuntimeState,
     AutonomousRuntimeUnavailable,
     PostgreSQLAutonomousRuntimeStore,
     runtime_identity,
@@ -21,8 +19,8 @@ from .v2_autonomous_runtime import (
 from .v2_evidence import EvidenceTarget, V2EvidenceCoordinator, apply_evidence
 from .v2_goal_planning import (
     BootstrapResult,
-    PlanningProjectionPort,
     PlannedWork,
+    PlanningProjectionPort,
     ProductDevelopmentRegistration,
     V2GoalBootstrapService,
 )
@@ -30,14 +28,11 @@ from .v2_supervisor import (
     V2Supervisor,
     V2SupervisorDecision,
     V2SupervisorDisposition,
-    V2Transition,
     V2WorkObservation,
     derive_transition,
     schedule_key,
 )
 from .v2_work_queue import V2WorkQueueSnapshot
-
-_PR_ID_RE = re.compile(r"pr:(\d+)")
 
 
 class AutonomousRunStatus(str, Enum):
@@ -71,7 +66,10 @@ class AutonomousRunResult:
 
 
 class WorkQueuePort(Protocol):
-    def synchronize(self, registration: ProductDevelopmentRegistration) -> V2WorkQueueSnapshot: ...
+    def synchronize(
+        self,
+        registration: ProductDevelopmentRegistration,
+    ) -> V2WorkQueueSnapshot: ...
 
 
 class TransitionExecutorPort(Protocol):
@@ -105,7 +103,7 @@ class _LineageSnapshot:
 
 
 class DurableGoalBootstrap:
-    """最初に採用したPlanをDBへ固定し、restart後は同じPlanだけを再projectionする。"""
+    """採用済みPlanをDBへ固定し、restart後にPlannerを再実行しない。"""
 
     def __init__(
         self,
@@ -131,7 +129,7 @@ class DurableGoalBootstrap:
 
 
 class GitHubAutonomousLineageObserver:
-    """Work branchに対応するcurrent PR/headとcanonical design blobをlive readbackする。"""
+    """Work branchに対応するcurrent PR/head/canonical designをlive readbackする。"""
 
     def __init__(self, runner: LineageCommandRunner) -> None:
         self._runner = runner
@@ -144,13 +142,10 @@ class GitHubAutonomousLineageObserver:
     ) -> _LineageSnapshot:
         branch = _work_branch(registration.work_branch_template, work.issue_number)
         open_prs = self._pr_list(registration.repository_identity, branch, "open")
-        if open_prs is None:
+        if open_prs is None or len(open_prs) > 1:
             return _LineageSnapshot(replace(work, unresolved_conflict=True), None)
-        if len(open_prs) > 1:
-            return _LineageSnapshot(replace(work, unresolved_conflict=True), None)
-        if len(open_prs) == 1:
-            pr = open_prs[0]
-            number, head, base = _pr_identity(pr)
+        if open_prs:
+            number, head, base = _pr_identity(open_prs[0])
             if number is None or head is None or base != registration.trunk_branch:
                 return _LineageSnapshot(replace(work, unresolved_conflict=True), None)
             designs = self._design_identities(
@@ -176,8 +171,7 @@ class GitHubAutonomousLineageObserver:
             return _LineageSnapshot(replace(work, unresolved_conflict=True), None)
         if not merged:
             return _LineageSnapshot(work, None)
-        latest = max(merged, key=_pr_number_sort)
-        number, head, base = _pr_identity(latest)
+        number, head, base = _pr_identity(max(merged, key=_pr_number_sort))
         if number is None or head is None or base != registration.trunk_branch:
             return _LineageSnapshot(replace(work, unresolved_conflict=True), None)
         return _LineageSnapshot(
@@ -227,24 +221,16 @@ class GitHubAutonomousLineageObserver:
         head: str,
         paths: tuple[str, ...],
     ) -> tuple[str, ...] | None:
-        if not paths:
-            return ()
         identities: list[str] = []
         for path in paths:
             try:
                 raw = self._runner.run(
-                    (
-                        "gh",
-                        "api",
-                        f"repos/{repository}/contents/{path}?ref={head}",
-                    )
+                    ("gh", "api", f"repos/{repository}/contents/{path}?ref={head}")
                 )
                 payload = json.loads(raw)
             except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError):
                 return None
-            if not isinstance(payload, dict):
-                return None
-            blob = payload.get("sha")
+            blob = payload.get("sha") if isinstance(payload, dict) else None
             if not isinstance(blob, str) or not blob:
                 return None
             identities.append(f"design:{path}:{blob}")
@@ -261,7 +247,10 @@ class EvidenceEnricher:
         snapshot: _LineageSnapshot,
         planned: PlannedWork,
     ) -> V2WorkObservation:
-        work = snapshot.observation
+        work = replace(
+            snapshot.observation,
+            human_verification_required=planned.human_verification_required,
+        )
         if snapshot.pr_number is None or work.exact_head_sha is None or work.merged:
             return work
         target = EvidenceTarget(
@@ -324,242 +313,250 @@ class V2AutonomousRunner:
         if not 1 <= max_iterations <= 1000:
             raise ValueError("AUTONOMOUS_ITERATION_LIMIT_INVALID")
         try:
-            state = self._runtime.ensure_runtime(registration)
-            if state.status == "COMPLETED":
-                return AutonomousRunResult(
-                    AutonomousRunStatus.GOAL_COMPLETED,
-                    "GOAL_ALREADY_COMPLETED",
-                    0,
+            return self._run(registration, max_iterations)
+        except (AutonomousRuntimeUnavailable, ValueError, RuntimeError) as error:
+            return AutonomousRunResult(
+                AutonomousRunStatus.INTERVENTION_REQUIRED,
+                str(error),
+                0,
+                runtime_identity(registration),
+            )
+
+    def _run(
+        self,
+        registration: ProductDevelopmentRegistration,
+        max_iterations: int,
+    ) -> AutonomousRunResult:
+        state = self._runtime.ensure_runtime(registration)
+        if state.status == "COMPLETED":
+            return AutonomousRunResult(
+                AutonomousRunStatus.GOAL_COMPLETED,
+                "GOAL_ALREADY_COMPLETED",
+                0,
+                state.runtime_identity,
+            )
+        bootstrap = self._bootstrap.ensure(registration)
+        planned = _planned_by_issue(bootstrap)
+        progressed = False
+
+        for iteration in range(1, max_iterations + 1):
+            queue = self._queue.synchronize(registration)
+            works = self._observe_all(registration, queue.works, planned)
+            dispatched = self._runtime.dispatched_schedule_keys(state.runtime_identity)
+            selectable, suppressed = _without_dispatched(
+                registration.goal_revision,
+                works,
+                dispatched,
+            )
+            acceptance = self._goal_acceptance.complete(registration, bootstrap, works)
+            acceptance = acceptance and not suppressed
+            current = _current_if_selectable(queue.current_work_identity, selectable)
+            decision = self._supervisor.decide(
+                goal_revision=registration.goal_revision,
+                works=selectable,
+                current_work_identity=current,
+                pending_effect=queue.pending_effect,
+                goal_acceptance_complete=acceptance,
+            )
+            fingerprint = _progress_fingerprint(
+                registration.goal_revision,
+                works,
+                queue.pending_effect,
+                decision,
+            )
+            no_progress = (
+                state.no_progress_count + 1
+                if fingerprint == state.last_progress_fingerprint
+                else 0
+            )
+
+            terminal = self._terminal_decision(
+                state.runtime_identity,
+                current,
+                decision,
+                fingerprint,
+                no_progress,
+                queue.pending_effect,
+                iteration,
+            )
+            if terminal is not None:
+                return terminal
+
+            if (
+                decision.work_identity is None
+                or decision.transition is None
+                or decision.schedule_key is None
+            ):
+                raise AutonomousRuntimeUnavailable("SUPERVISOR_ACTION_IDENTITY_MISSING")
+            work = next(item for item in works if item.work_identity == decision.work_identity)
+            planned_work = planned.get(work.issue_number)
+            if planned_work is None:
+                raise AutonomousRuntimeUnavailable("PLANNED_WORK_MAPPING_MISSING")
+            dispatch = AutonomousDispatch(
+                decision.schedule_key,
+                state.runtime_identity,
+                work.work_identity,
+                decision.transition.value,
+                "DISPATCHED",
+                "SUPERVISOR_DISPATCH",
+            )
+            if not self._runtime.dispatch(dispatch):
+                state = self._runtime.update_runtime(
                     state.runtime_identity,
-                    None,
+                    status="WAITING",
+                    current_work_identity=work.work_identity,
+                    schedule_key=decision.schedule_key,
+                    progress_fingerprint=fingerprint,
+                    no_progress_count=no_progress,
+                    detail="DUPLICATE_DISPATCH_SUPPRESSED",
                 )
-            bootstrap = self._bootstrap.ensure(registration)
-            planned = _planned_by_issue(bootstrap)
-            progressed = False
-            for iteration in range(1, max_iterations + 1):
-                queue = self._queue.synchronize(registration)
-                works = self._observe_all(registration, queue.works, planned)
-                dispatched = self._runtime.dispatched_schedule_keys(state.runtime_identity)
-                selectable, suppressed_incomplete = _without_dispatched(
-                    registration.goal_revision,
-                    works,
-                    dispatched,
-                )
-                acceptance = self._goal_acceptance.complete(registration, bootstrap, works)
-                if suppressed_incomplete:
-                    acceptance = False
-                current = queue.current_work_identity
-                if current is not None and all(
-                    work.work_identity != current for work in selectable
-                ):
-                    current = None
-                decision = self._supervisor.decide(
-                    goal_revision=registration.goal_revision,
-                    works=selectable,
-                    current_work_identity=current,
-                    dispatched_schedule_keys=frozenset(),
-                    pending_effect=queue.pending_effect,
-                    goal_acceptance_complete=acceptance,
-                )
-                fingerprint = _progress_fingerprint(
-                    registration.goal_revision,
-                    works,
-                    queue.pending_effect,
-                    decision,
-                )
-                no_progress = (
-                    state.no_progress_count + 1
-                    if fingerprint == state.last_progress_fingerprint
-                    else 0
-                )
+                continue
 
-                if decision.disposition is V2SupervisorDisposition.COMPLETE_GOAL:
-                    state = self._runtime.update_runtime(
-                        state.runtime_identity,
-                        status="COMPLETED",
-                        current_work_identity=None,
-                        schedule_key=None,
-                        progress_fingerprint=fingerprint,
-                        no_progress_count=0,
-                        detail=decision.detail,
-                    )
-                    return AutonomousRunResult(
-                        AutonomousRunStatus.GOAL_COMPLETED,
-                        decision.detail,
-                        iteration,
-                        state.runtime_identity,
-                        None,
-                    )
-                if decision.disposition is V2SupervisorDisposition.INTERVENTION_REQUIRED:
-                    state = self._runtime.update_runtime(
-                        state.runtime_identity,
-                        status="INTERVENTION_REQUIRED",
-                        current_work_identity=current,
-                        schedule_key=None,
-                        progress_fingerprint=fingerprint,
-                        no_progress_count=no_progress,
-                        detail=decision.detail,
-                    )
-                    return AutonomousRunResult(
-                        AutonomousRunStatus.INTERVENTION_REQUIRED,
-                        decision.detail,
-                        iteration,
-                        state.runtime_identity,
-                        current,
-                    )
-                if decision.disposition is V2SupervisorDisposition.YIELD_EXTERNAL:
-                    detail = decision.detail
-                    if no_progress >= self._no_progress_limit and queue.pending_effect:
-                        detail = "PENDING_EFFECT_RECONCILIATION_REQUIRED"
-                        status = "INTERVENTION_REQUIRED"
-                        result_status = AutonomousRunStatus.INTERVENTION_REQUIRED
-                    else:
-                        status = "WAITING"
-                        result_status = AutonomousRunStatus.WAITING
-                    state = self._runtime.update_runtime(
-                        state.runtime_identity,
-                        status=status,
-                        current_work_identity=current,
-                        schedule_key=decision.schedule_key,
-                        progress_fingerprint=fingerprint,
-                        no_progress_count=no_progress,
-                        detail=detail,
-                    )
-                    return AutonomousRunResult(
-                        result_status,
-                        detail,
-                        iteration,
-                        state.runtime_identity,
-                        current,
-                    )
-
-                if (
-                    decision.work_identity is None
-                    or decision.transition is None
-                    or decision.schedule_key is None
-                ):
-                    raise AutonomousRuntimeUnavailable("SUPERVISOR_ACTION_IDENTITY_MISSING")
-                work = next(
-                    item for item in works if item.work_identity == decision.work_identity
+            outcome = self._transitions.execute(
+                registration,
+                bootstrap,
+                work,
+                planned_work,
+                decision,
+            )
+            self._runtime.update_dispatch(
+                decision.schedule_key,
+                _dispatch_status(outcome.status),
+                outcome.detail,
+            )
+            if outcome.status is TransitionExecutionStatus.INTERVENTION_REQUIRED:
+                self._runtime.update_runtime(
+                    state.runtime_identity,
+                    status="INTERVENTION_REQUIRED",
+                    current_work_identity=work.work_identity,
+                    schedule_key=decision.schedule_key,
+                    progress_fingerprint=fingerprint,
+                    no_progress_count=no_progress,
+                    detail=outcome.detail,
                 )
-                planned_work = planned.get(work.issue_number)
-                if planned_work is None:
-                    raise AutonomousRuntimeUnavailable("PLANNED_WORK_MAPPING_MISSING")
-                dispatch = AutonomousDispatch(
-                    decision.schedule_key,
+                return AutonomousRunResult(
+                    AutonomousRunStatus.INTERVENTION_REQUIRED,
+                    outcome.detail,
+                    iteration,
                     state.runtime_identity,
                     work.work_identity,
-                    decision.transition.value,
-                    "DISPATCHED",
-                    "SUPERVISOR_DISPATCH",
                 )
-                if not self._runtime.dispatch(dispatch):
-                    state = self._runtime.update_runtime(
-                        state.runtime_identity,
-                        status="WAITING",
-                        current_work_identity=work.work_identity,
-                        schedule_key=decision.schedule_key,
-                        progress_fingerprint=fingerprint,
-                        no_progress_count=no_progress,
-                        detail="DUPLICATE_DISPATCH_SUPPRESSED",
-                    )
-                    continue
-                outcome = self._transitions.execute(
-                    registration,
-                    bootstrap,
-                    work,
-                    planned_work,
-                    decision,
-                )
-                dispatch_status = _dispatch_status(outcome.status)
-                self._runtime.update_dispatch(
-                    decision.schedule_key,
-                    dispatch_status,
-                    outcome.detail,
-                )
-                if outcome.status is TransitionExecutionStatus.INTERVENTION_REQUIRED:
-                    state = self._runtime.update_runtime(
-                        state.runtime_identity,
-                        status="INTERVENTION_REQUIRED",
-                        current_work_identity=work.work_identity,
-                        schedule_key=decision.schedule_key,
-                        progress_fingerprint=fingerprint,
-                        no_progress_count=no_progress,
-                        detail=outcome.detail,
-                    )
-                    return AutonomousRunResult(
-                        AutonomousRunStatus.INTERVENTION_REQUIRED,
-                        outcome.detail,
-                        iteration,
-                        state.runtime_identity,
-                        work.work_identity,
-                    )
-                if outcome.status is TransitionExecutionStatus.WAITING:
-                    state = self._runtime.update_runtime(
-                        state.runtime_identity,
-                        status="ACTIVE",
-                        current_work_identity=work.work_identity,
-                        schedule_key=decision.schedule_key,
-                        progress_fingerprint=fingerprint,
-                        no_progress_count=no_progress,
-                        detail=outcome.detail,
-                    )
-                    continue
-                if outcome.status is TransitionExecutionStatus.FAILED:
-                    if no_progress >= self._no_progress_limit:
-                        state = self._runtime.update_runtime(
-                            state.runtime_identity,
-                            status="WAITING",
-                            current_work_identity=work.work_identity,
-                            schedule_key=decision.schedule_key,
-                            progress_fingerprint=fingerprint,
-                            no_progress_count=no_progress,
-                            detail="REPAIRABLE_FAILURE_RETRY_BOUNDED",
-                        )
-                        return AutonomousRunResult(
-                            AutonomousRunStatus.WAITING,
-                            "REPAIRABLE_FAILURE_RETRY_BOUNDED",
-                            iteration,
-                            state.runtime_identity,
-                            work.work_identity,
-                        )
-                    state = self._runtime.update_runtime(
-                        state.runtime_identity,
-                        status="ACTIVE",
-                        current_work_identity=work.work_identity,
-                        schedule_key=decision.schedule_key,
-                        progress_fingerprint=fingerprint,
-                        no_progress_count=no_progress,
-                        detail=outcome.detail,
-                    )
-                    continue
-
-                progressed = True
+            if outcome.status is TransitionExecutionStatus.FAILED:
                 state = self._runtime.update_runtime(
                     state.runtime_identity,
                     status="ACTIVE",
                     current_work_identity=work.work_identity,
                     schedule_key=decision.schedule_key,
-                    progress_fingerprint=None,
-                    no_progress_count=0,
+                    progress_fingerprint=fingerprint,
+                    no_progress_count=no_progress,
                     detail=outcome.detail,
                 )
-            return AutonomousRunResult(
-                AutonomousRunStatus.PROGRESSED if progressed else AutonomousRunStatus.ITERATION_LIMIT,
-                "AUTONOMOUS_ITERATION_LIMIT_REACHED",
-                max_iterations,
+                continue
+            if outcome.status is TransitionExecutionStatus.WAITING:
+                state = self._runtime.update_runtime(
+                    state.runtime_identity,
+                    status="ACTIVE",
+                    current_work_identity=work.work_identity,
+                    schedule_key=decision.schedule_key,
+                    progress_fingerprint=fingerprint,
+                    no_progress_count=no_progress,
+                    detail=outcome.detail,
+                )
+                continue
+
+            progressed = True
+            state = self._runtime.update_runtime(
                 state.runtime_identity,
-                state.current_work_identity,
+                status="ACTIVE",
+                current_work_identity=work.work_identity,
+                schedule_key=decision.schedule_key,
+                progress_fingerprint=None,
+                no_progress_count=0,
+                detail=outcome.detail,
             )
-        except (AutonomousRuntimeUnavailable, ValueError) as error:
-            identity = runtime_identity(registration)
+
+        result_status = (
+            AutonomousRunStatus.PROGRESSED
+            if progressed
+            else AutonomousRunStatus.ITERATION_LIMIT
+        )
+        return AutonomousRunResult(
+            result_status,
+            "AUTONOMOUS_ITERATION_LIMIT_REACHED",
+            max_iterations,
+            state.runtime_identity,
+            state.current_work_identity,
+        )
+
+    def _terminal_decision(
+        self,
+        runtime_identity_value: str,
+        current_work_identity: str | None,
+        decision: V2SupervisorDecision,
+        fingerprint: str,
+        no_progress: int,
+        pending_effect: bool,
+        iteration: int,
+    ) -> AutonomousRunResult | None:
+        if decision.disposition is V2SupervisorDisposition.COMPLETE_GOAL:
+            self._runtime.update_runtime(
+                runtime_identity_value,
+                status="COMPLETED",
+                current_work_identity=None,
+                schedule_key=None,
+                progress_fingerprint=fingerprint,
+                no_progress_count=0,
+                detail=decision.detail,
+            )
+            return AutonomousRunResult(
+                AutonomousRunStatus.GOAL_COMPLETED,
+                decision.detail,
+                iteration,
+                runtime_identity_value,
+            )
+        if decision.disposition is V2SupervisorDisposition.INTERVENTION_REQUIRED:
+            self._runtime.update_runtime(
+                runtime_identity_value,
+                status="INTERVENTION_REQUIRED",
+                current_work_identity=current_work_identity,
+                schedule_key=None,
+                progress_fingerprint=fingerprint,
+                no_progress_count=no_progress,
+                detail=decision.detail,
+            )
             return AutonomousRunResult(
                 AutonomousRunStatus.INTERVENTION_REQUIRED,
-                str(error),
-                0,
-                identity,
-                None,
+                decision.detail,
+                iteration,
+                runtime_identity_value,
+                current_work_identity,
             )
+        if decision.disposition is not V2SupervisorDisposition.YIELD_EXTERNAL:
+            return None
+        if no_progress >= self._no_progress_limit and pending_effect:
+            detail = "PENDING_EFFECT_RECONCILIATION_REQUIRED"
+            status = "INTERVENTION_REQUIRED"
+            result_status = AutonomousRunStatus.INTERVENTION_REQUIRED
+        else:
+            detail = decision.detail
+            status = "WAITING"
+            result_status = AutonomousRunStatus.WAITING
+        self._runtime.update_runtime(
+            runtime_identity_value,
+            status=status,
+            current_work_identity=current_work_identity,
+            schedule_key=decision.schedule_key,
+            progress_fingerprint=fingerprint,
+            no_progress_count=no_progress,
+            detail=detail,
+        )
+        return AutonomousRunResult(
+            result_status,
+            detail,
+            iteration,
+            runtime_identity_value,
+            current_work_identity,
+        )
 
     def _observe_all(
         self,
@@ -605,11 +602,23 @@ def _without_dispatched(
             continue
         key = schedule_key(goal_revision, work, transition)
         if key in dispatched:
-            if work.lifecycle != "COMPLETED":
-                suppressed_incomplete = True
+            suppressed_incomplete = suppressed_incomplete or work.lifecycle != "COMPLETED"
             continue
         kept.append(work)
     return tuple(kept), suppressed_incomplete
+
+
+def _current_if_selectable(
+    current_work_identity: str | None,
+    works: tuple[V2WorkObservation, ...],
+) -> str | None:
+    if current_work_identity is None:
+        return None
+    return (
+        current_work_identity
+        if any(work.work_identity == current_work_identity for work in works)
+        else None
+    )
 
 
 def _progress_fingerprint(
@@ -633,6 +642,7 @@ def _progress_fingerprint(
                 "id": work.work_identity,
                 "revision": work.issue_revision,
                 "lifecycle": work.lifecycle,
+                "selected_transition": work.selected_transition,
                 "head": work.exact_head_sha,
                 "lineage": work.active_lineage_identity,
                 "ci": (work.verification_state.value, work.verification_identity),
@@ -650,7 +660,7 @@ def _progress_fingerprint(
         ],
     }
     raw = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-    return "progress:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    return "progress:" + hashlib.sha256(raw.encode()).hexdigest()
 
 
 def _dispatch_status(status: TransitionExecutionStatus) -> str:
@@ -665,20 +675,14 @@ def _work_branch(template: str, issue_number: int) -> str:
     if template.count("{issue}") != 1 or issue_number < 1:
         raise AutonomousRuntimeUnavailable("WORK_BRANCH_TEMPLATE_INVALID")
     branch = template.replace("{issue}", str(issue_number))
-    if (
+    invalid = (
         not branch
         or branch.startswith("/")
         or branch.endswith("/")
         or ".." in branch
-        or " " in branch
-        or "~" in branch
-        or "^" in branch
-        or ":" in branch
-        or "?" in branch
-        or "*" in branch
-        or "[" in branch
-        or "\\" in branch
-    ):
+        or any(char in branch for char in " ~^:?*[\\")
+    )
+    if invalid:
         raise AutonomousRuntimeUnavailable("WORK_BRANCH_TEMPLATE_INVALID")
     return branch
 

--- a/src/loop_engineering/v2_autonomous_runner.py
+++ b/src/loop_engineering/v2_autonomous_runner.py
@@ -1,0 +1,699 @@
+"""V2の各安全componentをGoal完了までboundedに接続する自律Runner。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Protocol
+
+from .v2_autonomous_runtime import (
+    AutonomousDispatch,
+    AutonomousRuntimeState,
+    AutonomousRuntimeUnavailable,
+    PostgreSQLAutonomousRuntimeStore,
+    runtime_identity,
+)
+from .v2_evidence import EvidenceTarget, V2EvidenceCoordinator, apply_evidence
+from .v2_goal_planning import (
+    BootstrapResult,
+    PlanningProjectionPort,
+    PlannedWork,
+    ProductDevelopmentRegistration,
+    V2GoalBootstrapService,
+)
+from .v2_supervisor import (
+    V2Supervisor,
+    V2SupervisorDecision,
+    V2SupervisorDisposition,
+    V2Transition,
+    V2WorkObservation,
+    derive_transition,
+    schedule_key,
+)
+from .v2_work_queue import V2WorkQueueSnapshot
+
+_PR_ID_RE = re.compile(r"pr:(\d+)")
+
+
+class AutonomousRunStatus(str, Enum):
+    GOAL_COMPLETED = "GOAL_COMPLETED"
+    PROGRESSED = "PROGRESSED"
+    WAITING = "WAITING"
+    INTERVENTION_REQUIRED = "INTERVENTION_REQUIRED"
+    ITERATION_LIMIT = "ITERATION_LIMIT"
+
+
+class TransitionExecutionStatus(str, Enum):
+    PROGRESSED = "PROGRESSED"
+    WAITING = "WAITING"
+    FAILED = "FAILED"
+    INTERVENTION_REQUIRED = "INTERVENTION_REQUIRED"
+
+
+@dataclass(frozen=True, slots=True)
+class TransitionExecutionResult:
+    status: TransitionExecutionStatus
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class AutonomousRunResult:
+    status: AutonomousRunStatus
+    detail: str
+    iterations: int
+    runtime_identity: str
+    current_work_identity: str | None = None
+
+
+class WorkQueuePort(Protocol):
+    def synchronize(self, registration: ProductDevelopmentRegistration) -> V2WorkQueueSnapshot: ...
+
+
+class TransitionExecutorPort(Protocol):
+    def execute(
+        self,
+        registration: ProductDevelopmentRegistration,
+        bootstrap: BootstrapResult,
+        work: V2WorkObservation,
+        planned_work: PlannedWork,
+        decision: V2SupervisorDecision,
+    ) -> TransitionExecutionResult: ...
+
+
+class GoalAcceptancePort(Protocol):
+    def complete(
+        self,
+        registration: ProductDevelopmentRegistration,
+        bootstrap: BootstrapResult,
+        works: tuple[V2WorkObservation, ...],
+    ) -> bool: ...
+
+
+class LineageCommandRunner(Protocol):
+    def run(self, args: Sequence[str]) -> str: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _LineageSnapshot:
+    observation: V2WorkObservation
+    pr_number: int | None
+
+
+class DurableGoalBootstrap:
+    """最初に採用したPlanをDBへ固定し、restart後は同じPlanだけを再projectionする。"""
+
+    def __init__(
+        self,
+        runtime: PostgreSQLAutonomousRuntimeStore,
+        bootstrap: V2GoalBootstrapService,
+        projection: PlanningProjectionPort,
+    ) -> None:
+        self._runtime = runtime
+        self._bootstrap = bootstrap
+        self._projection = projection
+
+    def ensure(self, registration: ProductDevelopmentRegistration) -> BootstrapResult:
+        identity = runtime_identity(registration)
+        stored = self._runtime.plan(identity)
+        if stored is not None:
+            projection = self._projection.ensure_plan(registration, stored.proposal)
+            if projection != stored.projection:
+                raise AutonomousRuntimeUnavailable("DURABLE_PLAN_PROJECTION_CONFLICT")
+            return stored
+        result = self._bootstrap.bootstrap(registration)
+        self._runtime.save_plan(identity, result)
+        return result
+
+
+class GitHubAutonomousLineageObserver:
+    """Work branchに対応するcurrent PR/headとcanonical design blobをlive readbackする。"""
+
+    def __init__(self, runner: LineageCommandRunner) -> None:
+        self._runner = runner
+
+    def observe(
+        self,
+        registration: ProductDevelopmentRegistration,
+        work: V2WorkObservation,
+        planned: PlannedWork,
+    ) -> _LineageSnapshot:
+        branch = _work_branch(registration.work_branch_template, work.issue_number)
+        open_prs = self._pr_list(registration.repository_identity, branch, "open")
+        if open_prs is None:
+            return _LineageSnapshot(replace(work, unresolved_conflict=True), None)
+        if len(open_prs) > 1:
+            return _LineageSnapshot(replace(work, unresolved_conflict=True), None)
+        if len(open_prs) == 1:
+            pr = open_prs[0]
+            number, head, base = _pr_identity(pr)
+            if number is None or head is None or base != registration.trunk_branch:
+                return _LineageSnapshot(replace(work, unresolved_conflict=True), None)
+            designs = self._design_identities(
+                registration.repository_identity,
+                head,
+                planned.canonical_design_targets,
+            )
+            if designs is None:
+                return _LineageSnapshot(replace(work, unresolved_conflict=True), number)
+            return _LineageSnapshot(
+                replace(
+                    work,
+                    active_lineage_identity=f"pr:{number}",
+                    exact_head_sha=head,
+                    canonical_design_identities=designs,
+                    merged=False,
+                ),
+                number,
+            )
+
+        merged = self._pr_list(registration.repository_identity, branch, "merged")
+        if merged is None:
+            return _LineageSnapshot(replace(work, unresolved_conflict=True), None)
+        if not merged:
+            return _LineageSnapshot(work, None)
+        latest = max(merged, key=_pr_number_sort)
+        number, head, base = _pr_identity(latest)
+        if number is None or head is None or base != registration.trunk_branch:
+            return _LineageSnapshot(replace(work, unresolved_conflict=True), None)
+        return _LineageSnapshot(
+            replace(
+                work,
+                active_lineage_identity=f"pr:{number}",
+                exact_head_sha=head,
+                merged=True,
+            ),
+            number,
+        )
+
+    def _pr_list(
+        self,
+        repository: str,
+        branch: str,
+        state: str,
+    ) -> list[dict[str, object]] | None:
+        try:
+            raw = self._runner.run(
+                (
+                    "gh",
+                    "pr",
+                    "list",
+                    "--repo",
+                    repository,
+                    "--head",
+                    branch,
+                    "--state",
+                    state,
+                    "--limit",
+                    "20",
+                    "--json",
+                    "number,url,headRefOid,headRefName,baseRefName,isDraft",
+                )
+            )
+            payload = json.loads(raw)
+        except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, list) or not all(isinstance(item, dict) for item in payload):
+            return None
+        return [item for item in payload if isinstance(item, dict)]
+
+    def _design_identities(
+        self,
+        repository: str,
+        head: str,
+        paths: tuple[str, ...],
+    ) -> tuple[str, ...] | None:
+        if not paths:
+            return ()
+        identities: list[str] = []
+        for path in paths:
+            try:
+                raw = self._runner.run(
+                    (
+                        "gh",
+                        "api",
+                        f"repos/{repository}/contents/{path}?ref={head}",
+                    )
+                )
+                payload = json.loads(raw)
+            except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError):
+                return None
+            if not isinstance(payload, dict):
+                return None
+            blob = payload.get("sha")
+            if not isinstance(blob, str) or not blob:
+                return None
+            identities.append(f"design:{path}:{blob}")
+        return tuple(identities)
+
+
+class EvidenceEnricher:
+    def __init__(self, evidence: V2EvidenceCoordinator) -> None:
+        self._evidence = evidence
+
+    def enrich(
+        self,
+        registration: ProductDevelopmentRegistration,
+        snapshot: _LineageSnapshot,
+        planned: PlannedWork,
+    ) -> V2WorkObservation:
+        work = snapshot.observation
+        if snapshot.pr_number is None or work.exact_head_sha is None or work.merged:
+            return work
+        target = EvidenceTarget(
+            repository=registration.repository_identity,
+            work_identity=work.work_identity,
+            issue_number=work.issue_number,
+            pr_number=snapshot.pr_number,
+            head_sha=work.exact_head_sha,
+            base_branch=registration.trunk_branch,
+            canonical_design_identities=work.canonical_design_identities,
+            acceptance_digest=work.acceptance_digest or "",
+        )
+        bundle = self._evidence.observe(target, planned.human_verification_required)
+        return apply_evidence(work, bundle)
+
+
+class AllWorkGoalAcceptance:
+    def complete(
+        self,
+        registration: ProductDevelopmentRegistration,
+        bootstrap: BootstrapResult,
+        works: tuple[V2WorkObservation, ...],
+    ) -> bool:
+        del registration, bootstrap
+        return bool(works) and all(work.lifecycle == "COMPLETED" for work in works)
+
+
+class V2AutonomousRunner:
+    def __init__(
+        self,
+        runtime: PostgreSQLAutonomousRuntimeStore,
+        bootstrap: DurableGoalBootstrap,
+        queue: WorkQueuePort,
+        lineage: GitHubAutonomousLineageObserver,
+        evidence: EvidenceEnricher,
+        supervisor: V2Supervisor,
+        transitions: TransitionExecutorPort,
+        goal_acceptance: GoalAcceptancePort | None = None,
+        *,
+        no_progress_limit: int = 3,
+    ) -> None:
+        if not 1 <= no_progress_limit <= 20:
+            raise ValueError("NO_PROGRESS_LIMIT_INVALID")
+        self._runtime = runtime
+        self._bootstrap = bootstrap
+        self._queue = queue
+        self._lineage = lineage
+        self._evidence = evidence
+        self._supervisor = supervisor
+        self._transitions = transitions
+        self._goal_acceptance = goal_acceptance or AllWorkGoalAcceptance()
+        self._no_progress_limit = no_progress_limit
+
+    def run(
+        self,
+        registration: ProductDevelopmentRegistration,
+        *,
+        max_iterations: int = 20,
+    ) -> AutonomousRunResult:
+        if not 1 <= max_iterations <= 1000:
+            raise ValueError("AUTONOMOUS_ITERATION_LIMIT_INVALID")
+        try:
+            state = self._runtime.ensure_runtime(registration)
+            if state.status == "COMPLETED":
+                return AutonomousRunResult(
+                    AutonomousRunStatus.GOAL_COMPLETED,
+                    "GOAL_ALREADY_COMPLETED",
+                    0,
+                    state.runtime_identity,
+                    None,
+                )
+            bootstrap = self._bootstrap.ensure(registration)
+            planned = _planned_by_issue(bootstrap)
+            progressed = False
+            for iteration in range(1, max_iterations + 1):
+                queue = self._queue.synchronize(registration)
+                works = self._observe_all(registration, queue.works, planned)
+                dispatched = self._runtime.dispatched_schedule_keys(state.runtime_identity)
+                selectable, suppressed_incomplete = _without_dispatched(
+                    registration.goal_revision,
+                    works,
+                    dispatched,
+                )
+                acceptance = self._goal_acceptance.complete(registration, bootstrap, works)
+                if suppressed_incomplete:
+                    acceptance = False
+                current = queue.current_work_identity
+                if current is not None and all(
+                    work.work_identity != current for work in selectable
+                ):
+                    current = None
+                decision = self._supervisor.decide(
+                    goal_revision=registration.goal_revision,
+                    works=selectable,
+                    current_work_identity=current,
+                    dispatched_schedule_keys=frozenset(),
+                    pending_effect=queue.pending_effect,
+                    goal_acceptance_complete=acceptance,
+                )
+                fingerprint = _progress_fingerprint(
+                    registration.goal_revision,
+                    works,
+                    queue.pending_effect,
+                    decision,
+                )
+                no_progress = (
+                    state.no_progress_count + 1
+                    if fingerprint == state.last_progress_fingerprint
+                    else 0
+                )
+
+                if decision.disposition is V2SupervisorDisposition.COMPLETE_GOAL:
+                    state = self._runtime.update_runtime(
+                        state.runtime_identity,
+                        status="COMPLETED",
+                        current_work_identity=None,
+                        schedule_key=None,
+                        progress_fingerprint=fingerprint,
+                        no_progress_count=0,
+                        detail=decision.detail,
+                    )
+                    return AutonomousRunResult(
+                        AutonomousRunStatus.GOAL_COMPLETED,
+                        decision.detail,
+                        iteration,
+                        state.runtime_identity,
+                        None,
+                    )
+                if decision.disposition is V2SupervisorDisposition.INTERVENTION_REQUIRED:
+                    state = self._runtime.update_runtime(
+                        state.runtime_identity,
+                        status="INTERVENTION_REQUIRED",
+                        current_work_identity=current,
+                        schedule_key=None,
+                        progress_fingerprint=fingerprint,
+                        no_progress_count=no_progress,
+                        detail=decision.detail,
+                    )
+                    return AutonomousRunResult(
+                        AutonomousRunStatus.INTERVENTION_REQUIRED,
+                        decision.detail,
+                        iteration,
+                        state.runtime_identity,
+                        current,
+                    )
+                if decision.disposition is V2SupervisorDisposition.YIELD_EXTERNAL:
+                    detail = decision.detail
+                    if no_progress >= self._no_progress_limit and queue.pending_effect:
+                        detail = "PENDING_EFFECT_RECONCILIATION_REQUIRED"
+                        status = "INTERVENTION_REQUIRED"
+                        result_status = AutonomousRunStatus.INTERVENTION_REQUIRED
+                    else:
+                        status = "WAITING"
+                        result_status = AutonomousRunStatus.WAITING
+                    state = self._runtime.update_runtime(
+                        state.runtime_identity,
+                        status=status,
+                        current_work_identity=current,
+                        schedule_key=decision.schedule_key,
+                        progress_fingerprint=fingerprint,
+                        no_progress_count=no_progress,
+                        detail=detail,
+                    )
+                    return AutonomousRunResult(
+                        result_status,
+                        detail,
+                        iteration,
+                        state.runtime_identity,
+                        current,
+                    )
+
+                if (
+                    decision.work_identity is None
+                    or decision.transition is None
+                    or decision.schedule_key is None
+                ):
+                    raise AutonomousRuntimeUnavailable("SUPERVISOR_ACTION_IDENTITY_MISSING")
+                work = next(
+                    item for item in works if item.work_identity == decision.work_identity
+                )
+                planned_work = planned.get(work.issue_number)
+                if planned_work is None:
+                    raise AutonomousRuntimeUnavailable("PLANNED_WORK_MAPPING_MISSING")
+                dispatch = AutonomousDispatch(
+                    decision.schedule_key,
+                    state.runtime_identity,
+                    work.work_identity,
+                    decision.transition.value,
+                    "DISPATCHED",
+                    "SUPERVISOR_DISPATCH",
+                )
+                if not self._runtime.dispatch(dispatch):
+                    state = self._runtime.update_runtime(
+                        state.runtime_identity,
+                        status="WAITING",
+                        current_work_identity=work.work_identity,
+                        schedule_key=decision.schedule_key,
+                        progress_fingerprint=fingerprint,
+                        no_progress_count=no_progress,
+                        detail="DUPLICATE_DISPATCH_SUPPRESSED",
+                    )
+                    continue
+                outcome = self._transitions.execute(
+                    registration,
+                    bootstrap,
+                    work,
+                    planned_work,
+                    decision,
+                )
+                dispatch_status = _dispatch_status(outcome.status)
+                self._runtime.update_dispatch(
+                    decision.schedule_key,
+                    dispatch_status,
+                    outcome.detail,
+                )
+                if outcome.status is TransitionExecutionStatus.INTERVENTION_REQUIRED:
+                    state = self._runtime.update_runtime(
+                        state.runtime_identity,
+                        status="INTERVENTION_REQUIRED",
+                        current_work_identity=work.work_identity,
+                        schedule_key=decision.schedule_key,
+                        progress_fingerprint=fingerprint,
+                        no_progress_count=no_progress,
+                        detail=outcome.detail,
+                    )
+                    return AutonomousRunResult(
+                        AutonomousRunStatus.INTERVENTION_REQUIRED,
+                        outcome.detail,
+                        iteration,
+                        state.runtime_identity,
+                        work.work_identity,
+                    )
+                if outcome.status is TransitionExecutionStatus.WAITING:
+                    state = self._runtime.update_runtime(
+                        state.runtime_identity,
+                        status="ACTIVE",
+                        current_work_identity=work.work_identity,
+                        schedule_key=decision.schedule_key,
+                        progress_fingerprint=fingerprint,
+                        no_progress_count=no_progress,
+                        detail=outcome.detail,
+                    )
+                    continue
+                if outcome.status is TransitionExecutionStatus.FAILED:
+                    if no_progress >= self._no_progress_limit:
+                        state = self._runtime.update_runtime(
+                            state.runtime_identity,
+                            status="WAITING",
+                            current_work_identity=work.work_identity,
+                            schedule_key=decision.schedule_key,
+                            progress_fingerprint=fingerprint,
+                            no_progress_count=no_progress,
+                            detail="REPAIRABLE_FAILURE_RETRY_BOUNDED",
+                        )
+                        return AutonomousRunResult(
+                            AutonomousRunStatus.WAITING,
+                            "REPAIRABLE_FAILURE_RETRY_BOUNDED",
+                            iteration,
+                            state.runtime_identity,
+                            work.work_identity,
+                        )
+                    state = self._runtime.update_runtime(
+                        state.runtime_identity,
+                        status="ACTIVE",
+                        current_work_identity=work.work_identity,
+                        schedule_key=decision.schedule_key,
+                        progress_fingerprint=fingerprint,
+                        no_progress_count=no_progress,
+                        detail=outcome.detail,
+                    )
+                    continue
+
+                progressed = True
+                state = self._runtime.update_runtime(
+                    state.runtime_identity,
+                    status="ACTIVE",
+                    current_work_identity=work.work_identity,
+                    schedule_key=decision.schedule_key,
+                    progress_fingerprint=None,
+                    no_progress_count=0,
+                    detail=outcome.detail,
+                )
+            return AutonomousRunResult(
+                AutonomousRunStatus.PROGRESSED if progressed else AutonomousRunStatus.ITERATION_LIMIT,
+                "AUTONOMOUS_ITERATION_LIMIT_REACHED",
+                max_iterations,
+                state.runtime_identity,
+                state.current_work_identity,
+            )
+        except (AutonomousRuntimeUnavailable, ValueError) as error:
+            identity = runtime_identity(registration)
+            return AutonomousRunResult(
+                AutonomousRunStatus.INTERVENTION_REQUIRED,
+                str(error),
+                0,
+                identity,
+                None,
+            )
+
+    def _observe_all(
+        self,
+        registration: ProductDevelopmentRegistration,
+        works: tuple[V2WorkObservation, ...],
+        planned: dict[int, PlannedWork],
+    ) -> tuple[V2WorkObservation, ...]:
+        observed: list[V2WorkObservation] = []
+        for work in works:
+            planned_work = planned.get(work.issue_number)
+            if planned_work is None:
+                observed.append(replace(work, unresolved_conflict=True))
+                continue
+            lineage = self._lineage.observe(registration, work, planned_work)
+            observed.append(self._evidence.enrich(registration, lineage, planned_work))
+        return tuple(observed)
+
+
+def _planned_by_issue(bootstrap: BootstrapResult) -> dict[int, PlannedWork]:
+    proposal = {work.logical_key: work for work in bootstrap.proposal.works}
+    result: dict[int, PlannedWork] = {}
+    for projected in bootstrap.projection.works:
+        planned = proposal.get(projected.logical_key)
+        if planned is None or projected.issue_number in result:
+            raise AutonomousRuntimeUnavailable("PLANNED_WORK_MAPPING_CONFLICT")
+        result[projected.issue_number] = planned
+    if len(result) != len(proposal):
+        raise AutonomousRuntimeUnavailable("PLANNED_WORK_MAPPING_CONFLICT")
+    return result
+
+
+def _without_dispatched(
+    goal_revision: str,
+    works: tuple[V2WorkObservation, ...],
+    dispatched: frozenset[str],
+) -> tuple[tuple[V2WorkObservation, ...], bool]:
+    kept: list[V2WorkObservation] = []
+    suppressed_incomplete = False
+    for work in works:
+        transition = derive_transition(work)
+        if transition is None:
+            kept.append(work)
+            continue
+        key = schedule_key(goal_revision, work, transition)
+        if key in dispatched:
+            if work.lifecycle != "COMPLETED":
+                suppressed_incomplete = True
+            continue
+        kept.append(work)
+    return tuple(kept), suppressed_incomplete
+
+
+def _progress_fingerprint(
+    goal_revision: str,
+    works: tuple[V2WorkObservation, ...],
+    pending_effect: bool,
+    decision: V2SupervisorDecision,
+) -> str:
+    payload = {
+        "goal_revision": goal_revision,
+        "pending_effect": pending_effect,
+        "decision": (
+            decision.disposition.value,
+            decision.work_identity,
+            decision.transition.value if decision.transition is not None else None,
+            decision.schedule_key,
+            decision.detail,
+        ),
+        "works": [
+            {
+                "id": work.work_identity,
+                "revision": work.issue_revision,
+                "lifecycle": work.lifecycle,
+                "head": work.exact_head_sha,
+                "lineage": work.active_lineage_identity,
+                "ci": (work.verification_state.value, work.verification_identity),
+                "review": (work.review_state.value, work.review_identity),
+                "human": (
+                    work.human_verification_state.value,
+                    work.human_verification_identity,
+                ),
+                "merged": work.merged,
+                "conflict": work.unresolved_conflict,
+                "packet": work.latest_packet_identity,
+                "checkpoint": work.latest_checkpoint_identity,
+            }
+            for work in works
+        ],
+    }
+    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return "progress:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _dispatch_status(status: TransitionExecutionStatus) -> str:
+    if status is TransitionExecutionStatus.PROGRESSED:
+        return "COMPLETED"
+    if status is TransitionExecutionStatus.WAITING:
+        return "WAITING"
+    return "FAILED"
+
+
+def _work_branch(template: str, issue_number: int) -> str:
+    if template.count("{issue}") != 1 or issue_number < 1:
+        raise AutonomousRuntimeUnavailable("WORK_BRANCH_TEMPLATE_INVALID")
+    branch = template.replace("{issue}", str(issue_number))
+    if (
+        not branch
+        or branch.startswith("/")
+        or branch.endswith("/")
+        or ".." in branch
+        or " " in branch
+        or "~" in branch
+        or "^" in branch
+        or ":" in branch
+        or "?" in branch
+        or "*" in branch
+        or "[" in branch
+        or "\\" in branch
+    ):
+        raise AutonomousRuntimeUnavailable("WORK_BRANCH_TEMPLATE_INVALID")
+    return branch
+
+
+def _pr_identity(item: Mapping[str, object]) -> tuple[int | None, str | None, str | None]:
+    number = item.get("number")
+    head = item.get("headRefOid")
+    base = item.get("baseRefName")
+    return (
+        number if isinstance(number, int) and number > 0 else None,
+        head if isinstance(head, str) and head else None,
+        base if isinstance(base, str) and base else None,
+    )
+
+
+def _pr_number_sort(item: Mapping[str, object]) -> int:
+    number = item.get("number")
+    return number if isinstance(number, int) else -1

--- a/src/loop_engineering/v2_autonomous_runtime.py
+++ b/src/loop_engineering/v2_autonomous_runtime.py
@@ -1,0 +1,419 @@
+"""V2自律RunnerのGoal単位状態・dispatch・Planning snapshotをPostgreSQLへ保存する。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Protocol
+
+from .v2_goal_planning import (
+    BootstrapResult,
+    PlannedWork,
+    ProductDevelopmentRegistration,
+    ProjectedPlan,
+    ProjectedWork,
+    WorkPlanProposal,
+)
+
+
+class AutonomousRuntimeUnavailable(RuntimeError):
+    """自律Runnerの永続状態を安全に利用できない。"""
+
+
+class AutonomousRuntimeDatabase(Protocol):
+    def execute_sql(self, sql: str) -> bool: ...
+
+    def query_json_rows(self, select_sql: str) -> list[dict[str, object]] | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class AutonomousRuntimeState:
+    runtime_identity: str
+    product_key: str
+    repository: str
+    goal_revision: str
+    status: str
+    current_work_identity: str | None
+    last_schedule_key: str | None
+    last_progress_fingerprint: str | None
+    no_progress_count: int
+    last_detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class AutonomousDispatch:
+    schedule_key: str
+    runtime_identity: str
+    work_identity: str
+    transition: str
+    status: str
+    detail: str
+
+
+class PostgreSQLAutonomousRuntimeStore:
+    _RUNTIME_STATUSES = frozenset(
+        {"ACTIVE", "WAITING", "INTERVENTION_REQUIRED", "COMPLETED"}
+    )
+    _DISPATCH_STATUSES = frozenset(
+        {"DISPATCHED", "COMPLETED", "WAITING", "FAILED", "SUPERSEDED"}
+    )
+
+    def __init__(self, database: AutonomousRuntimeDatabase) -> None:
+        self._database = database
+
+    def ensure_runtime(
+        self,
+        registration: ProductDevelopmentRegistration,
+    ) -> AutonomousRuntimeState:
+        identity = runtime_identity(registration)
+        sql = (
+            "INSERT INTO loop_autonomous_runtimes "
+            "(runtime_identity, product_key, repository, goal_revision, status) VALUES ("
+            f"{_literal(identity)}, {_literal(registration.product_key)}, "
+            f"{_literal(registration.repository_identity)}, "
+            f"{_literal(registration.goal_revision)}, 'ACTIVE') "
+            "ON CONFLICT (runtime_identity) DO NOTHING"
+        )
+        self._execute(sql)
+        state = self.get(identity)
+        if state is None:
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_RUNTIME_READBACK_MISSING")
+        if (
+            state.product_key != registration.product_key
+            or state.repository != registration.repository_identity
+            or state.goal_revision != registration.goal_revision
+        ):
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_RUNTIME_IDENTITY_CONFLICT")
+        return state
+
+    def get(self, runtime_identity_value: str) -> AutonomousRuntimeState | None:
+        rows = self._query(
+            "SELECT runtime_identity, product_key, repository, goal_revision, status, "
+            "current_work_identity, last_schedule_key, last_progress_fingerprint, "
+            "no_progress_count, last_detail FROM loop_autonomous_runtimes "
+            f"WHERE runtime_identity = {_literal(runtime_identity_value)} LIMIT 1"
+        )
+        if not rows:
+            return None
+        return _runtime_state(rows[0])
+
+    def update_runtime(
+        self,
+        runtime_identity_value: str,
+        *,
+        status: str,
+        current_work_identity: str | None,
+        schedule_key: str | None,
+        progress_fingerprint: str | None,
+        no_progress_count: int,
+        detail: str,
+    ) -> AutonomousRuntimeState:
+        if (
+            status not in self._RUNTIME_STATUSES
+            or no_progress_count < 0
+            or not detail
+            or len(detail) > 1024
+        ):
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_RUNTIME_UPDATE_INVALID")
+        completed = "now()" if status == "COMPLETED" else "NULL"
+        self._execute(
+            "UPDATE loop_autonomous_runtimes SET "
+            f"status = {_literal(status)}, "
+            f"current_work_identity = {_nullable_literal(current_work_identity)}, "
+            f"last_schedule_key = {_nullable_literal(schedule_key)}, "
+            f"last_progress_fingerprint = {_nullable_literal(progress_fingerprint)}, "
+            f"no_progress_count = {no_progress_count}, "
+            f"last_detail = {_literal(detail)}, updated_at = now(), completed_at = {completed} "
+            f"WHERE runtime_identity = {_literal(runtime_identity_value)}"
+        )
+        state = self.get(runtime_identity_value)
+        if state is None:
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_RUNTIME_UPDATE_READBACK_MISSING")
+        return state
+
+    def dispatch(self, item: AutonomousDispatch) -> bool:
+        if (
+            item.status not in self._DISPATCH_STATUSES
+            or not item.schedule_key
+            or not item.runtime_identity
+            or not item.work_identity
+            or not item.transition
+            or len(item.detail) > 1024
+        ):
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_DISPATCH_INVALID")
+        self._execute(
+            "INSERT INTO loop_autonomous_dispatches "
+            "(schedule_key, runtime_identity, work_identity, transition, status, detail) VALUES ("
+            f"{_literal(item.schedule_key)}, {_literal(item.runtime_identity)}, "
+            f"{_literal(item.work_identity)}, {_literal(item.transition)}, "
+            f"{_literal(item.status)}, {_literal(item.detail)}) "
+            "ON CONFLICT (schedule_key) DO NOTHING"
+        )
+        found = self.dispatch_record(item.schedule_key)
+        return found == item
+
+    def update_dispatch(self, schedule_key: str, status: str, detail: str) -> None:
+        if status not in self._DISPATCH_STATUSES or not detail or len(detail) > 1024:
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_DISPATCH_UPDATE_INVALID")
+        self._execute(
+            "UPDATE loop_autonomous_dispatches SET "
+            f"status = {_literal(status)}, detail = {_literal(detail)}, updated_at = now() "
+            f"WHERE schedule_key = {_literal(schedule_key)}"
+        )
+
+    def dispatch_record(self, schedule_key: str) -> AutonomousDispatch | None:
+        rows = self._query(
+            "SELECT schedule_key, runtime_identity, work_identity, transition, status, detail "
+            "FROM loop_autonomous_dispatches "
+            f"WHERE schedule_key = {_literal(schedule_key)} LIMIT 1"
+        )
+        if not rows:
+            return None
+        row = rows[0]
+        return AutonomousDispatch(
+            _required_string(row, "schedule_key"),
+            _required_string(row, "runtime_identity"),
+            _required_string(row, "work_identity"),
+            _required_string(row, "transition"),
+            _required_string(row, "status"),
+            _required_string(row, "detail"),
+        )
+
+    def dispatched_schedule_keys(self, runtime_identity_value: str) -> frozenset[str]:
+        rows = self._query(
+            "SELECT schedule_key FROM loop_autonomous_dispatches "
+            f"WHERE runtime_identity = {_literal(runtime_identity_value)} "
+            "AND status IN ('DISPATCHED', 'COMPLETED', 'WAITING')"
+        )
+        return frozenset(_required_string(row, "schedule_key") for row in rows)
+
+    def save_plan(self, runtime_identity_value: str, result: BootstrapResult) -> None:
+        proposal_json = json.dumps(
+            _proposal_to_json(result.proposal),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        projection_json = json.dumps(
+            _projection_to_json(result.projection),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        self._execute(
+            "INSERT INTO loop_goal_plans "
+            "(runtime_identity, proposal_identity, proposal_json, projection_json) VALUES ("
+            f"{_literal(runtime_identity_value)}, {_literal(result.proposal.proposal_identity)}, "
+            f"{_literal(proposal_json)}::jsonb, {_literal(projection_json)}::jsonb) "
+            "ON CONFLICT (runtime_identity) DO NOTHING"
+        )
+        stored = self.plan(runtime_identity_value)
+        if stored != result:
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_PLAN_IDENTITY_CONFLICT")
+
+    def plan(self, runtime_identity_value: str) -> BootstrapResult | None:
+        rows = self._query(
+            "SELECT proposal_identity, proposal_json, projection_json FROM loop_goal_plans "
+            f"WHERE runtime_identity = {_literal(runtime_identity_value)} LIMIT 1"
+        )
+        if not rows:
+            return None
+        row = rows[0]
+        proposal_raw = row.get("proposal_json")
+        projection_raw = row.get("projection_json")
+        if not isinstance(proposal_raw, dict) or not isinstance(projection_raw, dict):
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_PLAN_ROW_INVALID")
+        result = BootstrapResult(
+            _proposal_from_json(proposal_raw),
+            _projection_from_json(projection_raw),
+        )
+        if result.proposal.proposal_identity != _required_string(row, "proposal_identity"):
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_PLAN_ROW_INVALID")
+        return result
+
+    def _execute(self, sql: str) -> None:
+        if not self._database.execute_sql(sql):
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_RUNTIME_WRITE_FAILED")
+
+    def _query(self, sql: str) -> list[dict[str, object]]:
+        rows = self._database.query_json_rows(sql)
+        if rows is None:
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_RUNTIME_READ_FAILED")
+        return rows
+
+
+def runtime_identity(registration: ProductDevelopmentRegistration) -> str:
+    payload = (
+        registration.product_key,
+        registration.repository_identity,
+        registration.goal_definition_identity,
+        registration.goal_revision,
+    )
+    encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    return "runtime:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _runtime_state(row: dict[str, object]) -> AutonomousRuntimeState:
+    count = row.get("no_progress_count")
+    if not isinstance(count, int) or count < 0:
+        raise AutonomousRuntimeUnavailable("AUTONOMOUS_RUNTIME_ROW_INVALID")
+    status = _required_string(row, "status")
+    if status not in PostgreSQLAutonomousRuntimeStore._RUNTIME_STATUSES:
+        raise AutonomousRuntimeUnavailable("AUTONOMOUS_RUNTIME_ROW_INVALID")
+    return AutonomousRuntimeState(
+        _required_string(row, "runtime_identity"),
+        _required_string(row, "product_key"),
+        _required_string(row, "repository"),
+        _required_string(row, "goal_revision"),
+        status,
+        _optional_string(row, "current_work_identity"),
+        _optional_string(row, "last_schedule_key"),
+        _optional_string(row, "last_progress_fingerprint"),
+        count,
+        _required_string(row, "last_detail"),
+    )
+
+
+def _proposal_to_json(proposal: WorkPlanProposal) -> dict[str, object]:
+    return {
+        "proposal_identity": proposal.proposal_identity,
+        "goal_revision": proposal.goal_revision,
+        "completion_conditions": list(proposal.completion_conditions),
+        "works": [
+            {
+                "logical_key": work.logical_key,
+                "title": work.title,
+                "purpose": work.purpose,
+                "acceptance_criteria": list(work.acceptance_criteria),
+                "dependencies": list(work.dependencies),
+                "work_kind": work.work_kind,
+                "human_verification_required": work.human_verification_required,
+                "canonical_design_targets": list(work.canonical_design_targets),
+            }
+            for work in proposal.works
+        ],
+    }
+
+
+def _proposal_from_json(raw: dict[str, object]) -> WorkPlanProposal:
+    works = raw.get("works")
+    completion = raw.get("completion_conditions")
+    if not isinstance(works, list) or not isinstance(completion, list):
+        raise AutonomousRuntimeUnavailable("AUTONOMOUS_PLAN_ROW_INVALID")
+    parsed: list[PlannedWork] = []
+    for item in works:
+        if not isinstance(item, dict):
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_PLAN_ROW_INVALID")
+        acceptance = _string_list(item, "acceptance_criteria")
+        dependencies = _string_list(item, "dependencies")
+        targets = _string_list(item, "canonical_design_targets")
+        human = item.get("human_verification_required")
+        if not isinstance(human, bool):
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_PLAN_ROW_INVALID")
+        parsed.append(
+            PlannedWork(
+                logical_key=_required_string(item, "logical_key"),
+                title=_required_string(item, "title"),
+                purpose=_required_string(item, "purpose"),
+                acceptance_criteria=acceptance,
+                dependencies=dependencies,
+                work_kind=_required_string(item, "work_kind"),
+                human_verification_required=human,
+                canonical_design_targets=targets,
+            )
+        )
+    return WorkPlanProposal(
+        _required_string(raw, "proposal_identity"),
+        _required_string(raw, "goal_revision"),
+        tuple(parsed),
+        tuple(_strings(completion)),
+    )
+
+
+def _projection_to_json(projection: ProjectedPlan) -> dict[str, object]:
+    return {
+        "goal_issue_number": projection.goal_issue_number,
+        "goal_issue_url": projection.goal_issue_url,
+        "goal_project_item_id": projection.goal_project_item_id,
+        "works": [
+            {
+                "logical_key": work.logical_key,
+                "issue_number": work.issue_number,
+                "issue_url": work.issue_url,
+                "project_item_id": work.project_item_id,
+                "acceptance_digest": work.acceptance_digest,
+                "dependencies": list(work.dependencies),
+            }
+            for work in projection.works
+        ],
+    }
+
+
+def _projection_from_json(raw: dict[str, object]) -> ProjectedPlan:
+    works = raw.get("works")
+    goal_issue_number = raw.get("goal_issue_number")
+    if not isinstance(works, list) or not isinstance(goal_issue_number, int):
+        raise AutonomousRuntimeUnavailable("AUTONOMOUS_PLAN_ROW_INVALID")
+    projected: list[ProjectedWork] = []
+    for item in works:
+        if not isinstance(item, dict):
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_PLAN_ROW_INVALID")
+        issue_number = item.get("issue_number")
+        if not isinstance(issue_number, int):
+            raise AutonomousRuntimeUnavailable("AUTONOMOUS_PLAN_ROW_INVALID")
+        projected.append(
+            ProjectedWork(
+                _required_string(item, "logical_key"),
+                issue_number,
+                _required_string(item, "issue_url"),
+                _required_string(item, "project_item_id"),
+                _required_string(item, "acceptance_digest"),
+                _string_list(item, "dependencies"),
+            )
+        )
+    return ProjectedPlan(
+        goal_issue_number,
+        _required_string(raw, "goal_issue_url"),
+        _required_string(raw, "goal_project_item_id"),
+        tuple(projected),
+    )
+
+
+def _required_string(row: dict[str, object], key: str) -> str:
+    value = row.get(key)
+    if not isinstance(value, str):
+        raise AutonomousRuntimeUnavailable("AUTONOMOUS_RUNTIME_ROW_INVALID")
+    return value
+
+
+def _optional_string(row: dict[str, object], key: str) -> str | None:
+    value = row.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise AutonomousRuntimeUnavailable("AUTONOMOUS_RUNTIME_ROW_INVALID")
+    return value
+
+
+def _string_list(row: dict[str, object], key: str) -> tuple[str, ...]:
+    value = row.get(key)
+    if not isinstance(value, list):
+        raise AutonomousRuntimeUnavailable("AUTONOMOUS_PLAN_ROW_INVALID")
+    return tuple(_strings(value))
+
+
+def _strings(values: list[object]) -> list[str]:
+    if not all(isinstance(value, str) for value in values):
+        raise AutonomousRuntimeUnavailable("AUTONOMOUS_PLAN_ROW_INVALID")
+    return [value for value in values if isinstance(value, str)]
+
+
+def _literal(value: str) -> str:
+    if "\x00" in value or len(value) > 100_000:
+        raise AutonomousRuntimeUnavailable("AUTONOMOUS_RUNTIME_VALUE_INVALID")
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _nullable_literal(value: str | None) -> str:
+    return "NULL" if value is None else _literal(value)

--- a/src/loop_engineering/v2_autonomous_transitions.py
+++ b/src/loop_engineering/v2_autonomous_transitions.py
@@ -11,10 +11,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Protocol
 
-from .v2_autonomous_runner import (
-    TransitionExecutionResult,
-    TransitionExecutionStatus,
-)
+from .v2_autonomous_runner import TransitionExecutionResult, TransitionExecutionStatus
 from .v2_development_lineage import (
     GitHubDevelopmentLineageEffects,
     LineageIdentity,
@@ -91,25 +88,16 @@ class V2AutonomousTransitionExecutor:
     ) -> TransitionExecutionResult:
         transition = decision.transition
         if transition is None or decision.schedule_key is None:
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "TRANSITION_DECISION_INVALID",
-            )
+            return _intervention("TRANSITION_DECISION_INVALID")
         if transition in {V2Transition.DESIGN, V2Transition.IMPLEMENT, V2Transition.REPAIR}:
             return self._develop(registration, work, planned_work, decision)
         if transition in {V2Transition.VERIFY, V2Transition.REVIEW, V2Transition.HUMAN_VERIFY}:
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.WAITING,
-                f"{transition.value}_EVIDENCE_PENDING",
-            )
+            return _waiting(f"{transition.value}_EVIDENCE_PENDING")
         if transition is V2Transition.INTEGRATE:
             return self._integrate(registration, work, decision.schedule_key)
         if transition is V2Transition.COMPLETE_WORK:
             return self._complete_work(registration, bootstrap, work, decision.schedule_key)
-        return TransitionExecutionResult(
-            TransitionExecutionStatus.INTERVENTION_REQUIRED,
-            "TRANSITION_UNSUPPORTED",
-        )
+        return _intervention("TRANSITION_UNSUPPORTED")
 
     def _develop(
         self,
@@ -119,19 +107,20 @@ class V2AutonomousTransitionExecutor:
         decision: V2SupervisorDecision,
     ) -> TransitionExecutionResult:
         assert decision.transition is not None and decision.schedule_key is not None
+        branch = _work_branch(registration.work_branch_template, work.issue_number)
         exact_base = work.exact_head_sha or self._trunk_head(registration)
         if exact_base is None:
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.WAITING,
-                "TRUNK_HEAD_UNAVAILABLE",
-            )
-        implementer_transition = ImplementerTransition(decision.transition.value)
+            return _waiting("DEVELOPMENT_BASE_UNAVAILABLE")
+        remote_ref = branch if work.exact_head_sha is not None else registration.trunk_branch
+        if not self._ensure_commit_available(registration, exact_base, remote_ref):
+            return _waiting("DEVELOPMENT_BASE_FETCH_UNPROVEN")
+
         generation = _generation(decision.schedule_key)
         packet = DevelopmentTaskPacket(
             packet_identity=decision.schedule_key,
             work_identity=work.work_identity,
             generation=generation,
-            transition=implementer_transition,
+            transition=ImplementerTransition(decision.transition.value),
             repository_identity=registration.repository_identity,
             workspace_canonical_path=registration.workspace_canonical_path,
             exact_base_sha=exact_base,
@@ -142,8 +131,10 @@ class V2AutonomousTransitionExecutor:
             canonical_design_identities=work.canonical_design_identities,
             canonical_design_targets=planned.canonical_design_targets,
             active_lineage_identity=work.active_lineage_identity,
-            authority_refs=(registration.goal_definition_identity, f"Issue #{work.issue_number}"),
-            non_goals=(),
+            authority_refs=(
+                registration.goal_definition_identity,
+                f"Issue #{work.issue_number}",
+            ),
             safety_constraints=(
                 "main/trunkへ直接commit/pushしない",
                 "GitHub mutationはTrusted Hostへ委譲する",
@@ -151,12 +142,10 @@ class V2AutonomousTransitionExecutor:
         )
         implemented = self.implementer.execute(packet)
         if implemented.status is ImplementerStatus.BLOCKED:
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                implemented.detail,
-            )
+            return _intervention(implemented.detail)
         if implemented.status is not ImplementerStatus.SUCCESS or implemented.proposal is None:
-            return TransitionExecutionResult(TransitionExecutionStatus.FAILED, implemented.detail)
+            return _failed(implemented.detail)
+
         materialized = self.materializer.materialize(
             workspace=registration.workspace_canonical_path,
             repository=registration.repository_identity,
@@ -164,11 +153,8 @@ class V2AutonomousTransitionExecutor:
             commit_message=_commit_message(decision.transition, work.issue_number),
         )
         if materialized is None:
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.FAILED,
-                "PROPOSAL_MATERIALIZATION_FAILED",
-            )
-        branch = _work_branch(registration.work_branch_template, work.issue_number)
+            return _failed("PROPOSAL_MATERIALIZATION_FAILED")
+
         published = self.lineage.publish(
             LineageIdentity(
                 registration.repository_identity,
@@ -180,31 +166,25 @@ class V2AutonomousTransitionExecutor:
             ),
             materialized,
         )
-        if published.status is LineageStatus.UNCERTAIN:
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                published.detail,
-            )
-        if published.status is LineageStatus.BLOCKED:
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                published.detail,
-            )
+        if published.status in {LineageStatus.UNCERTAIN, LineageStatus.BLOCKED}:
+            return _intervention(published.detail)
         if published.status is not LineageStatus.CONFIRMED or published.pull_request is None:
-            return TransitionExecutionResult(TransitionExecutionStatus.FAILED, published.detail)
+            return _failed(published.detail)
+
         self._advance_work(
             work,
             lifecycle="RUNNING",
             selected_transition=decision.transition.value,
             active_lineage_identity=f"pr:{published.pull_request.number}",
-            next_action="OBSERVE_EXACT_HEAD_EVIDENCE",
+            next_action=(
+                "IMPLEMENT_SAME_LINEAGE"
+                if decision.transition is V2Transition.DESIGN
+                else "OBSERVE_EXACT_HEAD_EVIDENCE"
+            ),
             evidence=(f"head:{published.pull_request.head_sha}",),
             schedule_key=decision.schedule_key,
         )
-        return TransitionExecutionResult(
-            TransitionExecutionStatus.PROGRESSED,
-            published.detail,
-        )
+        return _progressed(published.detail)
 
     def _integrate(
         self,
@@ -212,56 +192,32 @@ class V2AutonomousTransitionExecutor:
         work: V2WorkObservation,
         schedule_key: str,
     ) -> TransitionExecutionResult:
-        if (
-            work.exact_head_sha is None
-            or work.verification_state is not EvidenceState.PASS
-            or work.review_state is not EvidenceState.PASS
-            or (
-                work.human_verification_required
-                and work.human_verification_state is not EvidenceState.PASS
-            )
-        ):
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "INTEGRATION_EVIDENCE_INVALID",
-            )
+        if not _integration_evidence_valid(work):
+            return _intervention("INTEGRATION_EVIDENCE_INVALID")
+        assert work.exact_head_sha is not None
         pr_number = _pr_number(work.active_lineage_identity)
         if pr_number is None:
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "INTEGRATION_PR_IDENTITY_INVALID",
-            )
+            return _intervention("INTEGRATION_PR_IDENTITY_INVALID")
         observed = self._pr_state(registration, pr_number)
         if observed is None:
-            return TransitionExecutionResult(TransitionExecutionStatus.WAITING, "PR_READBACK_UNAVAILABLE")
+            return _waiting("PR_READBACK_UNAVAILABLE")
         if observed[0] == "MERGED" and observed[1] == work.exact_head_sha:
-            self._advance_work(
-                work,
-                lifecycle="RUNNING",
-                selected_transition="INTEGRATE",
-                active_lineage_identity=f"pr:{pr_number}",
-                next_action="COMPLETE_WORK",
-                evidence=(f"merged-pr:{pr_number}:{work.exact_head_sha}",),
-                schedule_key=schedule_key,
-            )
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.PROGRESSED,
-                "PR_ALREADY_MERGED",
-            )
-        if observed != ("OPEN", work.exact_head_sha, registration.trunk_branch):
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "INTEGRATION_PR_PRECONDITION_CONFLICT",
-            )
-        generation = _generation(schedule_key)
+            self._mark_integrated(work, pr_number, schedule_key)
+            return _progressed("PR_ALREADY_MERGED")
+        expected = ("OPEN", work.exact_head_sha, registration.trunk_branch)
+        if observed != expected:
+            return _intervention("INTEGRATION_PR_PRECONDITION_CONFLICT")
+
         key = _effect_key(schedule_key, "MERGE", f"pr:{pr_number}")
+        if _pending_effect(self.work_state.recover(work.work_identity), key) == "UNCERTAIN":
+            return _intervention("MERGE_EFFECT_UNCERTAIN")
         attempt = EffectAttempt(
             idempotency_key=key,
             work_identity=work.work_identity,
             kind="MERGE",
             target_identity=f"pr:{pr_number}",
             status="INTENT_RECORDED",
-            packet_generation=generation,
+            packet_generation=_generation(schedule_key),
             expected_preconditions=(
                 ("head", work.exact_head_sha),
                 ("base", registration.trunk_branch),
@@ -269,31 +225,17 @@ class V2AutonomousTransitionExecutor:
             ),
             expected_effect=(("state", "MERGED"),),
         )
-        pending = _pending_effect(self.work_state.recover(work.work_identity), key)
-        if pending == "UNCERTAIN":
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "MERGE_EFFECT_UNCERTAIN",
-            )
         if not self.work_state.record_effect_intent(attempt):
             fresh = self._pr_state(registration, pr_number)
-            if fresh is not None and fresh[0] == "MERGED" and fresh[1] == work.exact_head_sha:
-                return TransitionExecutionResult(
-                    TransitionExecutionStatus.PROGRESSED,
-                    "MERGE_EFFECT_ALREADY_CONFIRMED",
-                )
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "MERGE_EFFECT_STATE_CONFLICT",
-            )
-        fresh_before = self._pr_state(registration, pr_number)
-        if fresh_before != observed:
+            if fresh is not None and fresh[:2] == ("MERGED", work.exact_head_sha):
+                self._mark_integrated(work, pr_number, schedule_key)
+                return _progressed("MERGE_EFFECT_ALREADY_CONFIRMED")
+            return _intervention("MERGE_EFFECT_STATE_CONFLICT")
+        if self._pr_state(registration, pr_number) != observed:
             self.work_state.record_effect_outcome(key, "NO_EFFECT")
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "MERGE_PRECONDITION_CHANGED",
-            )
-        command = self._run(
+            return _intervention("MERGE_PRECONDITION_CHANGED")
+
+        sent = self._run(
             (
                 "gh",
                 "pr",
@@ -309,29 +251,15 @@ class V2AutonomousTransitionExecutor:
             timeout_seconds=300,
         )
         fresh = self._pr_state(registration, pr_number)
-        if fresh is not None and fresh[0] == "MERGED" and fresh[1] == work.exact_head_sha:
+        if fresh is not None and fresh[:2] == ("MERGED", work.exact_head_sha):
             self.work_state.record_effect_outcome(key, "CONFIRMED")
-            self._advance_work(
-                work,
-                lifecycle="RUNNING",
-                selected_transition="INTEGRATE",
-                active_lineage_identity=f"pr:{pr_number}",
-                next_action="COMPLETE_WORK",
-                evidence=(f"merged-pr:{pr_number}:{work.exact_head_sha}",),
-                schedule_key=schedule_key,
-            )
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.PROGRESSED,
-                "MERGE_CONFIRMED",
-            )
-        if command.succeeded and fresh == observed:
+            self._mark_integrated(work, pr_number, schedule_key)
+            return _progressed("MERGE_CONFIRMED")
+        if sent.succeeded and fresh == observed:
             self.work_state.record_effect_outcome(key, "NO_EFFECT")
-            return TransitionExecutionResult(TransitionExecutionStatus.FAILED, "MERGE_NO_EFFECT")
+            return _failed("MERGE_NO_EFFECT")
         self.work_state.record_effect_outcome(key, "UNCERTAIN")
-        return TransitionExecutionResult(
-            TransitionExecutionStatus.INTERVENTION_REQUIRED,
-            "MERGE_READBACK_UNPROVEN",
-        )
+        return _intervention("MERGE_READBACK_UNPROVEN")
 
     def _complete_work(
         self,
@@ -341,39 +269,31 @@ class V2AutonomousTransitionExecutor:
         schedule_key: str,
     ) -> TransitionExecutionResult:
         if not work.merged:
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "WORK_COMPLETION_MERGE_REQUIRED",
-            )
+            return _intervention("WORK_COMPLETION_MERGE_REQUIRED")
         issue_state = self._issue_state(registration, work.issue_number)
         if issue_state is None:
-            return TransitionExecutionResult(TransitionExecutionStatus.WAITING, "ISSUE_READBACK_UNAVAILABLE")
+            return _waiting("ISSUE_READBACK_UNAVAILABLE")
         if issue_state == "OPEN":
-            result = self._close_issue(registration, work, schedule_key)
-            if result is not None:
-                return result
+            close = self._close_issue(registration, work, schedule_key)
+            if close is not None:
+                return close
         elif issue_state != "CLOSED":
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "ISSUE_STATE_INVALID",
-            )
+            return _intervention("ISSUE_STATE_INVALID")
+
         projected = next(
             (item for item in bootstrap.projection.works if item.issue_number == work.issue_number),
             None,
         )
         if projected is None:
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "PROJECTED_WORK_MISSING",
-            )
-        project_result = self._ensure_project_done(
+            return _intervention("PROJECTED_WORK_MISSING")
+        project = self._ensure_project_done(
             registration,
             work,
             projected.project_item_id,
             schedule_key,
         )
-        if project_result is not None:
-            return project_result
+        if project is not None:
+            return project
         self._advance_work(
             work,
             lifecycle="COMPLETED",
@@ -383,10 +303,7 @@ class V2AutonomousTransitionExecutor:
             evidence=(f"work-completed:{work.issue_number}",),
             schedule_key=schedule_key,
         )
-        return TransitionExecutionResult(
-            TransitionExecutionStatus.PROGRESSED,
-            "WORK_COMPLETED",
-        )
+        return _progressed("WORK_COMPLETED")
 
     def _close_issue(
         self,
@@ -395,6 +312,8 @@ class V2AutonomousTransitionExecutor:
         schedule_key: str,
     ) -> TransitionExecutionResult | None:
         key = _effect_key(schedule_key, "ISSUE_UPDATE", f"issue:{work.issue_number}")
+        if _pending_effect(self.work_state.recover(work.work_identity), key) == "UNCERTAIN":
+            return _intervention("ISSUE_CLOSE_UNCERTAIN")
         attempt = EffectAttempt(
             idempotency_key=key,
             work_identity=work.work_identity,
@@ -405,26 +324,15 @@ class V2AutonomousTransitionExecutor:
             expected_preconditions=(("state", "OPEN"),),
             expected_effect=(("state", "CLOSED"),),
         )
-        pending = _pending_effect(self.work_state.recover(work.work_identity), key)
-        if pending == "UNCERTAIN":
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "ISSUE_CLOSE_UNCERTAIN",
-            )
         if not self.work_state.record_effect_intent(attempt):
             if self._issue_state(registration, work.issue_number) == "CLOSED":
                 return None
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "ISSUE_CLOSE_STATE_CONFLICT",
-            )
+            return _intervention("ISSUE_CLOSE_STATE_CONFLICT")
         if self._issue_state(registration, work.issue_number) != "OPEN":
             self.work_state.record_effect_outcome(key, "NO_EFFECT")
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "ISSUE_CLOSE_PRECONDITION_CHANGED",
-            )
-        result = self._run(
+            return _intervention("ISSUE_CLOSE_PRECONDITION_CHANGED")
+
+        sent = self._run(
             (
                 "gh",
                 "issue",
@@ -439,14 +347,11 @@ class V2AutonomousTransitionExecutor:
         if state == "CLOSED":
             self.work_state.record_effect_outcome(key, "CONFIRMED")
             return None
-        if result.succeeded and state == "OPEN":
+        if sent.succeeded and state == "OPEN":
             self.work_state.record_effect_outcome(key, "NO_EFFECT")
-            return TransitionExecutionResult(TransitionExecutionStatus.FAILED, "ISSUE_CLOSE_NO_EFFECT")
+            return _failed("ISSUE_CLOSE_NO_EFFECT")
         self.work_state.record_effect_outcome(key, "UNCERTAIN")
-        return TransitionExecutionResult(
-            TransitionExecutionStatus.INTERVENTION_REQUIRED,
-            "ISSUE_CLOSE_READBACK_UNPROVEN",
-        )
+        return _intervention("ISSUE_CLOSE_READBACK_UNPROVEN")
 
     def _ensure_project_done(
         self,
@@ -456,17 +361,25 @@ class V2AutonomousTransitionExecutor:
         schedule_key: str,
     ) -> TransitionExecutionResult | None:
         project_id = self._project_id(registration)
-        option = self._project_status_option(registration, project_id, self.done_project_status)
+        option = self._project_status_option(
+            registration,
+            project_id,
+            self.done_project_status,
+        )
         if project_id is None or option is None:
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "PROJECT_STATUS_AUTHORITY_UNAVAILABLE",
-            )
+            return _intervention("PROJECT_STATUS_AUTHORITY_UNAVAILABLE")
         field_id, option_id = option
-        observed = self._project_item_status(item_id)
+        observed = self._project_item_status(registration, item_id)
         if observed == self.done_project_status:
             return None
-        key = _effect_key(schedule_key, "PROJECT_FIELD_UPDATE", f"project-item:{item_id}:Status")
+
+        key = _effect_key(
+            schedule_key,
+            "PROJECT_FIELD_UPDATE",
+            f"project-item:{item_id}:Status",
+        )
+        if _pending_effect(self.work_state.recover(work.work_identity), key) == "UNCERTAIN":
+            return _intervention("PROJECT_STATUS_UNCERTAIN")
         attempt = EffectAttempt(
             idempotency_key=key,
             work_identity=work.work_identity,
@@ -477,26 +390,15 @@ class V2AutonomousTransitionExecutor:
             expected_preconditions=(("value", observed or "<unset>"),),
             expected_effect=(("value", self.done_project_status),),
         )
-        pending = _pending_effect(self.work_state.recover(work.work_identity), key)
-        if pending == "UNCERTAIN":
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "PROJECT_STATUS_UNCERTAIN",
-            )
         if not self.work_state.record_effect_intent(attempt):
-            if self._project_item_status(item_id) == self.done_project_status:
+            if self._project_item_status(registration, item_id) == self.done_project_status:
                 return None
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "PROJECT_STATUS_STATE_CONFLICT",
-            )
-        if self._project_item_status(item_id) != observed:
+            return _intervention("PROJECT_STATUS_STATE_CONFLICT")
+        if self._project_item_status(registration, item_id) != observed:
             self.work_state.record_effect_outcome(key, "NO_EFFECT")
-            return TransitionExecutionResult(
-                TransitionExecutionStatus.INTERVENTION_REQUIRED,
-                "PROJECT_STATUS_PRECONDITION_CHANGED",
-            )
-        result = self._run(
+            return _intervention("PROJECT_STATUS_PRECONDITION_CHANGED")
+
+        sent = self._run(
             (
                 "gh",
                 "project",
@@ -512,17 +414,31 @@ class V2AutonomousTransitionExecutor:
             ),
             registration.workspace_canonical_path,
         )
-        fresh = self._project_item_status(item_id)
+        fresh = self._project_item_status(registration, item_id)
         if fresh == self.done_project_status:
             self.work_state.record_effect_outcome(key, "CONFIRMED")
             return None
-        if result.succeeded and fresh == observed:
+        if sent.succeeded and fresh == observed:
             self.work_state.record_effect_outcome(key, "NO_EFFECT")
-            return TransitionExecutionResult(TransitionExecutionStatus.FAILED, "PROJECT_STATUS_NO_EFFECT")
+            return _failed("PROJECT_STATUS_NO_EFFECT")
         self.work_state.record_effect_outcome(key, "UNCERTAIN")
-        return TransitionExecutionResult(
-            TransitionExecutionStatus.INTERVENTION_REQUIRED,
-            "PROJECT_STATUS_READBACK_UNPROVEN",
+        return _intervention("PROJECT_STATUS_READBACK_UNPROVEN")
+
+    def _mark_integrated(
+        self,
+        work: V2WorkObservation,
+        pr_number: int,
+        schedule_key: str,
+    ) -> None:
+        assert work.exact_head_sha is not None
+        self._advance_work(
+            work,
+            lifecycle="RUNNING",
+            selected_transition="INTEGRATE",
+            active_lineage_identity=f"pr:{pr_number}",
+            next_action="COMPLETE_WORK",
+            evidence=(f"merged-pr:{pr_number}:{work.exact_head_sha}",),
+            schedule_key=schedule_key,
         )
 
     def _advance_work(
@@ -539,29 +455,56 @@ class V2AutonomousTransitionExecutor:
         recovered = self.work_state.recover(work.work_identity)
         if recovered is None:
             raise RuntimeError("WORK_STATE_RECOVERY_MISSING")
-        record = replace(
-            recovered.record,
-            lifecycle=lifecycle,
-            selected_transition=selected_transition,
-            active_lineage_identity=active_lineage_identity,
+        self.work_state.upsert_work(
+            replace(
+                recovered.record,
+                lifecycle=lifecycle,
+                selected_transition=selected_transition,
+                active_lineage_identity=active_lineage_identity,
+            )
         )
-        self.work_state.upsert_work(record)
-        checkpoint = WorkCheckpoint(
-            identity="autonomous-checkpoint:"
-            + hashlib.sha256(
-                f"{schedule_key}|{lifecycle}|{next_action}".encode("utf-8")
-            ).hexdigest(),
-            work_identity=work.work_identity,
-            run_identity=f"autonomous:{schedule_key}",
-            checkpoint_kind="SAFE_POINT",
-            resumable_state=lifecycle,
-            next_action=next_action,
-            external_target_identities=(active_lineage_identity,)
-            if active_lineage_identity is not None
-            else (),
-            evidence_identities=evidence,
+        digest = hashlib.sha256(
+            f"{schedule_key}|{lifecycle}|{next_action}".encode()
+        ).hexdigest()
+        self.work_state.record_checkpoint(
+            WorkCheckpoint(
+                identity=f"autonomous-checkpoint:{digest}",
+                work_identity=work.work_identity,
+                run_identity=f"autonomous:{schedule_key}",
+                checkpoint_kind="SAFE_POINT",
+                resumable_state=lifecycle,
+                next_action=next_action,
+                external_target_identities=(active_lineage_identity,)
+                if active_lineage_identity is not None
+                else (),
+                evidence_identities=evidence,
+            )
         )
-        self.work_state.record_checkpoint(checkpoint)
+
+    def _ensure_commit_available(
+        self,
+        registration: ProductDevelopmentRegistration,
+        sha: str,
+        remote_ref: str,
+    ) -> bool:
+        local = self._run(
+            ("git", "cat-file", "-e", f"{sha}^{{commit}}"),
+            registration.workspace_canonical_path,
+        )
+        if local.succeeded:
+            return True
+        fetched = self._run(
+            ("git", "fetch", "origin", f"refs/heads/{remote_ref}"),
+            registration.workspace_canonical_path,
+            timeout_seconds=180,
+        )
+        if not fetched.succeeded:
+            return False
+        readback = self._run(
+            ("git", "cat-file", "-e", f"{sha}^{{commit}}"),
+            registration.workspace_canonical_path,
+        )
+        return readback.succeeded
 
     def _trunk_head(self, registration: ProductDevelopmentRegistration) -> str | None:
         result = self._run(
@@ -602,11 +545,8 @@ class V2AutonomousTransitionExecutor:
         )
         if not result.succeeded:
             return None
-        try:
-            payload = json.loads(result.output)
-        except json.JSONDecodeError:
-            return None
-        if not isinstance(payload, dict) or payload.get("number") != pr_number:
+        payload = _json_mapping(result.output)
+        if payload is None or payload.get("number") != pr_number:
             return None
         state = payload.get("state")
         head = payload.get("headRefOid")
@@ -633,13 +573,8 @@ class V2AutonomousTransitionExecutor:
             ),
             registration.workspace_canonical_path,
         )
-        if not result.succeeded:
-            return None
-        try:
-            payload = json.loads(result.output)
-        except json.JSONDecodeError:
-            return None
-        if not isinstance(payload, dict) or payload.get("number") != issue_number:
+        payload = _json_mapping(result.output) if result.succeeded else None
+        if payload is None or payload.get("number") != issue_number:
             return None
         state = payload.get("state")
         return state if isinstance(state, str) else None
@@ -658,13 +593,8 @@ class V2AutonomousTransitionExecutor:
             ),
             registration.workspace_canonical_path,
         )
-        if not result.succeeded:
-            return None
-        try:
-            payload = json.loads(result.output)
-        except json.JSONDecodeError:
-            return None
-        value = payload.get("id") if isinstance(payload, dict) else None
+        payload = _json_mapping(result.output) if result.succeeded else None
+        value = payload.get("id") if payload is not None else None
         return value if isinstance(value, str) else None
 
     def _project_status_option(
@@ -692,14 +622,10 @@ class V2AutonomousTransitionExecutor:
             ),
             registration.workspace_canonical_path,
         )
-        if not result.succeeded:
+        payload = _json_mapping(result.output) if result.succeeded else None
+        if payload is None:
             return None
-        try:
-            payload = json.loads(result.output)
-        except json.JSONDecodeError:
-            return None
-        node = _mapping(_mapping(payload, "data"), "node")
-        fields = _mapping(node, "fields")
+        fields = _mapping(_mapping(_mapping(payload, "data"), "node"), "fields")
         if _mapping(fields, "pageInfo").get("hasNextPage") is True:
             return None
         nodes = fields.get("nodes")
@@ -713,17 +639,22 @@ class V2AutonomousTransitionExecutor:
             if not isinstance(field_id, str) or not isinstance(options, list):
                 return None
             for option in options:
-                if isinstance(option, dict) and option.get("name") == status_name:
-                    option_id = option.get("id")
-                    if isinstance(option_id, str):
-                        return field_id, option_id
+                if not isinstance(option, dict) or option.get("name") != status_name:
+                    continue
+                option_id = option.get("id")
+                if isinstance(option_id, str):
+                    return field_id, option_id
         return None
 
-    def _project_item_status(self, item_id: str) -> str | None:
+    def _project_item_status(
+        self,
+        registration: ProductDevelopmentRegistration,
+        item_id: str,
+    ) -> str | None:
         query = (
-            "query($id:ID!){node(id:$id){... on ProjectV2Item{fieldValues(first:100){nodes{"
-            "... on ProjectV2ItemFieldSingleSelectValue{field{... on ProjectV2FieldCommon{name}}name}"
-            "}pageInfo{hasNextPage}}}}}"
+            "query($id:ID!){node(id:$id){... on ProjectV2Item{"
+            "fieldValues(first:100){nodes{... on ProjectV2ItemFieldSingleSelectValue{"
+            "field{... on ProjectV2FieldCommon{name}} name}}pageInfo{hasNextPage}}}}}"
         )
         result = self._run(
             (
@@ -735,16 +666,12 @@ class V2AutonomousTransitionExecutor:
                 "-f",
                 f"id={item_id}",
             ),
-            Path.cwd(),
+            registration.workspace_canonical_path,
         )
-        if not result.succeeded:
+        payload = _json_mapping(result.output) if result.succeeded else None
+        if payload is None:
             return None
-        try:
-            payload = json.loads(result.output)
-        except json.JSONDecodeError:
-            return None
-        node = _mapping(_mapping(payload, "data"), "node")
-        values = _mapping(node, "fieldValues")
+        values = _mapping(_mapping(_mapping(payload, "data"), "node"), "fieldValues")
         if _mapping(values, "pageInfo").get("hasNextPage") is True:
             return None
         nodes = values.get("nodes")
@@ -753,9 +680,10 @@ class V2AutonomousTransitionExecutor:
         for raw in nodes:
             if not isinstance(raw, dict):
                 continue
-            if _mapping(raw, "field").get("name") == "Status":
-                value = raw.get("name")
-                return value if isinstance(value, str) else None
+            if _mapping(raw, "field").get("name") != "Status":
+                continue
+            value = raw.get("name")
+            return value if isinstance(value, str) else None
         return None
 
     def _run(
@@ -786,14 +714,26 @@ class _FailedResult:
         return False
 
 
+def _integration_evidence_valid(work: V2WorkObservation) -> bool:
+    return (
+        work.exact_head_sha is not None
+        and work.verification_state is EvidenceState.PASS
+        and work.review_state is EvidenceState.PASS
+        and (
+            not work.human_verification_required
+            or work.human_verification_state is EvidenceState.PASS
+        )
+    )
+
+
 def _generation(schedule_key: str) -> int:
-    digest = hashlib.sha256(schedule_key.encode("utf-8")).hexdigest()
+    digest = hashlib.sha256(schedule_key.encode()).hexdigest()
     return int(digest[:15], 16) + 1
 
 
 def _effect_key(schedule_key: str, kind: str, target: str) -> str:
     raw = f"{schedule_key}|{kind}|{target}"
-    return "autonomous-effect:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    return "autonomous-effect:" + hashlib.sha256(raw.encode()).hexdigest()
 
 
 def _pending_effect(recovered: RecoveredWork | None, key: str) -> str | None:
@@ -831,6 +771,30 @@ def _commit_message(transition: V2Transition, issue_number: int) -> str:
     return f"{prefix}: #{issue_number} の{transition.value}を反映する"
 
 
+def _json_mapping(raw: str) -> dict[str, object] | None:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
 def _mapping(value: Mapping[str, object], key: str) -> Mapping[str, object]:
     nested = value.get(key)
     return nested if isinstance(nested, dict) else {}
+
+
+def _progressed(detail: str) -> TransitionExecutionResult:
+    return TransitionExecutionResult(TransitionExecutionStatus.PROGRESSED, detail)
+
+
+def _waiting(detail: str) -> TransitionExecutionResult:
+    return TransitionExecutionResult(TransitionExecutionStatus.WAITING, detail)
+
+
+def _failed(detail: str) -> TransitionExecutionResult:
+    return TransitionExecutionResult(TransitionExecutionStatus.FAILED, detail)
+
+
+def _intervention(detail: str) -> TransitionExecutionResult:
+    return TransitionExecutionResult(TransitionExecutionStatus.INTERVENTION_REQUIRED, detail)

--- a/src/loop_engineering/v2_autonomous_transitions.py
+++ b/src/loop_engineering/v2_autonomous_transitions.py
@@ -1,0 +1,836 @@
+"""Supervisor transitionを#85/#86と安全なIntegration/Completion effectへ接続する。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Protocol
+
+from .v2_autonomous_runner import (
+    TransitionExecutionResult,
+    TransitionExecutionStatus,
+)
+from .v2_development_lineage import (
+    GitHubDevelopmentLineageEffects,
+    LineageIdentity,
+    LineageStatus,
+    TrustedProposalMaterializer,
+)
+from .v2_goal_planning import BootstrapResult, PlannedWork, ProductDevelopmentRegistration
+from .v2_implementer import (
+    CodexProposalImplementer,
+    DevelopmentTaskPacket,
+    ImplementerStatus,
+    ImplementerTransition,
+)
+from .v2_supervisor import EvidenceState, V2SupervisorDecision, V2Transition, V2WorkObservation
+from .work_state import EffectAttempt, RecoveredWork, WorkCheckpoint, WorkRecord
+
+_SHA_RE = re.compile(r"[0-9a-f]{40}")
+_PR_RE = re.compile(r"pr:(\d+)")
+
+
+class CommandResultLike(Protocol):
+    @property
+    def returncode(self) -> int: ...
+
+    @property
+    def output(self) -> str: ...
+
+    @property
+    def succeeded(self) -> bool: ...
+
+
+class AutonomousTransitionCommandRunner(Protocol):
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        environment: Mapping[str, str] | None = None,
+        timeout_seconds: int = 120,
+        capture_output: bool = True,
+    ) -> CommandResultLike: ...
+
+
+class AutonomousWorkStatePort(Protocol):
+    def recover(self, work_identity: str) -> RecoveredWork | None: ...
+
+    def upsert_work(self, record: WorkRecord) -> None: ...
+
+    def record_checkpoint(self, checkpoint: WorkCheckpoint) -> None: ...
+
+    def record_effect_intent(self, attempt: EffectAttempt) -> bool: ...
+
+    def record_effect_outcome(self, idempotency_key: str, status: str) -> None: ...
+
+
+@dataclass(slots=True)
+class V2AutonomousTransitionExecutor:
+    implementer: CodexProposalImplementer
+    materializer: TrustedProposalMaterializer
+    lineage: GitHubDevelopmentLineageEffects
+    work_state: AutonomousWorkStatePort
+    runner: AutonomousTransitionCommandRunner
+    environment: Mapping[str, str]
+    scope_paths: tuple[str, ...]
+    done_project_status: str = "Done"
+
+    def execute(
+        self,
+        registration: ProductDevelopmentRegistration,
+        bootstrap: BootstrapResult,
+        work: V2WorkObservation,
+        planned_work: PlannedWork,
+        decision: V2SupervisorDecision,
+    ) -> TransitionExecutionResult:
+        transition = decision.transition
+        if transition is None or decision.schedule_key is None:
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "TRANSITION_DECISION_INVALID",
+            )
+        if transition in {V2Transition.DESIGN, V2Transition.IMPLEMENT, V2Transition.REPAIR}:
+            return self._develop(registration, work, planned_work, decision)
+        if transition in {V2Transition.VERIFY, V2Transition.REVIEW, V2Transition.HUMAN_VERIFY}:
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.WAITING,
+                f"{transition.value}_EVIDENCE_PENDING",
+            )
+        if transition is V2Transition.INTEGRATE:
+            return self._integrate(registration, work, decision.schedule_key)
+        if transition is V2Transition.COMPLETE_WORK:
+            return self._complete_work(registration, bootstrap, work, decision.schedule_key)
+        return TransitionExecutionResult(
+            TransitionExecutionStatus.INTERVENTION_REQUIRED,
+            "TRANSITION_UNSUPPORTED",
+        )
+
+    def _develop(
+        self,
+        registration: ProductDevelopmentRegistration,
+        work: V2WorkObservation,
+        planned: PlannedWork,
+        decision: V2SupervisorDecision,
+    ) -> TransitionExecutionResult:
+        assert decision.transition is not None and decision.schedule_key is not None
+        exact_base = work.exact_head_sha or self._trunk_head(registration)
+        if exact_base is None:
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.WAITING,
+                "TRUNK_HEAD_UNAVAILABLE",
+            )
+        implementer_transition = ImplementerTransition(decision.transition.value)
+        generation = _generation(decision.schedule_key)
+        packet = DevelopmentTaskPacket(
+            packet_identity=decision.schedule_key,
+            work_identity=work.work_identity,
+            generation=generation,
+            transition=implementer_transition,
+            repository_identity=registration.repository_identity,
+            workspace_canonical_path=registration.workspace_canonical_path,
+            exact_base_sha=exact_base,
+            goal_revision=registration.goal_revision,
+            issue_revision=work.issue_revision,
+            scope_paths=self.scope_paths,
+            acceptance_checks=planned.acceptance_criteria,
+            canonical_design_identities=work.canonical_design_identities,
+            canonical_design_targets=planned.canonical_design_targets,
+            active_lineage_identity=work.active_lineage_identity,
+            authority_refs=(registration.goal_definition_identity, f"Issue #{work.issue_number}"),
+            non_goals=(),
+            safety_constraints=(
+                "main/trunkへ直接commit/pushしない",
+                "GitHub mutationはTrusted Hostへ委譲する",
+            ),
+        )
+        implemented = self.implementer.execute(packet)
+        if implemented.status is ImplementerStatus.BLOCKED:
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                implemented.detail,
+            )
+        if implemented.status is not ImplementerStatus.SUCCESS or implemented.proposal is None:
+            return TransitionExecutionResult(TransitionExecutionStatus.FAILED, implemented.detail)
+        materialized = self.materializer.materialize(
+            workspace=registration.workspace_canonical_path,
+            repository=registration.repository_identity,
+            proposal=implemented.proposal,
+            commit_message=_commit_message(decision.transition, work.issue_number),
+        )
+        if materialized is None:
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.FAILED,
+                "PROPOSAL_MATERIALIZATION_FAILED",
+            )
+        branch = _work_branch(registration.work_branch_template, work.issue_number)
+        published = self.lineage.publish(
+            LineageIdentity(
+                registration.repository_identity,
+                work.work_identity,
+                work.issue_number,
+                branch,
+                registration.trunk_branch,
+                generation,
+            ),
+            materialized,
+        )
+        if published.status is LineageStatus.UNCERTAIN:
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                published.detail,
+            )
+        if published.status is LineageStatus.BLOCKED:
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                published.detail,
+            )
+        if published.status is not LineageStatus.CONFIRMED or published.pull_request is None:
+            return TransitionExecutionResult(TransitionExecutionStatus.FAILED, published.detail)
+        self._advance_work(
+            work,
+            lifecycle="RUNNING",
+            selected_transition=decision.transition.value,
+            active_lineage_identity=f"pr:{published.pull_request.number}",
+            next_action="OBSERVE_EXACT_HEAD_EVIDENCE",
+            evidence=(f"head:{published.pull_request.head_sha}",),
+            schedule_key=decision.schedule_key,
+        )
+        return TransitionExecutionResult(
+            TransitionExecutionStatus.PROGRESSED,
+            published.detail,
+        )
+
+    def _integrate(
+        self,
+        registration: ProductDevelopmentRegistration,
+        work: V2WorkObservation,
+        schedule_key: str,
+    ) -> TransitionExecutionResult:
+        if (
+            work.exact_head_sha is None
+            or work.verification_state is not EvidenceState.PASS
+            or work.review_state is not EvidenceState.PASS
+            or (
+                work.human_verification_required
+                and work.human_verification_state is not EvidenceState.PASS
+            )
+        ):
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "INTEGRATION_EVIDENCE_INVALID",
+            )
+        pr_number = _pr_number(work.active_lineage_identity)
+        if pr_number is None:
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "INTEGRATION_PR_IDENTITY_INVALID",
+            )
+        observed = self._pr_state(registration, pr_number)
+        if observed is None:
+            return TransitionExecutionResult(TransitionExecutionStatus.WAITING, "PR_READBACK_UNAVAILABLE")
+        if observed[0] == "MERGED" and observed[1] == work.exact_head_sha:
+            self._advance_work(
+                work,
+                lifecycle="RUNNING",
+                selected_transition="INTEGRATE",
+                active_lineage_identity=f"pr:{pr_number}",
+                next_action="COMPLETE_WORK",
+                evidence=(f"merged-pr:{pr_number}:{work.exact_head_sha}",),
+                schedule_key=schedule_key,
+            )
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.PROGRESSED,
+                "PR_ALREADY_MERGED",
+            )
+        if observed != ("OPEN", work.exact_head_sha, registration.trunk_branch):
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "INTEGRATION_PR_PRECONDITION_CONFLICT",
+            )
+        generation = _generation(schedule_key)
+        key = _effect_key(schedule_key, "MERGE", f"pr:{pr_number}")
+        attempt = EffectAttempt(
+            idempotency_key=key,
+            work_identity=work.work_identity,
+            kind="MERGE",
+            target_identity=f"pr:{pr_number}",
+            status="INTENT_RECORDED",
+            packet_generation=generation,
+            expected_preconditions=(
+                ("head", work.exact_head_sha),
+                ("base", registration.trunk_branch),
+                ("state", "OPEN"),
+            ),
+            expected_effect=(("state", "MERGED"),),
+        )
+        pending = _pending_effect(self.work_state.recover(work.work_identity), key)
+        if pending == "UNCERTAIN":
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "MERGE_EFFECT_UNCERTAIN",
+            )
+        if not self.work_state.record_effect_intent(attempt):
+            fresh = self._pr_state(registration, pr_number)
+            if fresh is not None and fresh[0] == "MERGED" and fresh[1] == work.exact_head_sha:
+                return TransitionExecutionResult(
+                    TransitionExecutionStatus.PROGRESSED,
+                    "MERGE_EFFECT_ALREADY_CONFIRMED",
+                )
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "MERGE_EFFECT_STATE_CONFLICT",
+            )
+        fresh_before = self._pr_state(registration, pr_number)
+        if fresh_before != observed:
+            self.work_state.record_effect_outcome(key, "NO_EFFECT")
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "MERGE_PRECONDITION_CHANGED",
+            )
+        command = self._run(
+            (
+                "gh",
+                "pr",
+                "merge",
+                str(pr_number),
+                "--repo",
+                registration.repository_identity,
+                "--merge",
+                "--match-head-commit",
+                work.exact_head_sha,
+            ),
+            registration.workspace_canonical_path,
+            timeout_seconds=300,
+        )
+        fresh = self._pr_state(registration, pr_number)
+        if fresh is not None and fresh[0] == "MERGED" and fresh[1] == work.exact_head_sha:
+            self.work_state.record_effect_outcome(key, "CONFIRMED")
+            self._advance_work(
+                work,
+                lifecycle="RUNNING",
+                selected_transition="INTEGRATE",
+                active_lineage_identity=f"pr:{pr_number}",
+                next_action="COMPLETE_WORK",
+                evidence=(f"merged-pr:{pr_number}:{work.exact_head_sha}",),
+                schedule_key=schedule_key,
+            )
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.PROGRESSED,
+                "MERGE_CONFIRMED",
+            )
+        if command.succeeded and fresh == observed:
+            self.work_state.record_effect_outcome(key, "NO_EFFECT")
+            return TransitionExecutionResult(TransitionExecutionStatus.FAILED, "MERGE_NO_EFFECT")
+        self.work_state.record_effect_outcome(key, "UNCERTAIN")
+        return TransitionExecutionResult(
+            TransitionExecutionStatus.INTERVENTION_REQUIRED,
+            "MERGE_READBACK_UNPROVEN",
+        )
+
+    def _complete_work(
+        self,
+        registration: ProductDevelopmentRegistration,
+        bootstrap: BootstrapResult,
+        work: V2WorkObservation,
+        schedule_key: str,
+    ) -> TransitionExecutionResult:
+        if not work.merged:
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "WORK_COMPLETION_MERGE_REQUIRED",
+            )
+        issue_state = self._issue_state(registration, work.issue_number)
+        if issue_state is None:
+            return TransitionExecutionResult(TransitionExecutionStatus.WAITING, "ISSUE_READBACK_UNAVAILABLE")
+        if issue_state == "OPEN":
+            result = self._close_issue(registration, work, schedule_key)
+            if result is not None:
+                return result
+        elif issue_state != "CLOSED":
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "ISSUE_STATE_INVALID",
+            )
+        projected = next(
+            (item for item in bootstrap.projection.works if item.issue_number == work.issue_number),
+            None,
+        )
+        if projected is None:
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "PROJECTED_WORK_MISSING",
+            )
+        project_result = self._ensure_project_done(
+            registration,
+            work,
+            projected.project_item_id,
+            schedule_key,
+        )
+        if project_result is not None:
+            return project_result
+        self._advance_work(
+            work,
+            lifecycle="COMPLETED",
+            selected_transition="COMPLETE_WORK",
+            active_lineage_identity=work.active_lineage_identity,
+            next_action="SELECT_NEXT_WORK",
+            evidence=(f"work-completed:{work.issue_number}",),
+            schedule_key=schedule_key,
+        )
+        return TransitionExecutionResult(
+            TransitionExecutionStatus.PROGRESSED,
+            "WORK_COMPLETED",
+        )
+
+    def _close_issue(
+        self,
+        registration: ProductDevelopmentRegistration,
+        work: V2WorkObservation,
+        schedule_key: str,
+    ) -> TransitionExecutionResult | None:
+        key = _effect_key(schedule_key, "ISSUE_UPDATE", f"issue:{work.issue_number}")
+        attempt = EffectAttempt(
+            idempotency_key=key,
+            work_identity=work.work_identity,
+            kind="ISSUE_UPDATE",
+            target_identity=f"issue:{work.issue_number}",
+            status="INTENT_RECORDED",
+            packet_generation=_generation(schedule_key),
+            expected_preconditions=(("state", "OPEN"),),
+            expected_effect=(("state", "CLOSED"),),
+        )
+        pending = _pending_effect(self.work_state.recover(work.work_identity), key)
+        if pending == "UNCERTAIN":
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "ISSUE_CLOSE_UNCERTAIN",
+            )
+        if not self.work_state.record_effect_intent(attempt):
+            if self._issue_state(registration, work.issue_number) == "CLOSED":
+                return None
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "ISSUE_CLOSE_STATE_CONFLICT",
+            )
+        if self._issue_state(registration, work.issue_number) != "OPEN":
+            self.work_state.record_effect_outcome(key, "NO_EFFECT")
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "ISSUE_CLOSE_PRECONDITION_CHANGED",
+            )
+        result = self._run(
+            (
+                "gh",
+                "issue",
+                "close",
+                str(work.issue_number),
+                "--repo",
+                registration.repository_identity,
+            ),
+            registration.workspace_canonical_path,
+        )
+        state = self._issue_state(registration, work.issue_number)
+        if state == "CLOSED":
+            self.work_state.record_effect_outcome(key, "CONFIRMED")
+            return None
+        if result.succeeded and state == "OPEN":
+            self.work_state.record_effect_outcome(key, "NO_EFFECT")
+            return TransitionExecutionResult(TransitionExecutionStatus.FAILED, "ISSUE_CLOSE_NO_EFFECT")
+        self.work_state.record_effect_outcome(key, "UNCERTAIN")
+        return TransitionExecutionResult(
+            TransitionExecutionStatus.INTERVENTION_REQUIRED,
+            "ISSUE_CLOSE_READBACK_UNPROVEN",
+        )
+
+    def _ensure_project_done(
+        self,
+        registration: ProductDevelopmentRegistration,
+        work: V2WorkObservation,
+        item_id: str,
+        schedule_key: str,
+    ) -> TransitionExecutionResult | None:
+        project_id = self._project_id(registration)
+        option = self._project_status_option(registration, project_id, self.done_project_status)
+        if project_id is None or option is None:
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "PROJECT_STATUS_AUTHORITY_UNAVAILABLE",
+            )
+        field_id, option_id = option
+        observed = self._project_item_status(item_id)
+        if observed == self.done_project_status:
+            return None
+        key = _effect_key(schedule_key, "PROJECT_FIELD_UPDATE", f"project-item:{item_id}:Status")
+        attempt = EffectAttempt(
+            idempotency_key=key,
+            work_identity=work.work_identity,
+            kind="PROJECT_FIELD_UPDATE",
+            target_identity=f"project-item:{item_id}:Status",
+            status="INTENT_RECORDED",
+            packet_generation=_generation(schedule_key),
+            expected_preconditions=(("value", observed or "<unset>"),),
+            expected_effect=(("value", self.done_project_status),),
+        )
+        pending = _pending_effect(self.work_state.recover(work.work_identity), key)
+        if pending == "UNCERTAIN":
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "PROJECT_STATUS_UNCERTAIN",
+            )
+        if not self.work_state.record_effect_intent(attempt):
+            if self._project_item_status(item_id) == self.done_project_status:
+                return None
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "PROJECT_STATUS_STATE_CONFLICT",
+            )
+        if self._project_item_status(item_id) != observed:
+            self.work_state.record_effect_outcome(key, "NO_EFFECT")
+            return TransitionExecutionResult(
+                TransitionExecutionStatus.INTERVENTION_REQUIRED,
+                "PROJECT_STATUS_PRECONDITION_CHANGED",
+            )
+        result = self._run(
+            (
+                "gh",
+                "project",
+                "item-edit",
+                "--id",
+                item_id,
+                "--project-id",
+                project_id,
+                "--field-id",
+                field_id,
+                "--single-select-option-id",
+                option_id,
+            ),
+            registration.workspace_canonical_path,
+        )
+        fresh = self._project_item_status(item_id)
+        if fresh == self.done_project_status:
+            self.work_state.record_effect_outcome(key, "CONFIRMED")
+            return None
+        if result.succeeded and fresh == observed:
+            self.work_state.record_effect_outcome(key, "NO_EFFECT")
+            return TransitionExecutionResult(TransitionExecutionStatus.FAILED, "PROJECT_STATUS_NO_EFFECT")
+        self.work_state.record_effect_outcome(key, "UNCERTAIN")
+        return TransitionExecutionResult(
+            TransitionExecutionStatus.INTERVENTION_REQUIRED,
+            "PROJECT_STATUS_READBACK_UNPROVEN",
+        )
+
+    def _advance_work(
+        self,
+        work: V2WorkObservation,
+        *,
+        lifecycle: str,
+        selected_transition: str,
+        active_lineage_identity: str | None,
+        next_action: str,
+        evidence: tuple[str, ...],
+        schedule_key: str,
+    ) -> None:
+        recovered = self.work_state.recover(work.work_identity)
+        if recovered is None:
+            raise RuntimeError("WORK_STATE_RECOVERY_MISSING")
+        record = replace(
+            recovered.record,
+            lifecycle=lifecycle,
+            selected_transition=selected_transition,
+            active_lineage_identity=active_lineage_identity,
+        )
+        self.work_state.upsert_work(record)
+        checkpoint = WorkCheckpoint(
+            identity="autonomous-checkpoint:"
+            + hashlib.sha256(
+                f"{schedule_key}|{lifecycle}|{next_action}".encode("utf-8")
+            ).hexdigest(),
+            work_identity=work.work_identity,
+            run_identity=f"autonomous:{schedule_key}",
+            checkpoint_kind="SAFE_POINT",
+            resumable_state=lifecycle,
+            next_action=next_action,
+            external_target_identities=(active_lineage_identity,)
+            if active_lineage_identity is not None
+            else (),
+            evidence_identities=evidence,
+        )
+        self.work_state.record_checkpoint(checkpoint)
+
+    def _trunk_head(self, registration: ProductDevelopmentRegistration) -> str | None:
+        result = self._run(
+            (
+                "git",
+                "ls-remote",
+                "--heads",
+                "origin",
+                f"refs/heads/{registration.trunk_branch}",
+            ),
+            registration.workspace_canonical_path,
+        )
+        if not result.succeeded:
+            return None
+        lines = [line for line in result.output.splitlines() if line.strip()]
+        if len(lines) != 1:
+            return None
+        sha = lines[0].split(maxsplit=1)[0]
+        return sha if _SHA_RE.fullmatch(sha) is not None else None
+
+    def _pr_state(
+        self,
+        registration: ProductDevelopmentRegistration,
+        pr_number: int,
+    ) -> tuple[str, str, str] | None:
+        result = self._run(
+            (
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                registration.repository_identity,
+                "--json",
+                "number,state,headRefOid,baseRefName",
+            ),
+            registration.workspace_canonical_path,
+        )
+        if not result.succeeded:
+            return None
+        try:
+            payload = json.loads(result.output)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(payload, dict) or payload.get("number") != pr_number:
+            return None
+        state = payload.get("state")
+        head = payload.get("headRefOid")
+        base = payload.get("baseRefName")
+        if not isinstance(state, str) or not isinstance(head, str) or not isinstance(base, str):
+            return None
+        return state, head, base
+
+    def _issue_state(
+        self,
+        registration: ProductDevelopmentRegistration,
+        issue_number: int,
+    ) -> str | None:
+        result = self._run(
+            (
+                "gh",
+                "issue",
+                "view",
+                str(issue_number),
+                "--repo",
+                registration.repository_identity,
+                "--json",
+                "number,state",
+            ),
+            registration.workspace_canonical_path,
+        )
+        if not result.succeeded:
+            return None
+        try:
+            payload = json.loads(result.output)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(payload, dict) or payload.get("number") != issue_number:
+            return None
+        state = payload.get("state")
+        return state if isinstance(state, str) else None
+
+    def _project_id(self, registration: ProductDevelopmentRegistration) -> str | None:
+        result = self._run(
+            (
+                "gh",
+                "project",
+                "view",
+                str(registration.project_number),
+                "--owner",
+                registration.project_owner,
+                "--format",
+                "json",
+            ),
+            registration.workspace_canonical_path,
+        )
+        if not result.succeeded:
+            return None
+        try:
+            payload = json.loads(result.output)
+        except json.JSONDecodeError:
+            return None
+        value = payload.get("id") if isinstance(payload, dict) else None
+        return value if isinstance(value, str) else None
+
+    def _project_status_option(
+        self,
+        registration: ProductDevelopmentRegistration,
+        project_id: str | None,
+        status_name: str,
+    ) -> tuple[str, str] | None:
+        if project_id is None:
+            return None
+        query = (
+            "query($id:ID!){node(id:$id){... on ProjectV2{fields(first:100){nodes{"
+            "... on ProjectV2SingleSelectField{id name options{id name}}}"
+            "pageInfo{hasNextPage}}}}}"
+        )
+        result = self._run(
+            (
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-f",
+                f"id={project_id}",
+            ),
+            registration.workspace_canonical_path,
+        )
+        if not result.succeeded:
+            return None
+        try:
+            payload = json.loads(result.output)
+        except json.JSONDecodeError:
+            return None
+        node = _mapping(_mapping(payload, "data"), "node")
+        fields = _mapping(node, "fields")
+        if _mapping(fields, "pageInfo").get("hasNextPage") is True:
+            return None
+        nodes = fields.get("nodes")
+        if not isinstance(nodes, list):
+            return None
+        for raw in nodes:
+            if not isinstance(raw, dict) or raw.get("name") != "Status":
+                continue
+            field_id = raw.get("id")
+            options = raw.get("options")
+            if not isinstance(field_id, str) or not isinstance(options, list):
+                return None
+            for option in options:
+                if isinstance(option, dict) and option.get("name") == status_name:
+                    option_id = option.get("id")
+                    if isinstance(option_id, str):
+                        return field_id, option_id
+        return None
+
+    def _project_item_status(self, item_id: str) -> str | None:
+        query = (
+            "query($id:ID!){node(id:$id){... on ProjectV2Item{fieldValues(first:100){nodes{"
+            "... on ProjectV2ItemFieldSingleSelectValue{field{... on ProjectV2FieldCommon{name}}name}"
+            "}pageInfo{hasNextPage}}}}}"
+        )
+        result = self._run(
+            (
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-f",
+                f"id={item_id}",
+            ),
+            Path.cwd(),
+        )
+        if not result.succeeded:
+            return None
+        try:
+            payload = json.loads(result.output)
+        except json.JSONDecodeError:
+            return None
+        node = _mapping(_mapping(payload, "data"), "node")
+        values = _mapping(node, "fieldValues")
+        if _mapping(values, "pageInfo").get("hasNextPage") is True:
+            return None
+        nodes = values.get("nodes")
+        if not isinstance(nodes, list):
+            return None
+        for raw in nodes:
+            if not isinstance(raw, dict):
+                continue
+            if _mapping(raw, "field").get("name") == "Status":
+                value = raw.get("name")
+                return value if isinstance(value, str) else None
+        return None
+
+    def _run(
+        self,
+        command: Sequence[str],
+        cwd: Path,
+        *,
+        timeout_seconds: int = 120,
+    ) -> CommandResultLike:
+        try:
+            return self.runner.run(
+                command,
+                cwd=cwd,
+                environment=self.environment,
+                timeout_seconds=timeout_seconds,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return _FailedResult()
+
+
+@dataclass(frozen=True, slots=True)
+class _FailedResult:
+    returncode: int = 127
+    output: str = ""
+
+    @property
+    def succeeded(self) -> bool:
+        return False
+
+
+def _generation(schedule_key: str) -> int:
+    digest = hashlib.sha256(schedule_key.encode("utf-8")).hexdigest()
+    return int(digest[:15], 16) + 1
+
+
+def _effect_key(schedule_key: str, kind: str, target: str) -> str:
+    raw = f"{schedule_key}|{kind}|{target}"
+    return "autonomous-effect:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _pending_effect(recovered: RecoveredWork | None, key: str) -> str | None:
+    if recovered is None:
+        return None
+    for effect in recovered.pending_effects:
+        if effect.idempotency_key == key:
+            return effect.status
+    return None
+
+
+def _pr_number(identity: str | None) -> int | None:
+    if identity is None:
+        return None
+    match = _PR_RE.fullmatch(identity)
+    if match is None:
+        return None
+    number = int(match.group(1))
+    return number if number > 0 else None
+
+
+def _work_branch(template: str, issue_number: int) -> str:
+    if template.count("{issue}") != 1:
+        raise RuntimeError("WORK_BRANCH_TEMPLATE_INVALID")
+    branch = template.replace("{issue}", str(issue_number))
+    if not branch or branch in {"main", "master"} or ".." in branch or " " in branch:
+        raise RuntimeError("WORK_BRANCH_TEMPLATE_INVALID")
+    return branch
+
+
+def _commit_message(transition: V2Transition, issue_number: int) -> str:
+    prefix = "docs" if transition is V2Transition.DESIGN else "feat"
+    if transition is V2Transition.REPAIR:
+        prefix = "fix"
+    return f"{prefix}: #{issue_number} の{transition.value}を反映する"
+
+
+def _mapping(value: Mapping[str, object], key: str) -> Mapping[str, object]:
+    nested = value.get(key)
+    return nested if isinstance(nested, dict) else {}

--- a/src/loop_engineering/v2_supervisor.py
+++ b/src/loop_engineering/v2_supervisor.py
@@ -48,6 +48,7 @@ class V2WorkObservation:
     priority: str | None
     dependency_states: tuple[str, ...]
     acceptance_digest: str | None
+    selected_transition: str | None = None
     canonical_design_identities: tuple[str, ...] = ()
     active_lineage_identity: str | None = None
     exact_head_sha: str | None = None
@@ -199,6 +200,8 @@ def derive_transition(work: V2WorkObservation) -> V2Transition | None:
         return None
     if not work.canonical_design_identities:
         return V2Transition.DESIGN
+    if work.selected_transition == V2Transition.DESIGN.value:
+        return V2Transition.IMPLEMENT
     if work.exact_head_sha is None:
         return V2Transition.IMPLEMENT
     if work.verification_state is EvidenceState.FAIL:
@@ -241,6 +244,7 @@ def schedule_key(
         "issue_revision": work.issue_revision,
         "issue_state": work.issue_state,
         "lifecycle": work.lifecycle,
+        "selected_transition": work.selected_transition,
         "project_status": work.project_status,
         "priority": work.priority,
         "dependency_states": work.dependency_states,

--- a/src/loop_engineering/v2_work_queue.py
+++ b/src/loop_engineering/v2_work_queue.py
@@ -200,6 +200,7 @@ def _observation(
         priority=definition.priority,
         dependency_states=definition.dependency_states,
         acceptance_digest=definition.acceptance_criteria_digest,
+        selected_transition=record.selected_transition,
         canonical_design_identities=canonical_design_identities,
         active_lineage_identity=record.active_lineage_identity,
         latest_packet_identity=record.latest_task_packet_identity,

--- a/tests/loop_engineering/test_v2_autonomous_runner.py
+++ b/tests/loop_engineering/test_v2_autonomous_runner.py
@@ -1,0 +1,319 @@
+from dataclasses import replace
+from pathlib import Path
+
+from loop_engineering.v2_autonomous_runner import (
+    AutonomousRunStatus,
+    DurableGoalBootstrap,
+    EvidenceEnricher,
+    GitHubAutonomousLineageObserver,
+    TransitionExecutionResult,
+    TransitionExecutionStatus,
+    V2AutonomousRunner,
+    _LineageSnapshot,
+)
+from loop_engineering.v2_autonomous_runtime import (
+    AutonomousDispatch,
+    AutonomousRuntimeState,
+    PostgreSQLAutonomousRuntimeStore,
+    runtime_identity,
+)
+from loop_engineering.v2_goal_planning import (
+    BootstrapResult,
+    PlannedWork,
+    ProductDevelopmentRegistration,
+    ProjectedPlan,
+    ProjectedWork,
+    WorkPlanProposal,
+    proposal_identity,
+)
+from loop_engineering.v2_supervisor import EvidenceState, V2Supervisor, V2WorkObservation
+from loop_engineering.v2_work_queue import V2WorkQueueSnapshot
+
+
+class MemoryRuntime(PostgreSQLAutonomousRuntimeStore):
+    def __init__(self) -> None:
+        self.state: AutonomousRuntimeState | None = None
+        self.dispatches: dict[str, AutonomousDispatch] = {}
+        self.saved_plan: BootstrapResult | None = None
+
+    def ensure_runtime(self, registration: ProductDevelopmentRegistration) -> AutonomousRuntimeState:
+        if self.state is None:
+            self.state = AutonomousRuntimeState(
+                runtime_identity(registration),
+                registration.product_key,
+                registration.repository_identity,
+                registration.goal_revision,
+                "ACTIVE",
+                None,
+                None,
+                None,
+                0,
+                "",
+            )
+        return self.state
+
+    def update_runtime(
+        self,
+        runtime_identity_value: str,
+        *,
+        status: str,
+        current_work_identity: str | None,
+        schedule_key: str | None,
+        progress_fingerprint: str | None,
+        no_progress_count: int,
+        detail: str,
+    ) -> AutonomousRuntimeState:
+        assert self.state is not None and self.state.runtime_identity == runtime_identity_value
+        self.state = AutonomousRuntimeState(
+            self.state.runtime_identity,
+            self.state.product_key,
+            self.state.repository,
+            self.state.goal_revision,
+            status,
+            current_work_identity,
+            schedule_key,
+            progress_fingerprint,
+            no_progress_count,
+            detail,
+        )
+        return self.state
+
+    def plan(self, runtime_identity_value: str) -> BootstrapResult | None:
+        del runtime_identity_value
+        return self.saved_plan
+
+    def save_plan(self, runtime_identity_value: str, result: BootstrapResult) -> None:
+        del runtime_identity_value
+        self.saved_plan = result
+
+    def dispatch(self, item: AutonomousDispatch) -> bool:
+        self.dispatches.setdefault(item.schedule_key, item)
+        return self.dispatches[item.schedule_key] == item
+
+    def update_dispatch(self, schedule_key: str, status: str, detail: str) -> None:
+        current = self.dispatches[schedule_key]
+        self.dispatches[schedule_key] = replace(current, status=status, detail=detail)
+
+    def dispatched_schedule_keys(self, runtime_identity_value: str) -> frozenset[str]:
+        del runtime_identity_value
+        return frozenset(
+            key
+            for key, item in self.dispatches.items()
+            if item.status in {"DISPATCHED", "COMPLETED", "WAITING"}
+        )
+
+
+class FixedBootstrap(DurableGoalBootstrap):
+    def __init__(self, result: BootstrapResult) -> None:
+        self.result = result
+
+    def ensure(self, registration: ProductDevelopmentRegistration) -> BootstrapResult:
+        del registration
+        return self.result
+
+
+class MutableQueue:
+    def __init__(self, works: tuple[V2WorkObservation, ...], current: str | None = None) -> None:
+        self.works = works
+        self.current = current
+        self.pending_effect = False
+
+    def synchronize(self, registration: ProductDevelopmentRegistration) -> V2WorkQueueSnapshot:
+        del registration
+        return V2WorkQueueSnapshot(self.works, self.current, self.pending_effect)
+
+
+class PassLineage(GitHubAutonomousLineageObserver):
+    def __init__(self) -> None:
+        pass
+
+    def observe(
+        self,
+        registration: ProductDevelopmentRegistration,
+        work: V2WorkObservation,
+        planned: PlannedWork,
+    ) -> _LineageSnapshot:
+        del registration, planned
+        return _LineageSnapshot(work, _pr_number(work.active_lineage_identity))
+
+
+class PassEvidence(EvidenceEnricher):
+    def __init__(self) -> None:
+        pass
+
+    def enrich(
+        self,
+        registration: ProductDevelopmentRegistration,
+        snapshot: _LineageSnapshot,
+        planned: PlannedWork,
+    ) -> V2WorkObservation:
+        del registration, planned
+        return snapshot.observation
+
+
+class RecordingTransitions:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def execute(self, registration, bootstrap, work, planned_work, decision):
+        del registration, bootstrap, planned_work, decision
+        self.calls.append(work.work_identity)
+        return TransitionExecutionResult(TransitionExecutionStatus.PROGRESSED, "ok")
+
+
+def registration() -> ProductDevelopmentRegistration:
+    return ProductDevelopmentRegistration(
+        product_key="sample",
+        workspace_canonical_path=Path("/tmp/sample"),
+        repository_identity="owner/sample",
+        project_owner="owner",
+        project_number=10,
+        trunk_branch="main",
+        goal_definition_identity="goal:sample",
+        goal_revision="rev-1",
+        goal_text="sample",
+        acceptance_criteria=("done",),
+        work_branch_template="feature/work-{issue}",
+        ci_workflow_name="CI",
+        initial_project_status="Backlog",
+    )
+
+
+def bootstrap() -> BootstrapResult:
+    reg = registration()
+    works = (
+        PlannedWork("first", "First", "p1", ("done1",), canonical_design_targets=("docs/a.md",)),
+        PlannedWork("second", "Second", "p2", ("done2",), canonical_design_targets=("docs/b.md",)),
+    )
+    proposal = WorkPlanProposal(
+        proposal_identity(reg, works),
+        reg.goal_revision,
+        works,
+        ("done",),
+    )
+    return BootstrapResult(
+        proposal,
+        ProjectedPlan(
+            1,
+            "goal-url",
+            "goal-item",
+            (
+                ProjectedWork("first", 2, "u2", "i2", "d2", ()),
+                ProjectedWork("second", 3, "u3", "i3", "d3", ()),
+            ),
+        ),
+    )
+
+
+def observation(issue: int, **changes) -> V2WorkObservation:
+    base = V2WorkObservation(
+        work_identity=f"work:owner/sample:{issue}",
+        issue_number=issue,
+        issue_revision=f"r{issue}",
+        issue_state="OPEN",
+        lifecycle="PLANNED",
+        project_status="Backlog",
+        priority="P1",
+        dependency_states=(),
+        acceptance_digest=f"d{issue}",
+    )
+    return replace(base, **changes)
+
+
+def runner(
+    runtime: MemoryRuntime,
+    queue: MutableQueue,
+    transitions: RecordingTransitions,
+) -> V2AutonomousRunner:
+    return V2AutonomousRunner(
+        runtime,
+        FixedBootstrap(bootstrap()),
+        queue,
+        PassLineage(),
+        PassEvidence(),
+        V2Supervisor(),
+        transitions,
+    )
+
+
+def test_waiting_current_work_does_not_block_second_work() -> None:
+    waiting = observation(
+        2,
+        lifecycle="RUNNING",
+        canonical_design_identities=("design:a",),
+        exact_head_sha="a" * 40,
+        active_lineage_identity="pr:7",
+        verification_state=EvidenceState.PENDING,
+    )
+    second = observation(3)
+    runtime = MemoryRuntime()
+    transitions = RecordingTransitions()
+
+    result = runner(runtime, MutableQueue((waiting, second), waiting.work_identity), transitions).run(
+        registration(), max_iterations=1
+    )
+
+    assert result.status is AutonomousRunStatus.PROGRESSED
+    assert transitions.calls == [second.work_identity]
+
+
+def test_restart_suppresses_same_schedule_and_selects_other_work() -> None:
+    first = observation(2)
+    second = observation(3, priority="P2")
+    runtime = MemoryRuntime()
+    state = runtime.ensure_runtime(registration())
+    from loop_engineering.v2_supervisor import V2Transition, schedule_key
+
+    key = schedule_key(registration().goal_revision, first, V2Transition.DESIGN)
+    runtime.dispatches[key] = AutonomousDispatch(
+        key,
+        state.runtime_identity,
+        first.work_identity,
+        "DESIGN",
+        "WAITING",
+        "restart",
+    )
+    transitions = RecordingTransitions()
+
+    runner(runtime, MutableQueue((first, second)), transitions).run(registration(), max_iterations=1)
+
+    assert transitions.calls == [second.work_identity]
+
+
+def test_all_completed_works_complete_goal() -> None:
+    completed1 = observation(2, issue_state="CLOSED", lifecycle="COMPLETED")
+    completed2 = observation(3, issue_state="CLOSED", lifecycle="COMPLETED")
+    runtime = MemoryRuntime()
+    transitions = RecordingTransitions()
+
+    result = runner(runtime, MutableQueue((completed1, completed2)), transitions).run(registration())
+
+    assert result.status is AutonomousRunStatus.GOAL_COMPLETED
+    assert transitions.calls == []
+    assert runtime.state is not None and runtime.state.status == "COMPLETED"
+
+
+def test_pending_effect_escalates_only_after_repeated_same_state() -> None:
+    blocked = observation(2, dependency_states=("OPEN",))
+    runtime = MemoryRuntime()
+    queue = MutableQueue((blocked,))
+    queue.pending_effect = True
+    transitions = RecordingTransitions()
+    app = runner(runtime, queue, transitions)
+
+    first = app.run(registration())
+    second = app.run(registration())
+    third = app.run(registration())
+    fourth = app.run(registration())
+
+    assert first.status is AutonomousRunStatus.WAITING
+    assert second.status is AutonomousRunStatus.WAITING
+    assert third.status is AutonomousRunStatus.WAITING
+    assert fourth.status is AutonomousRunStatus.INTERVENTION_REQUIRED
+
+
+def _pr_number(identity: str | None) -> int | None:
+    if identity is None or not identity.startswith("pr:"):
+        return None
+    value = identity[3:]
+    return int(value) if value.isdigit() else None

--- a/tests/loop_engineering/test_v2_autonomous_runner.py
+++ b/tests/loop_engineering/test_v2_autonomous_runner.py
@@ -26,7 +26,12 @@ from loop_engineering.v2_goal_planning import (
     WorkPlanProposal,
     proposal_identity,
 )
-from loop_engineering.v2_supervisor import EvidenceState, V2Supervisor, V2WorkObservation
+from loop_engineering.v2_supervisor import (
+    EvidenceState,
+    V2Supervisor,
+    V2SupervisorDecision,
+    V2WorkObservation,
+)
 from loop_engineering.v2_work_queue import V2WorkQueueSnapshot
 
 
@@ -36,7 +41,10 @@ class MemoryRuntime(PostgreSQLAutonomousRuntimeStore):
         self.dispatches: dict[str, AutonomousDispatch] = {}
         self.saved_plan: BootstrapResult | None = None
 
-    def ensure_runtime(self, registration: ProductDevelopmentRegistration) -> AutonomousRuntimeState:
+    def ensure_runtime(
+        self,
+        registration: ProductDevelopmentRegistration,
+    ) -> AutonomousRuntimeState:
         if self.state is None:
             self.state = AutonomousRuntimeState(
                 runtime_identity(registration),
@@ -63,7 +71,8 @@ class MemoryRuntime(PostgreSQLAutonomousRuntimeStore):
         no_progress_count: int,
         detail: str,
     ) -> AutonomousRuntimeState:
-        assert self.state is not None and self.state.runtime_identity == runtime_identity_value
+        assert self.state is not None
+        assert self.state.runtime_identity == runtime_identity_value
         self.state = AutonomousRuntimeState(
             self.state.runtime_identity,
             self.state.product_key,
@@ -118,7 +127,10 @@ class MutableQueue:
         self.current = current
         self.pending_effect = False
 
-    def synchronize(self, registration: ProductDevelopmentRegistration) -> V2WorkQueueSnapshot:
+    def synchronize(
+        self,
+        registration: ProductDevelopmentRegistration,
+    ) -> V2WorkQueueSnapshot:
         del registration
         return V2WorkQueueSnapshot(self.works, self.current, self.pending_effect)
 
@@ -147,16 +159,26 @@ class PassEvidence(EvidenceEnricher):
         snapshot: _LineageSnapshot,
         planned: PlannedWork,
     ) -> V2WorkObservation:
-        del registration, planned
-        return snapshot.observation
+        del registration
+        return replace(
+            snapshot.observation,
+            human_verification_required=planned.human_verification_required,
+        )
 
 
 class RecordingTransitions:
     def __init__(self) -> None:
         self.calls: list[str] = []
 
-    def execute(self, registration, bootstrap, work, planned_work, decision):
-        del registration, bootstrap, planned_work, decision
+    def execute(
+        self,
+        registration: ProductDevelopmentRegistration,
+        bootstrap_result: BootstrapResult,
+        work: V2WorkObservation,
+        planned_work: PlannedWork,
+        decision: V2SupervisorDecision,
+    ) -> TransitionExecutionResult:
+        del registration, bootstrap_result, planned_work, decision
         self.calls.append(work.work_identity)
         return TransitionExecutionResult(TransitionExecutionStatus.PROGRESSED, "ok")
 
@@ -182,8 +204,20 @@ def registration() -> ProductDevelopmentRegistration:
 def bootstrap() -> BootstrapResult:
     reg = registration()
     works = (
-        PlannedWork("first", "First", "p1", ("done1",), canonical_design_targets=("docs/a.md",)),
-        PlannedWork("second", "Second", "p2", ("done2",), canonical_design_targets=("docs/b.md",)),
+        PlannedWork(
+            "first",
+            "First",
+            "p1",
+            ("done1",),
+            canonical_design_targets=("docs/a.md",),
+        ),
+        PlannedWork(
+            "second",
+            "Second",
+            "p2",
+            ("done2",),
+            canonical_design_targets=("docs/b.md",),
+        ),
     )
     proposal = WorkPlanProposal(
         proposal_identity(reg, works),
@@ -205,8 +239,8 @@ def bootstrap() -> BootstrapResult:
     )
 
 
-def observation(issue: int, **changes) -> V2WorkObservation:
-    base = V2WorkObservation(
+def observation(issue: int) -> V2WorkObservation:
+    return V2WorkObservation(
         work_identity=f"work:owner/sample:{issue}",
         issue_number=issue,
         issue_revision=f"r{issue}",
@@ -217,10 +251,9 @@ def observation(issue: int, **changes) -> V2WorkObservation:
         dependency_states=(),
         acceptance_digest=f"d{issue}",
     )
-    return replace(base, **changes)
 
 
-def runner(
+def application(
     runtime: MemoryRuntime,
     queue: MutableQueue,
     transitions: RecordingTransitions,
@@ -237,9 +270,10 @@ def runner(
 
 
 def test_waiting_current_work_does_not_block_second_work() -> None:
-    waiting = observation(
-        2,
+    waiting = replace(
+        observation(2),
         lifecycle="RUNNING",
+        selected_transition="IMPLEMENT",
         canonical_design_identities=("design:a",),
         exact_head_sha="a" * 40,
         active_lineage_identity="pr:7",
@@ -248,10 +282,13 @@ def test_waiting_current_work_does_not_block_second_work() -> None:
     second = observation(3)
     runtime = MemoryRuntime()
     transitions = RecordingTransitions()
-
-    result = runner(runtime, MutableQueue((waiting, second), waiting.work_identity), transitions).run(
-        registration(), max_iterations=1
+    app = application(
+        runtime,
+        MutableQueue((waiting, second), waiting.work_identity),
+        transitions,
     )
+
+    result = app.run(registration(), max_iterations=1)
 
     assert result.status is AutonomousRunStatus.PROGRESSED
     assert transitions.calls == [second.work_identity]
@@ -259,7 +296,7 @@ def test_waiting_current_work_does_not_block_second_work() -> None:
 
 def test_restart_suppresses_same_schedule_and_selects_other_work() -> None:
     first = observation(2)
-    second = observation(3, priority="P2")
+    second = replace(observation(3), priority="P2")
     runtime = MemoryRuntime()
     state = runtime.ensure_runtime(registration())
     from loop_engineering.v2_supervisor import V2Transition, schedule_key
@@ -275,18 +312,22 @@ def test_restart_suppresses_same_schedule_and_selects_other_work() -> None:
     )
     transitions = RecordingTransitions()
 
-    runner(runtime, MutableQueue((first, second)), transitions).run(registration(), max_iterations=1)
+    application(runtime, MutableQueue((first, second)), transitions).run(
+        registration(),
+        max_iterations=1,
+    )
 
     assert transitions.calls == [second.work_identity]
 
 
 def test_all_completed_works_complete_goal() -> None:
-    completed1 = observation(2, issue_state="CLOSED", lifecycle="COMPLETED")
-    completed2 = observation(3, issue_state="CLOSED", lifecycle="COMPLETED")
+    completed1 = replace(observation(2), issue_state="CLOSED", lifecycle="COMPLETED")
+    completed2 = replace(observation(3), issue_state="CLOSED", lifecycle="COMPLETED")
     runtime = MemoryRuntime()
     transitions = RecordingTransitions()
+    app = application(runtime, MutableQueue((completed1, completed2)), transitions)
 
-    result = runner(runtime, MutableQueue((completed1, completed2)), transitions).run(registration())
+    result = app.run(registration())
 
     assert result.status is AutonomousRunStatus.GOAL_COMPLETED
     assert transitions.calls == []
@@ -294,22 +335,20 @@ def test_all_completed_works_complete_goal() -> None:
 
 
 def test_pending_effect_escalates_only_after_repeated_same_state() -> None:
-    blocked = observation(2, dependency_states=("OPEN",))
+    blocked = replace(observation(2), dependency_states=("OPEN",))
     runtime = MemoryRuntime()
     queue = MutableQueue((blocked,))
     queue.pending_effect = True
-    transitions = RecordingTransitions()
-    app = runner(runtime, queue, transitions)
+    app = application(runtime, queue, RecordingTransitions())
 
-    first = app.run(registration())
-    second = app.run(registration())
-    third = app.run(registration())
-    fourth = app.run(registration())
+    results = [app.run(registration()) for _ in range(4)]
 
-    assert first.status is AutonomousRunStatus.WAITING
-    assert second.status is AutonomousRunStatus.WAITING
-    assert third.status is AutonomousRunStatus.WAITING
-    assert fourth.status is AutonomousRunStatus.INTERVENTION_REQUIRED
+    assert [item.status for item in results[:3]] == [
+        AutonomousRunStatus.WAITING,
+        AutonomousRunStatus.WAITING,
+        AutonomousRunStatus.WAITING,
+    ]
+    assert results[3].status is AutonomousRunStatus.INTERVENTION_REQUIRED
 
 
 def _pr_number(identity: str | None) -> int | None:

--- a/tests/loop_engineering/test_v2_autonomous_runtime.py
+++ b/tests/loop_engineering/test_v2_autonomous_runtime.py
@@ -1,0 +1,234 @@
+import json
+from pathlib import Path
+
+from loop_engineering.v2_autonomous_runtime import (
+    AutonomousDispatch,
+    PostgreSQLAutonomousRuntimeStore,
+    runtime_identity,
+)
+from loop_engineering.v2_goal_planning import (
+    BootstrapResult,
+    PlannedWork,
+    ProductDevelopmentRegistration,
+    ProjectedPlan,
+    ProjectedWork,
+    WorkPlanProposal,
+    proposal_identity,
+)
+
+
+class FakeDatabase:
+    def __init__(self) -> None:
+        self.runtimes: dict[str, dict[str, object]] = {}
+        self.dispatches: dict[str, dict[str, object]] = {}
+        self.plans: dict[str, dict[str, object]] = {}
+
+    def execute_sql(self, sql: str) -> bool:
+        values = _quoted_values(sql)
+        if sql.startswith("INSERT INTO loop_autonomous_runtimes"):
+            identity, product, repository, revision = values[:4]
+            self.runtimes.setdefault(
+                identity,
+                {
+                    "runtime_identity": identity,
+                    "product_key": product,
+                    "repository": repository,
+                    "goal_revision": revision,
+                    "status": "ACTIVE",
+                    "current_work_identity": None,
+                    "last_schedule_key": None,
+                    "last_progress_fingerprint": None,
+                    "no_progress_count": 0,
+                    "last_detail": "",
+                },
+            )
+            return True
+        if sql.startswith("UPDATE loop_autonomous_runtimes SET"):
+            identity = values[-1]
+            row = self.runtimes[identity]
+            row["status"] = values[0]
+            row["current_work_identity"] = None if "current_work_identity = NULL" in sql else values[1]
+            offset = 1 if row["current_work_identity"] is None else 2
+            row["last_schedule_key"] = None if "last_schedule_key = NULL" in sql else values[offset]
+            if row["last_schedule_key"] is not None:
+                offset += 1
+            row["last_progress_fingerprint"] = (
+                None if "last_progress_fingerprint = NULL" in sql else values[offset]
+            )
+            row["no_progress_count"] = int(
+                sql.split("no_progress_count = ", 1)[1].split(",", 1)[0]
+            )
+            row["last_detail"] = values[-2]
+            return True
+        if sql.startswith("INSERT INTO loop_autonomous_dispatches"):
+            key, runtime, work, transition, status, detail = values[:6]
+            self.dispatches.setdefault(
+                key,
+                {
+                    "schedule_key": key,
+                    "runtime_identity": runtime,
+                    "work_identity": work,
+                    "transition": transition,
+                    "status": status,
+                    "detail": detail,
+                },
+            )
+            return True
+        if sql.startswith("UPDATE loop_autonomous_dispatches SET"):
+            status, detail, key = values
+            self.dispatches[key]["status"] = status
+            self.dispatches[key]["detail"] = detail
+            return True
+        if sql.startswith("INSERT INTO loop_goal_plans"):
+            runtime, proposal_identity_value, proposal_json, projection_json = values[:4]
+            self.plans.setdefault(
+                runtime,
+                {
+                    "proposal_identity": proposal_identity_value,
+                    "proposal_json": json.loads(proposal_json),
+                    "projection_json": json.loads(projection_json),
+                },
+            )
+            return True
+        raise AssertionError(sql)
+
+    def query_json_rows(self, sql: str) -> list[dict[str, object]] | None:
+        if "FROM loop_autonomous_runtimes" in sql:
+            key = sql.split("runtime_identity = '", 1)[1].split("'", 1)[0]
+            row = self.runtimes.get(key)
+            return [] if row is None else [dict(row)]
+        if "FROM loop_autonomous_dispatches" in sql and "schedule_key =" in sql:
+            key = sql.split("schedule_key = '", 1)[1].split("'", 1)[0]
+            row = self.dispatches.get(key)
+            return [] if row is None else [dict(row)]
+        if "FROM loop_autonomous_dispatches" in sql:
+            runtime = sql.split("runtime_identity = '", 1)[1].split("'", 1)[0]
+            return [
+                {"schedule_key": key}
+                for key, row in self.dispatches.items()
+                if row["runtime_identity"] == runtime
+                and row["status"] in {"DISPATCHED", "COMPLETED", "WAITING"}
+            ]
+        if "FROM loop_goal_plans" in sql:
+            runtime = sql.split("runtime_identity = '", 1)[1].split("'", 1)[0]
+            row = self.plans.get(runtime)
+            return [] if row is None else [dict(row)]
+        raise AssertionError(sql)
+
+
+def registration() -> ProductDevelopmentRegistration:
+    return ProductDevelopmentRegistration(
+        product_key="sample",
+        workspace_canonical_path=Path("/tmp/sample"),
+        repository_identity="owner/sample",
+        project_owner="owner",
+        project_number=10,
+        trunk_branch="main",
+        goal_definition_identity="goal:sample",
+        goal_revision="rev-1",
+        goal_text="sample",
+        acceptance_criteria=("done",),
+        work_branch_template="feature/work-{issue}",
+        ci_workflow_name="CI",
+        initial_project_status="Backlog",
+    )
+
+
+def bootstrap() -> BootstrapResult:
+    reg = registration()
+    work = PlannedWork(
+        "first",
+        "First",
+        "purpose",
+        ("done",),
+        canonical_design_targets=("docs/design.md",),
+    )
+    proposal = WorkPlanProposal(
+        proposal_identity(reg, (work,)),
+        reg.goal_revision,
+        (work,),
+        ("done",),
+    )
+    projection = ProjectedPlan(
+        1,
+        "https://example/goal",
+        "ITEM-GOAL",
+        (
+            ProjectedWork(
+                "first",
+                2,
+                "https://example/work",
+                "ITEM-WORK",
+                "digest",
+                (),
+            ),
+        ),
+    )
+    return BootstrapResult(proposal, projection)
+
+
+def test_runtime_and_plan_survive_store_reconstruction() -> None:
+    database = FakeDatabase()
+    first = PostgreSQLAutonomousRuntimeStore(database)
+    state = first.ensure_runtime(registration())
+    first.save_plan(state.runtime_identity, bootstrap())
+    first.dispatch(
+        AutonomousDispatch(
+            "schedule:1",
+            state.runtime_identity,
+            "work:owner/sample:2",
+            "DESIGN",
+            "DISPATCHED",
+            "test",
+        )
+    )
+
+    restarted = PostgreSQLAutonomousRuntimeStore(database)
+
+    assert restarted.get(state.runtime_identity) == state
+    assert restarted.plan(state.runtime_identity) == bootstrap()
+    assert restarted.dispatched_schedule_keys(state.runtime_identity) == frozenset({"schedule:1"})
+
+
+def test_runtime_identity_is_goal_revision_bound() -> None:
+    reg = registration()
+    assert runtime_identity(reg).startswith("runtime:")
+    changed = ProductDevelopmentRegistration(
+        product_key=reg.product_key,
+        workspace_canonical_path=reg.workspace_canonical_path,
+        repository_identity=reg.repository_identity,
+        project_owner=reg.project_owner,
+        project_number=reg.project_number,
+        trunk_branch=reg.trunk_branch,
+        goal_definition_identity=reg.goal_definition_identity,
+        goal_revision="rev-2",
+        goal_text=reg.goal_text,
+        acceptance_criteria=reg.acceptance_criteria,
+        work_branch_template=reg.work_branch_template,
+        ci_workflow_name=reg.ci_workflow_name,
+        initial_project_status=reg.initial_project_status,
+    )
+    assert runtime_identity(reg) != runtime_identity(changed)
+
+
+def _quoted_values(sql: str) -> list[str]:
+    values: list[str] = []
+    index = 0
+    while index < len(sql):
+        if sql[index] != "'":
+            index += 1
+            continue
+        index += 1
+        current: list[str] = []
+        while index < len(sql):
+            if sql[index] == "'" and index + 1 < len(sql) and sql[index + 1] == "'":
+                current.append("'")
+                index += 2
+                continue
+            if sql[index] == "'":
+                index += 1
+                break
+            current.append(sql[index])
+            index += 1
+        values.append("".join(current))
+    return values

--- a/tests/loop_engineering/test_v2_autonomous_runtime.py
+++ b/tests/loop_engineering/test_v2_autonomous_runtime.py
@@ -47,9 +47,13 @@ class FakeDatabase:
             identity = values[-1]
             row = self.runtimes[identity]
             row["status"] = values[0]
-            row["current_work_identity"] = None if "current_work_identity = NULL" in sql else values[1]
+            row["current_work_identity"] = (
+                None if "current_work_identity = NULL" in sql else values[1]
+            )
             offset = 1 if row["current_work_identity"] is None else 2
-            row["last_schedule_key"] = None if "last_schedule_key = NULL" in sql else values[offset]
+            row["last_schedule_key"] = (
+                None if "last_schedule_key = NULL" in sql else values[offset]
+            )
             if row["last_schedule_key"] is not None:
                 offset += 1
             row["last_progress_fingerprint"] = (


### PR DESCRIPTION
## 関連Issue

Closes #88
Parent manufacturing: #81
Depends on: #83, #84, #85, #86, #87

## 設計

`docs/architecture/v2/autonomous_runner_recovery.md` を先行追加し、bounded autonomous run / durable planning / restart / no-progress / waitingとinterventionの境界を確定した。

## 実装中

- Product/Goal単位のAutonomousRuntimeState / dispatch journal
- 最初に採用したWorkPlan/ProjectionのPostgreSQL永続化
- live PR/head/canonical design blob観測
- exact-head EvidenceのSupervisor投入
- duplicate ScheduleKey抑止と独立Work継続
- DESIGN/IMPLEMENT/REPAIR → #85 proposal → #86 lineage
- exact evidence後のMERGE
- merge後のIssue close / Project Done / Work COMPLETED
- restart時のDB/live state再構成

まずCIで型・挙動を監査し、その後composition/CLI入口を仕上げる。